### PR TITLE
Fix: remove bgp port from IP which wasn't present with  bgp summary

### DIFF
--- a/bgp/collector.go
+++ b/bgp/collector.go
@@ -4,6 +4,8 @@ import (
 	"github.com/czerwonk/junos_exporter/collector"
 	"github.com/czerwonk/junos_exporter/rpc"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"strings"
 )
 
 const prefix string = "junos_bgp_session_"
@@ -81,7 +83,8 @@ func (c *bgpCollector) collect(client *rpc.Client, ch chan<- prometheus.Metric, 
 }
 
 func (c *bgpCollector) collectForPeer(p BGPPeer, ch chan<- prometheus.Metric, labelValues []string) {
-	l := append(labelValues, []string{p.ASN, p.IP, p.Description}...)
+	ip := strings.Split(p.IP, "+")
+	l := append(labelValues, []string{p.ASN, ip[0], p.Description}...)
 
 	up := 0
 	if p.State == "Established" {

--- a/connector/connection.go
+++ b/connector/connection.go
@@ -25,7 +25,7 @@ func (c *SSHConnection) RunCommand(cmd string) ([]byte, error) {
 	defer c.mu.Unlock()
 
 	if c.client == nil {
-		return nil, errors.New("not conneted")
+		return nil, errors.New("not connected")
 	}
 
 	session, err := c.client.NewSession()

--- a/main.go
+++ b/main.go
@@ -115,6 +115,7 @@ func initChannels() {
 			case <-term:
 				log.Infoln("Closing connections to devices")
 				connManager.Close()
+				os.Exit(0)
 			}
 		}
 	}()


### PR DESCRIPTION
The switch from 'show bgp summary' to 'show bgp neighbor' added a bgp port to the peer-address.