### PR TITLE
enable target parameter in query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ In this example we want to scrape 3 hosts:
 docker run -d --restart unless-stopped -p 9326:9326 -v /opt/junos_exporter_keyfile:/ssh-keyfile:ro -v /opt/junos_exporter_config.yml:/config.yml:ro czerwonk/junos_exporter
 ```
 
+### Target Parameter
+By default, all configured targets will be scrapped when `/metrics` is hit. As an alternative, it is possible to scrape a specific target by passing the target's hostname/IP address to the target parameter - e.g. ` http://localhost:9326/metrics?target=1.2.3.4`. The specific target must be present in the configuration file or passed in with the ssh.targets flag, otherwise, the request will be denied. This can be used with the below example Prometheus config:
+
+```
+scrape_configs:
+  - job_name: 'junos'
+    static_configs:
+      - targets:
+        - 192.168.1.2  # Target device.
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: 127.0.0.1:9326  # The junos_exporter's real hostname:port.
+```
+
 ## Config file
 
 The exporter can be configured with a YAML based config file:

--- a/junos_collector.go
+++ b/junos_collector.go
@@ -35,12 +35,13 @@ func init() {
 }
 
 type junosCollector struct {
+	targets    []string
 	collectors map[string]collector.RPCCollector
 }
 
-func newJunosCollector() *junosCollector {
+func newJunosCollector(targets []string) *junosCollector {
 	collectors := collectors()
-	return &junosCollector{collectors}
+	return &junosCollector{targets, collectors}
 }
 
 func collectors() map[string]collector.RPCCollector {
@@ -97,7 +98,7 @@ func (c *junosCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements prometheus.Collector interface
 func (c *junosCollector) Collect(ch chan<- prometheus.Metric) {
-	hosts := cfg.Targets
+	hosts := c.targets
 	wg := &sync.WaitGroup{}
 
 	wg.Add(len(hosts))


### PR DESCRIPTION
A bit of background: I could not find a way to have Prometheus scrape the metrics from the junos_exporter for individual targets. For example, if I have two targets configured in Prometheus, with the \_\_address\_\_ changed to the junos_exporter, both targets will contain all the metrics that junos_exporter exposes. While it's possible to filter on the target label once the metrics are in Prometheus, it's undesirable as that's a lot of unneeded metric duplication. If I am missing something and there is a way to do this, I'm all ears.

This PR enables passing a target parameter with the target's hostname/IP address so that metrics can be filtered for individual targets. This is very similar to how the snmp_exporter works. Security has been implemented so the exporter cannot be used to maliciously SSH into devices that have not been configured as a target.

P.S. this exporter is awesome - thanks!