### PR TITLE
Allow SSH_KEYFILE to be configurable in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang
 
+ENV SSH_KEYFILE "/ssh-keyfile"
 ENV ROUTES_ENABLED true
 ENV BGP_ENABLED true
 ENV OSPF_ENABLED true
@@ -8,5 +9,5 @@ ENV ALARM_FILTER ""
 RUN apt-get install -y git && \
     go get github.com/czerwonk/junos_exporter
 
-CMD junos_exporter -ssh.targets $TARGETS -ssh.keyfile /ssh-keyfile -routes.enabled=$ROUTES_ENABLED -bgp.enabled=$BGP_ENABLED -ospf.enabled=$OSPF_ENABLED -alarms.filter=$ALARM_FILTER
+CMD junos_exporter -ssh.targets $TARGETS -ssh.keyfile $SSH_KEYFILE -routes.enabled=$ROUTES_ENABLED -bgp.enabled=$BGP_ENABLED -ospf.enabled=$OSPF_ENABLED -alarms.filter=$ALARM_FILTER
 EXPOSE 9326


### PR DESCRIPTION
When running junos_exporter on kubernetes, it is not possible to mount a
secret or a volume to a file in the root path. This change allows an
administrator to specify a custom path in the container where they have
placed the private key.