### PR TITLE
Adding metrics for RPKI sessions/stats

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ type FeatureConfig struct {
 	Accounting          bool `yaml:"accounting,omitempty"`
 	IPSec               bool `yaml:"ipsec,omitempty"`
 	FPC                 bool `yaml:"fpc,omitempty"`
+	RPKI                bool `yaml:"rpki,omitempty"`
 }
 
 // New creates a new config
@@ -89,4 +90,5 @@ func setDefaultValues(c *Config) {
 	f.Accounting = false
 	f.FPC = false
 	f.L2Circuit = false
+	f.RPKI = false
 }

--- a/junos_collector.go
+++ b/junos_collector.go
@@ -25,6 +25,7 @@ import (
 	"github.com/czerwonk/junos_exporter/route"
 	"github.com/czerwonk/junos_exporter/routingengine"
 	"github.com/czerwonk/junos_exporter/rpc"
+	"github.com/czerwonk/junos_exporter/rpki"
 	"github.com/czerwonk/junos_exporter/storage"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
@@ -170,6 +171,10 @@ func collectors(ifaceLabels *interfacelabels.DynamicLabels) map[string]collector
 		m["interface_queue"] = interfacequeue.NewCollector(ifaceLabels)
 	}
 
+	if f.RPKI {
+		m["rpki"] = rpki.NewCollector()
+	}
+
 	return m
 }
 
@@ -216,12 +221,12 @@ func (c *junosCollector) collectForHost(device *connector.Device, ch chan<- prom
 
 	for k, col := range c.collectors {
 		ct := time.Now()
-    err := col.Collect(rpc, ch, l)
-    
+		err := col.Collect(rpc, ch, l)
+
 		if err != nil && err.Error() != "EOF" {
 			log.Errorln(k + ": " + err.Error())
 		}
-    
-    ch <- prometheus.MustNewConstMetric(scrapeCollectorDurationDesc, prometheus.GaugeValue, time.Since(ct).Seconds(), append(l, k)...)
+
+		ch <- prometheus.MustNewConstMetric(scrapeCollectorDurationDesc, prometheus.GaugeValue, time.Since(ct).Seconds(), append(l, k)...)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ var (
 	fpcEnabled                  = flag.Bool("fpc.enabled", true, "Scrape line card metrics")
 	accountingEnabled           = flag.Bool("accounting.enabled", false, "Scrape accounting flow metrics")
 	interfaceQueuesEnabled      = flag.Bool("queues.enabled", false, "Scrape interface queue metrics")
+	rpkiEnabled                 = flag.Bool("rpki.enabled", false, "Scrape rpki metrics")
 	alarmFilter                 = flag.String("alarms.filter", "", "Regex to filter for alerts to ignore")
 	configFile                  = flag.String("config.file", "", "Path to config file")
 	dynamicIfaceLabels          = flag.Bool("dynamic-interface-labels", true, "Parse interface descriptions to get labels dynamicly")
@@ -192,6 +193,7 @@ func loadConfigFromFlags() *config.Config {
 	f.RoutingEngine = *routingEngineEnabled
 	f.Accounting = *accountingEnabled
 	f.FPC = *fpcEnabled
+	f.RPKI = *rpkiEnabled
 
 	return c
 }

--- a/rpki/collector.go
+++ b/rpki/collector.go
@@ -1,0 +1,117 @@
+package rpki
+
+import (
+	"github.com/czerwonk/junos_exporter/collector"
+	"github.com/czerwonk/junos_exporter/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix string = "junos_rpki_"
+
+var (
+	// Session metrics
+	upDesc              *prometheus.Desc
+	flapsDesc           *prometheus.Desc
+	ipv4PrefixCountDesc *prometheus.Desc
+	ipv6PrefixCountDesc *prometheus.Desc
+
+	// Statistics metrics
+	memoryUtilizationDesc    *prometheus.Desc
+	originResultsValidDesc   *prometheus.Desc
+	originResultsInvalidDesc *prometheus.Desc
+	originResultsUnknownDesc *prometheus.Desc
+)
+
+func init() {
+	lSession := []string{"target", "ip"}
+	upDesc = prometheus.NewDesc(prefix+"session_state", "Session is up (1 = Up)", lSession, nil)
+	flapsDesc = prometheus.NewDesc(prefix+"session_flap_count", "Number of session flaps", lSession, nil)
+	ipv4PrefixCountDesc = prometheus.NewDesc(prefix+"session_ipv4_prefix_count", "Number of IPv4 route validation records", lSession, nil)
+	ipv6PrefixCountDesc = prometheus.NewDesc(prefix+"session_ipv6_prefix_count", "Number of IPv6 route validation records", lSession, nil)
+
+	lStats := []string{"target"}
+	stats_prefix := prefix + "statistics_"
+	memoryUtilizationDesc = prometheus.NewDesc(stats_prefix+"memory", "Memory utilization of RV database (in bytes)", lStats, nil)
+	originResultsValidDesc = prometheus.NewDesc(stats_prefix+"origin_valid", "Origin validation result of valid", lStats, nil)
+	originResultsInvalidDesc = prometheus.NewDesc(stats_prefix+"origin_invalid", "Origin validation result of invalid", lStats, nil)
+	originResultsUnknownDesc = prometheus.NewDesc(stats_prefix+"origin_unknown", "Origin validation result of unknown", lStats, nil)
+}
+
+type rpkiCollector struct {
+}
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector {
+	return &rpkiCollector{}
+}
+
+// Describe describes the metrics
+func (*rpkiCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- upDesc
+	ch <- flapsDesc
+	ch <- ipv4PrefixCountDesc
+	ch <- ipv6PrefixCountDesc
+	ch <- memoryUtilizationDesc
+	ch <- originResultsValidDesc
+	ch <- originResultsInvalidDesc
+	ch <- originResultsUnknownDesc
+}
+
+// Collect collects metrics from JunOS
+func (c *rpkiCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	err := c.collectSessions(client, ch, labelValues)
+	if err != nil {
+		return err
+	}
+
+	err = c.collectStatistics(client, ch, labelValues)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *rpkiCollector) collectSessions(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var x = RpkiSessionRpc{}
+	err := client.RunCommandAndParse("show validation session", &x)
+	if err != nil {
+		return err
+	}
+
+	for _, session := range x.Information.RpkiSessions {
+		c.collectForSession(session, ch, labelValues)
+	}
+
+	return nil
+}
+
+func (c *rpkiCollector) collectForSession(s RpkiSession, ch chan<- prometheus.Metric, labelValues []string) {
+	l := append(labelValues, []string{s.IpAddress}...)
+
+	up := 0
+	if s.SessionState == "Up" {
+		up = 1
+	}
+
+	ch <- prometheus.MustNewConstMetric(upDesc, prometheus.GaugeValue, float64(up), l...)
+	ch <- prometheus.MustNewConstMetric(flapsDesc, prometheus.GaugeValue, float64(s.SessionFlaps), l...)
+	ch <- prometheus.MustNewConstMetric(ipv4PrefixCountDesc, prometheus.GaugeValue, float64(s.Ipv4PrefixCount), l...)
+	ch <- prometheus.MustNewConstMetric(ipv6PrefixCountDesc, prometheus.GaugeValue, float64(s.Ipv6PrefixCount), l...)
+}
+
+func (c *rpkiCollector) collectStatistics(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var x = RpkiStatisticsRpc{}
+
+	err := client.RunCommandAndParse("show validation statistics", &x)
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(memoryUtilizationDesc, prometheus.GaugeValue, float64(x.Information.Statistics.MemoryUtilization), labelValues...)
+	ch <- prometheus.MustNewConstMetric(originResultsValidDesc, prometheus.GaugeValue, float64(x.Information.Statistics.OriginResultsValid), labelValues...)
+	ch <- prometheus.MustNewConstMetric(originResultsInvalidDesc, prometheus.GaugeValue, float64(x.Information.Statistics.OriginResultsInvalid), labelValues...)
+	ch <- prometheus.MustNewConstMetric(originResultsUnknownDesc, prometheus.GaugeValue, float64(x.Information.Statistics.OriginResultsUnknown), labelValues...)
+
+	return nil
+}

--- a/rpki/rpc.go
+++ b/rpki/rpc.go
@@ -1,0 +1,32 @@
+package rpki
+
+type RpkiSessionRpc struct {
+	Information struct {
+		RpkiSessions []RpkiSession `xml:"rv-session"`
+	} `xml:"rv-session-information"`
+}
+
+type RpkiSession struct {
+	IpAddress       string `xml:"ip-address"`
+	SessionState    string `xml:"session-state"`
+	SessionFlaps    int64  `xml:"session-flaps"`
+	Ipv4PrefixCount int64  `xml:"ip-prefix-count"`
+	Ipv6PrefixCount int64  `xml:"ip6-prefix-count"`
+}
+
+type RpkiStatisticsRpc struct {
+	Information struct {
+		Statistics RpkiStatistics `xml:"rv-statistics"`
+	} `xml:"rv-statistics-information"`
+}
+
+type RpkiStatistics struct {
+	RecordCount            int64 `xml:"rv-record-count"`
+	ReplicationRecordCount int64 `xml:"rv-replication-record-count"`
+	PrefixCount            int64 `xml:"rv-prefix-count"`
+	OriginASCount          int64 `xml:"rv-origin-as-count"`
+	MemoryUtilization      int64 `xml:"rv-memory-utilization"`
+	OriginResultsValid     int64 `xml:"rv-policy-origin-validation-results-valid"`
+	OriginResultsInvalid   int64 `xml:"rv-policy-origin-validation-results-invalid"`
+	OriginResultsUnknown   int64 `xml:"rv-policy-origin-validation-results-unknown"`
+}


### PR DESCRIPTION
This PR adds prometheus metrics for RPKI route validation cache server sessions and global route validation statistics. The following metrics are now exposed:
```
# HELP junos_rpki_session_flap_count Number of session flaps                        
# TYPE junos_rpki_session_flap_count gauge                                          
junos_rpki_session_flap_count{ip="10.10.1.2",target="localhost:2222"} 1
   
# HELP junos_rpki_session_ipv4_prefix_count Number of IPv4 route validation records 
# TYPE junos_rpki_session_ipv4_prefix_count gauge                                   
junos_rpki_session_ipv4_prefix_count{ip="10.10.1.2",target="localhost:2222"} 97361  

# HELP junos_rpki_session_ipv6_prefix_count Number of IPv6 route validation records 
# TYPE junos_rpki_session_ipv6_prefix_count gauge                                   
junos_rpki_session_ipv6_prefix_count{ip="10.10.1.2",target="localhost:2222"} 16418  

# HELP junos_rpki_session_state Session is up (1 = Up)                              
# TYPE junos_rpki_session_state gauge                                               
junos_rpki_session_state{ip="10.10.1.2",target="localhost:2222"} 1                  

# HELP junos_rpki_statistics_memory Memory utilization of RV database (in bytes)    
# TYPE junos_rpki_statistics_memory gauge                                           
junos_rpki_statistics_memory{target="localhost:2222"} 2.181864e+07                  

# HELP junos_rpki_statistics_origin_invalid Origin validation result of invalid     
# TYPE junos_rpki_statistics_origin_invalid gauge                                   
junos_rpki_statistics_origin_invalid{target="localhost:2222"} 0                     

# HELP junos_rpki_statistics_origin_unknown Origin validation result of unknown     
# TYPE junos_rpki_statistics_origin_unknown gauge                                   
junos_rpki_statistics_origin_unknown{target="localhost:2222"} 0                     

# HELP junos_rpki_statistics_origin_valid Origin validation result of valid         
# TYPE junos_rpki_statistics_origin_valid gauge                                     
junos_rpki_statistics_origin_valid{target="localhost:2222"} 0                       
```