### PR TITLE
add support for l2circuits

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ The following metrics are supported by now:
 * ISIS (number of adjacencies, total number of routers)
 * Environment (temperatures)
 * Routing engine statistics
+* Statistics about l2circuits (tunnel state, number of tunnels)
+```   0:EI -- encapsulation invalid      12:NP -- interface h/w not present
+   1:MM -- mtu mismatch               13:Dn -- down
+   2:EM -- encapsulation mismatch     14:VC-Dn -- Virtual circuit Down
+   3:CM -- control-word mismatch      15:Up -- operational
+   4:VM -- vlan id mismatch           16:CF -- Call admission control failure
+   5:OL -- no outgoing label          17:IB -- TDM incompatible bitrate
+   6:NC -- intf encaps not CCC/TCC    18:TM -- TDM misconfiguration
+   7:BK -- Backup Connection          19:ST -- Standby Connection
+   8:CB -- rcvd cell-bundle size bad  20:SP -- Static Pseudowire
+   9:LD -- local site signaled down   21:RS -- remote site standby
+  10:RD -- remote site signaled down  22:HS -- Hot-standby Connection
+  11:XX -- unknown
+```
 
 ## Install
 ```bash
@@ -86,6 +100,7 @@ features:
   bgp: true
   ospf: false
   isis: false
+  l2circuit: false
   environment: true
   routes: true
   routing_engine: true

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 		BPG                 bool `yaml:"bgp,omitempty"`
 		OSPF                bool `yaml:"ospf,omitempty"`
 		ISIS                bool `yaml:"isis,omitempty"`
+		L2CIRCUIT           bool `yaml:"l2circuit,omitempty"`
 		Routes              bool `yaml:"routes,omitempty"`
 		RoutingEngine       bool `yaml:"routing_engine,omitempty"`
 		Interfaces          bool `yaml:"interfaces,omitempty"`

--- a/junos_collector.go
+++ b/junos_collector.go
@@ -14,6 +14,7 @@ import (
 	"github.com/czerwonk/junos_exporter/interfacediagnostics"
 	"github.com/czerwonk/junos_exporter/interfaces"
 	"github.com/czerwonk/junos_exporter/isis"
+	"github.com/czerwonk/junos_exporter/l2circuit"
 	"github.com/czerwonk/junos_exporter/ospf"
 	"github.com/czerwonk/junos_exporter/route"
 	"github.com/czerwonk/junos_exporter/routingengine"
@@ -69,6 +70,10 @@ func collectors() map[string]collector.RPCCollector {
 
 	if f.ISIS {
 		m["isis"] = isis.NewCollector()
+	}
+
+	if f.L2CIRCUIT {
+		m["l2circuit"] = l2circuit.NewCollector()
 	}
 
 	if f.RoutingEngine {

--- a/l2circuit/l2circuit_collector.go
+++ b/l2circuit/l2circuit_collector.go
@@ -1,0 +1,102 @@
+package l2circuit
+
+import (
+	"regexp"
+
+	"github.com/czerwonk/junos_exporter/collector"
+	"github.com/czerwonk/junos_exporter/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	l2circuitConnectionStateDesc *prometheus.Desc
+	l2circuitConnectionsDesc     *prometheus.Desc
+	l2circuitMap                 = map[string]int{
+		"EI":    0,
+		"MM":    1,
+		"EM":    2,
+		"CM":    3,
+		"VM":    4,
+		"OL":    5,
+		"NC":    6,
+		"BK":    7,
+		"CB":    8,
+		"LD":    9,
+		"RD":    10,
+		"XX":    11,
+		"NP":    12,
+		"Dn":    13,
+		"VC-Dn": 14,
+		"Up":    15,
+		"CF":    16,
+		"IB":    17,
+		"TM":    18,
+		"ST":    19,
+		"SP":    20,
+		"RS":    21,
+		"HS":    22,
+	}
+)
+
+func init() {
+	l2circuitPrefix := "junos_l2circuit_"
+
+	l := []string{"target", "address", "vcid"}
+
+	l2StateDescription := "A l2circuit can have one of the following state-mappings EI: 0,MM: 1,EM: 2,CM: 3,VM: 4,OL: 5,NC: 6,BK: 7,CB: 8,LD: 9,RD: 10,XX: 11,NP: 12,Dn: 13,VC-Dn: 14, Up: 15, CF: 16,IB: 17,TM: 18,ST: 19,SP: 20,RS: 21,HS: 22"
+
+	l2circuitConnectionsDesc = prometheus.NewDesc(l2circuitPrefix+"connection_count", "Number of L2Circuits", l, nil)
+
+	l2circuitConnectionStateDesc = prometheus.NewDesc(l2circuitPrefix+"connection_status", l2StateDescription, l, nil)
+}
+
+// Collector collects L2CIRCUIT metrics
+type l2circuitCollector struct {
+}
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector {
+	return &l2circuitCollector{}
+}
+
+// Describe describes the metrics
+func (*l2circuitCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- l2circuitConnectionStateDesc
+	ch <- l2circuitConnectionsDesc
+}
+
+// Collect collects metrics from JunOS
+func (c *l2circuitCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	return c.collectL2circuitMetrics(client, ch, labelValues)
+}
+
+func (c *l2circuitCollector) collectL2circuitMetrics(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var x = L2circuitRpc{}
+	err := client.RunCommandAndParse("show l2circuit connections brief", &x)
+	if err != nil {
+		return err
+	}
+
+	neighbors := x.Information.Neighbors
+
+	conncount := 0
+	for i := 0; i < len(neighbors); i++ {
+		conncount = conncount + len(neighbors[i].Connections)
+	}
+
+	for _, a := range neighbors {
+		l := append(labelValues, a.Address)
+		for _, b := range a.Connections {
+			idstr := b.ID
+			re := regexp.MustCompile(`\(vc ([0-9]+)\)`)
+			idint := re.FindStringSubmatch(idstr)
+			id := idint[len(idint)-1]
+			l := append(l, id)
+			state := l2circuitMap[b.StatusString]
+			ch <- prometheus.MustNewConstMetric(l2circuitConnectionsDesc, prometheus.GaugeValue, float64(conncount), l...)
+			ch <- prometheus.MustNewConstMetric(l2circuitConnectionStateDesc, prometheus.GaugeValue, float64(state), l...)
+		}
+	}
+
+	return nil
+}

--- a/l2circuit/rpc.go
+++ b/l2circuit/rpc.go
@@ -1,0 +1,21 @@
+package l2circuit
+
+type L2circuitRpc struct {
+	Information l2circuitInformation `xml:"l2circuit-connection-information"`
+}
+
+type l2circuitInformation struct {
+	Neighbors []l2circuitNeighbor `xml:"l2circuit-neighbor"`
+}
+
+type l2circuitNeighbor struct {
+	Address     string                `xml:"neighbor-address"`
+	Connections []l2circuitConnection `xml:"connection"`
+}
+
+type l2circuitConnection struct {
+	ID           string `xml:"connection-id"`
+	Type         string `xml:"connection-type"`
+	StatusString string `xml:"connection-status"`
+	Transitions  int    `xml:"up-transitions,omitempty"`
+}

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ var (
 	bgpEnabled                  = flag.Bool("bgp.enabled", true, "Scrape BGP metrics")
 	ospfEnabled                 = flag.Bool("ospf.enabled", true, "Scrape OSPFv3 metrics")
 	isisEnabled                 = flag.Bool("isis.enabled", false, "Scrape ISIS metrics")
+	l2circuitEnabled            = flag.Bool("l2circuit.enabled", false, "Scrape l2circuit metrics")
 	routingEngineEnabled        = flag.Bool("routingengine.enabled", true, "Scrape Routing Engine metrics")
 	routesEnabled               = flag.Bool("routes.enabled", true, "Scrape routing table metrics")
 	environmentEnabled          = flag.Bool("environment.enabled", true, "Scrape environment metrics")
@@ -95,6 +96,7 @@ func loadConfigFromFlags() *config.Config {
 	f.InterfaceDiagnostic = *interfaceDiagnosticsEnabled
 	f.ISIS = *isisEnabled
 	f.OSPF = *ospfEnabled
+	f.L2CIRCUIT = *l2circuitEnabled
 	f.Routes = *routesEnabled
 	f.RoutingEngine = *routingEngineEnabled
 


### PR DESCRIPTION
adds simple support for l2circuits.

- junos_l2circuit_connection_status
maps the tunnel state to number(0 to 22, 15 being operational/Up, rest indicates errors, or backup tunnels)
- junos_l2circuit_connections_count
count of all configured tunnels, can be compared to `junos_l2circuit_connection_status == 15` to check if all tunnels are good

