### PR TITLE
export interface speeds

### DIFF
--- a/interfaces/interface_stats.go
+++ b/interfaces/interface_stats.go
@@ -8,6 +8,7 @@ type InterfaceStats struct {
 	Description         string
 	Mac                 string
 	IsPhysical          bool
+	Speed               float64
 	ReceiveBytes        float64
 	ReceivePackets      float64
 	ReceiveErrors       float64

--- a/interfaces/rpc.go
+++ b/interfaces/rpc.go
@@ -12,6 +12,7 @@ type PhyInterface struct {
 	OperStatus        string         `xml:"oper-status"`
 	Description       string         `xml:"description"`
 	MacAddress        string         `xml:"current-physical-address"`
+	Speed             string         `xml:"speed"`
 	Stats             TrafficStat    `xml:"traffic-statistics"`
 	LogicalInterfaces []LogInterface `xml:"logical-interface"`
 	InputErrors       struct {
@@ -31,10 +32,10 @@ type LogInterface struct {
 }
 
 type TrafficStat struct {
-	InputBytes    uint64    `xml:"input-bytes"`
-	InputPackets  uint64    `xml:"input-packets"`
-	OutputBytes   uint64    `xml:"output-bytes"`
-	OutputPackets uint64    `xml:"output-packets"`
+	InputBytes    uint64   `xml:"input-bytes"`
+	InputPackets  uint64   `xml:"input-packets"`
+	OutputBytes   uint64   `xml:"output-bytes"`
+	OutputPackets uint64   `xml:"output-packets"`
 	IPv6Traffic   IPv6Stat `xml:"ipv6-transit-statistics"`
 }
 


### PR DESCRIPTION
This PR exports interface speeds, the map consists of the speeds we have in our org but is not exhaustive, other than adding all possible speeds I can't think of a better idea to solve this.

This fixes #27 