### PR TITLE
add cli flag to ignore check if target is specified in config

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"github.com/czerwonk/junos_exporter/connector"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/czerwonk/junos_exporter/connector"
+	"github.com/pkg/errors"
 
 	"github.com/czerwonk/junos_exporter/config"
 	"github.com/prometheus/client_golang/prometheus"
@@ -21,6 +22,7 @@ const version string = "0.8.0"
 
 var (
 	showVersion                 = flag.Bool("version", false, "Print version information.")
+	ignoreConfigTargets         = flag.Bool("config.ignore-targets", false, "Ignore check if target is specified in config")
 	listenAddress               = flag.String("web.listen-address", ":9326", "Address on which to expose metrics and web interface.")
 	metricsPath                 = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 	sshHosts                    = flag.String("ssh.targets", "", "Hosts to scrape")
@@ -169,6 +171,10 @@ func targetsForRequest(r *http.Request) ([]string, error) {
 		if t == reqTarget {
 			return []string{t}, nil
 		}
+	}
+
+	if *ignoreConfigTargets {
+		return []string{reqTarget}, nil
 	}
 
 	return nil, fmt.Errorf("the target '%s' is not defined in the configuration file", reqTarget)


### PR DESCRIPTION
As mentioned in #36 I have a bunch of small PRs that I'd need to move from an internal fork to upstream.

This PR adds a cli flag to ignore the check if a target is specified in the configuration file.

We're monitoring 400+ (rapidly increasing) devices with junos_exporter, and a mistaken curl without a target would scrape all devices putting unnecessary load on the devices and the exporter machine. So we currently run with no targets specified in the config and ignore the check.