### PR TITLE
Adding metric for PIC status in the FPC Collector

### DIFF
--- a/fpc/rpc.go
+++ b/fpc/rpc.go
@@ -23,5 +23,11 @@ type FPC struct {
 	UpTime struct {
 		Seconds uint64 `xml:"seconds,attr"`
 	} `xml:"up-time"`
-	MaxPowerConsumption uint `xml:"max-power-consumption,omitempty"`
+	MaxPowerConsumption uint  `xml:"max-power-consumption,omitempty"`
+	Pics                []PIC `xml:"pic"`
+}
+type PIC struct {
+	PicSlot  int    `xml:"pic-slot"`
+	PicState string `xml:"pic-state"`
+	PicType  string `xml:"pic-type"`
 }


### PR DESCRIPTION
This PR adds a metric for pic state which is gathered from `show chassis fpc pic-status`, it also appends the fpc_slot, pic_slot, pic_type, and target as labels.

```
# HELP junos_fpc_pic_status Status of the PIC (1 = Online, 0 = Offline)
# TYPE junos_fpc_pic_status gauge
junos_fpc_pic_status{fpc_slot="0",pic_slot="0",pic_type="48x 10G-SFP+",target="127.0.0.1:2200"} 1
```