### PR TITLE
Add support for logical systems

### DIFF
--- a/bgp/collector.go
+++ b/bgp/collector.go
@@ -38,11 +38,12 @@ func init() {
 }
 
 type bgpCollector struct {
+	LogicalSystem string
 }
 
 // NewCollector creates a new collector
-func NewCollector() collector.RPCCollector {
-	return &bgpCollector{}
+func NewCollector(ls string) collector.RPCCollector {
+	return &bgpCollector{LogicalSystem: ls}
 }
 
 // Describe describes the metrics
@@ -70,7 +71,13 @@ func (c *bgpCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, 
 
 func (c *bgpCollector) collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = BGPRPC{}
-	err := client.RunCommandAndParse("show bgp neighbor", &x)
+	var cmd strings.Builder
+	cmd.WriteString("show bgp neighbor")
+	if c.LogicalSystem != "" {
+		cmd.WriteString(" logical-system " + c.LogicalSystem)
+	}
+
+	err := client.RunCommandAndParse(cmd.String(), &x)
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -9,10 +9,11 @@ import (
 
 // Config represents the configuration for the exporter
 type Config struct {
-	Password string          `yaml:"password"`
-	Targets  []string        `yaml:"targets,omitempty"`
-	Devices  []*DeviceConfig `yaml:"devices,omitempty"`
-	Features FeatureConfig   `yaml:"features,omitempty"`
+	Password  string          `yaml:"password"`
+	Targets   []string        `yaml:"targets,omitempty"`
+	Devices   []*DeviceConfig `yaml:"devices,omitempty"`
+	Features  FeatureConfig   `yaml:"features,omitempty"`
+	LSEnabled bool            `yaml:"logical_systems,omitempty"`
 }
 
 // DeviceConfig is the config representation of 1 device
@@ -25,6 +26,7 @@ type DeviceConfig struct {
 
 // FeatureConfig is the list of collectors enabled or disabled
 type FeatureConfig struct {
+	Alarm               bool `yaml:"alarm,omitempty"`
 	Environment         bool `yaml:"environment,omitempty"`
 	BGP                 bool `yaml:"bgp,omitempty"`
 	OSPF                bool `yaml:"ospf,omitempty"`
@@ -73,7 +75,9 @@ func Load(reader io.Reader) (*Config, error) {
 
 func setDefaultValues(c *Config) {
 	c.Password = ""
+	c.LSEnabled = false
 	f := &c.Features
+	f.Alarm = true
 	f.BGP = true
 	f.Environment = true
 	f.Interfaces = true

--- a/ospf/collector.go
+++ b/ospf/collector.go
@@ -1,6 +1,8 @@
 package ospf
 
 import (
+	"strings"
+
 	"github.com/czerwonk/junos_exporter/collector"
 	"github.com/czerwonk/junos_exporter/rpc"
 	"github.com/prometheus/client_golang/prometheus"
@@ -28,11 +30,12 @@ func init() {
 
 // Collector collects OSPFv3 metrics
 type ospfCollector struct {
+	LogicalSystem string
 }
 
 // NewCollector creates a new collector
-func NewCollector() collector.RPCCollector {
-	return &ospfCollector{}
+func NewCollector(ls string) collector.RPCCollector {
+	return &ospfCollector{LogicalSystem: ls}
 }
 
 // Describe describes the metrics
@@ -55,7 +58,13 @@ func (c *ospfCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric,
 
 func (c *ospfCollector) collectOSPFMetrics(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = OspfRpc{}
-	err := client.RunCommandAndParse("show ospf overview", &x)
+	var cmd strings.Builder
+	cmd.WriteString("show ospf overview")
+	if c.LogicalSystem != "" {
+		cmd.WriteString(" logical-system " + c.LogicalSystem)
+	}
+
+	err := client.RunCommandAndParse(cmd.String(), &x)
 	if err != nil {
 		return err
 	}
@@ -79,7 +88,13 @@ func (c *ospfCollector) collectOSPFMetrics(client *rpc.Client, ch chan<- prometh
 
 func (c *ospfCollector) collectOSPFv3Metrics(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = Ospf3Rpc{}
-	err := client.RunCommandAndParse("show ospf3 overview", &x)
+	var cmd strings.Builder
+	cmd.WriteString("show ospf3 overview")
+	if c.LogicalSystem != "" {
+		cmd.WriteString(" logical-system " + c.LogicalSystem)
+	}
+
+	err := client.RunCommandAndParse(cmd.String(), &x)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In this PR:
- added support for logical systems in bgp and ospf collectors
- make possible to disable alarm collector (when work with logical systems as example)