### PR TITLE
Collection of firewall filter counters and policers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following metrics are supported by now:
 * Environment (temperatures)
 * Routing engine statistics
 * Storage (total, available and used blocks, used percentage)
+* Firewall filters (counters and policers) - needs explicit rights beyond read-only
 * Statistics about l2circuits (tunnel state, number of tunnels)
 ```   0:EI -- encapsulation invalid      12:NP -- interface h/w not present
    1:MM -- mtu mismatch               13:Dn -- down
@@ -106,6 +107,7 @@ features:
   routes: true
   routing_engine: true
   interface_diagnostic: true
+  firewall: false
 ```
 
 ## Third Party Components

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 		Environment         bool `yaml:"environment,omitempty"`
 		BGP                 bool `yaml:"bgp,omitempty"`
 		OSPF                bool `yaml:"ospf,omitempty"`
+		Firewall            bool `yaml:"firewall,omitempty"`
 		ISIS                bool `yaml:"isis,omitempty"`
 		L2Circuit           bool `yaml:"l2circuit,omitempty"`
 		Routes              bool `yaml:"routes,omitempty"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,6 +25,7 @@ func TestShouldParse(t *testing.T) {
 
 	assertFeature("BGP", c.Features.BGP, true, t)
 	assertFeature("OSPF", c.Features.OSPF, false, t)
+	assertFeature("Firewall", c.Features.Firewall, false, t)
 	assertFeature("ISIS", c.Features.ISIS, true, t)
 	assertFeature("Routes", c.Features.Routes, true, t)
 	assertFeature("RoutingEngine", c.Features.RoutingEngine, true, t)
@@ -48,6 +49,7 @@ func TestShouldUseDefaults(t *testing.T) {
 
 	assertFeature("BGP", c.Features.BGP, true, t)
 	assertFeature("OSPF", c.Features.OSPF, true, t)
+	assertFeature("Firewall", c.Features.Firewall, false, t)
 	assertFeature("ISIS", c.Features.ISIS, false, t)
 	assertFeature("Routes", c.Features.Routes, true, t)
 	assertFeature("RoutingEngine", c.Features.RoutingEngine, true, t)

--- a/firewall/firewall_collector.go
+++ b/firewall/firewall_collector.go
@@ -1,0 +1,72 @@
+package firewall
+
+import (
+	"github.com/czerwonk/junos_exporter/collector"
+	"github.com/czerwonk/junos_exporter/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix string = "junos_firewall_filter_"
+
+var (
+	counterPackets       *prometheus.Desc
+	counterBytes         *prometheus.Desc
+	policerPackets       *prometheus.Desc
+	policerBytes         *prometheus.Desc
+)
+
+func init() {
+	l := []string{"target", "filter", "counter", "type"}
+
+	counterPackets = prometheus.NewDesc(prefix+"counter_packets", "Number of packets matching counter in firewall filter", l, nil)
+	counterBytes = prometheus.NewDesc(prefix+"counter_bytes", "Number of bytes matching counter in firewall filter", l, nil)
+  policerPackets = prometheus.NewDesc(prefix+"policer_packets", "Number of packets matching policer in firewall filter", l, nil)
+	policerBytes = prometheus.NewDesc(prefix+"policer_bytes", "Number of bytes matching policer in firewall filter", l, nil)
+}
+
+type firewallCollector struct {
+}
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector {
+	return &firewallCollector{}
+}
+
+// Describe describes the metrics
+func (*firewallCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- counterPackets
+	ch <- counterBytes
+	ch <- policerPackets
+	ch <- policerBytes
+}
+
+// Collect collects metrics from JunOS
+func (c *firewallCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var x = FirewallRpc{}
+	err := client.RunCommandAndParse("show firewall filter regex .*", &x)
+	if err != nil {
+		return err
+	}
+
+	for _, t := range x.Information.Filters {
+		c.collectForFilter(t, ch, labelValues)
+	}
+
+	return nil
+}
+
+func (c *firewallCollector) collectForFilter(filter Filter, ch chan<- prometheus.Metric, labelValues []string) {
+	l := append(labelValues, filter.Name)
+
+	for _, counter := range filter.Counters {
+		lp := append(l, counter.Name, "counter")
+		ch <- prometheus.MustNewConstMetric(counterPackets, prometheus.GaugeValue, float64(counter.Packets), lp...)
+		ch <- prometheus.MustNewConstMetric(counterBytes, prometheus.GaugeValue, float64(counter.Bytes), lp...)
+	}
+
+	for _, policer := range filter.Policers {
+		lp := append(l, policer.Name, "policer")
+		ch <- prometheus.MustNewConstMetric(policerPackets, prometheus.GaugeValue, float64(policer.Packets), lp...)
+		ch <- prometheus.MustNewConstMetric(policerBytes, prometheus.GaugeValue, float64(policer.Bytes), lp...)
+	}
+}

--- a/firewall/rpc.go
+++ b/firewall/rpc.go
@@ -1,0 +1,25 @@
+package firewall
+
+type FirewallRpc struct {
+	Information struct {
+		Filters []Filter `xml:"filter-information"`
+	} `xml:"firewall-information"`
+}
+
+type Filter struct {
+	Name         string               `xml:"filter-name"`
+	Counters    []FilterCounter       `xml:"counter"`
+	Policers    []FilterPolicer       `xml:"policer"`
+}
+
+type FilterCounter struct {
+	Name         string `xml:"counter-name"`
+	Packets      int64  `xml:"packet-count"`
+	Bytes        int64  `xml:"byte-count"`
+}
+
+type FilterPolicer struct {
+	Name         string `xml:"policer-name"`
+	Packets      int64  `xml:"packet-count"`
+	Bytes        int64  `xml:"byte-count"`
+}

--- a/junos_collector.go
+++ b/junos_collector.go
@@ -10,6 +10,7 @@ import (
 	"github.com/czerwonk/junos_exporter/collector"
 	"github.com/czerwonk/junos_exporter/connector"
 	"github.com/czerwonk/junos_exporter/environment"
+	"github.com/czerwonk/junos_exporter/firewall"
 	"github.com/czerwonk/junos_exporter/interfacediagnostics"
 	"github.com/czerwonk/junos_exporter/interfaces"
 	"github.com/czerwonk/junos_exporter/isis"
@@ -63,6 +64,10 @@ func collectors() map[string]collector.RPCCollector {
 
 	if f.BGP {
 		m["bgp"] = bgp.NewCollector()
+	}
+
+	if f.Firewall {
+		m["firewall"] = firewall.NewCollector()
 	}
 
 	if f.OSPF {

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ var (
 	sshKeyFile                  = flag.String("ssh.keyfile", "junos_exporter", "Public key file to use when connecting to junos devices using ssh")
 	debug                       = flag.Bool("debug", false, "Show verbose debug output in log")
 	bgpEnabled                  = flag.Bool("bgp.enabled", true, "Scrape BGP metrics")
+	firewallEnabled             = flag.Bool("firewall.enabled", true, "Scrape Firewall count metrics")
 	ospfEnabled                 = flag.Bool("ospf.enabled", true, "Scrape OSPFv3 metrics")
 	isisEnabled                 = flag.Bool("isis.enabled", false, "Scrape ISIS metrics")
 	l2circuitEnabled            = flag.Bool("l2circuit.enabled", false, "Scrape l2circuit metrics")
@@ -101,6 +102,7 @@ func loadConfigFromFlags() *config.Config {
 
 	f := &c.Features
 	f.BGP = *bgpEnabled
+	f.Firewall = *firewallEnabled
 	f.Environment = *environmentEnabled
 	f.Interfaces = *interfacesEnabled
 	f.InterfaceDiagnostic = *interfaceDiagnosticsEnabled


### PR DESCRIPTION
So this is my second go at Go, so please still bear with me and any pointers will be much appreciated.

Based off a copy of the routes package, as this was doing much the same as what I needed, albeit in a different directive.

This gets statistics (packets and bytes) from firewall filter (counters and policers), with labels for the filter and counter name, as well as if the type is counter or policer.

It's been tested to work with interface-specific filters too.