### PR TITLE
Enable/disable interface statistics with "interfaces" flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 		ISIS                bool `yaml:"isis,omitempty"`
 		Routes              bool `yaml:"routes,omitempty"`
 		RoutingEngine       bool `yaml:"routing_engine,omitempty"`
+		Interfaces          bool `yaml:"interfaces,omitempty"`
 		InterfaceDiagnostic bool `yaml:"interface_diagnostic,omitempty"`
 	} `yaml:"features,omitempty"`
 }
@@ -50,6 +51,7 @@ func setDefaultValues(c *Config) {
 	f := &c.Features
 	f.BPG = true
 	f.Environment = true
+	f.Interfaces = true
 	f.InterfaceDiagnostic = true
 	f.OSPF = true
 	f.Routes = true

--- a/junos_collector.go
+++ b/junos_collector.go
@@ -45,11 +45,14 @@ func newJunosCollector() *junosCollector {
 
 func collectors() map[string]collector.RPCCollector {
 	m := map[string]collector.RPCCollector{
-		"interface": interfaces.NewCollector(),
 		"alarm":     alarm.NewCollector(*alarmFilter),
 	}
 
 	f := &cfg.Features
+
+	if f.Interfaces {
+		m["interfaces"] = interfaces.NewCollector()
+	}
 
 	if f.Routes {
 		m["routes"] = route.NewCollector()

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var (
 	routingEngineEnabled = flag.Bool("routingengine.enabled", true, "Scrape Routing Engine metrics")
 	routesEnabled        = flag.Bool("routes.enabled", true, "Scrape routing table metrics")
 	environmentEnabled   = flag.Bool("environment.enabled", true, "Scrape environment metrics")
+	ifEnabled            = flag.Bool("interfaces.enabled", true, "Scrape interface metrics")
 	ifDiagnEnabled       = flag.Bool("ifdiag.enabled", true, "Scrape optical interface diagnostic metrics")
 	alarmFilter          = flag.String("alarms.filter", "", "Regex to filter for alerts to ignore")
 	configFile           = flag.String("config.file", "", "Path to config file")
@@ -90,6 +91,7 @@ func loadConfigFromFlags() *config.Config {
 	f := &c.Features
 	f.BPG = *bgpEnabled
 	f.Environment = *environmentEnabled
+	f.Interfaces = *ifEnabled
 	f.InterfaceDiagnostic = *ifDiagnEnabled
 	f.ISIS = *isisEnabled
 	f.OSPF = *ospfEnabled


### PR DESCRIPTION
Break out the interfaces collector into a standalone collector that can be enabled or disabled by including the `-interfaces.enabled` parameter (or adding `"interfaces: true"` in a configuration file).

The default interfaces collector can be very resource heavy on CPU, especially on a virtual chassis with multiple members. Removing this collector as default allows for more fine-tuning, allowing features unique to junos_exporter (e.g. optical interface metrics) to be used without the additional costly overhead.

(As an aside, this is my first effort at contributing to a project - feedback or changes greatly appreciated!)

