### PR TITLE
adding re_status and re_uptime

### DIFF
--- a/routingengine/rpc.go
+++ b/routingengine/rpc.go
@@ -7,18 +7,22 @@ type RoutingEngineRpc struct {
 }
 
 type RouteEngine struct {
-	Slot               string                 `xml:"slot"`
-	Temperature        RouteEngineTemperature `xml:"temperature"`
-	MemoryUtilization  float64                `xml:"memory-buffer-utilization"`
-	CPUTemperature     RouteEngineTemperature `xml:"cpu-temperature"`
-	CPUUser            float64                `xml:"cpu-user"`
-	CPUBackground      float64                `xml:"cpu-background"`
-	CPUSystem          float64                `xml:"cpu-system"`
-	CPUInterrupt       float64                `xml:"cpu-interrupt"`
-	CPUIdle            float64                `xml:"cpu-idle"`
-	LoadAverageOne     float64                `xml:"load-average-one"`
-	LoadAverageFive    float64                `xml:"load-average-five"`
-	LoadAverageFifteen float64                `xml:"load-average-fifteen"`
+	Slot              string                 `xml:"slot"`
+	Status            string                 `xml:"status"`
+	Temperature       RouteEngineTemperature `xml:"temperature"`
+	MemoryUtilization float64                `xml:"memory-buffer-utilization"`
+	CPUTemperature    RouteEngineTemperature `xml:"cpu-temperature"`
+	CPUUser           float64                `xml:"cpu-user"`
+	CPUBackground     float64                `xml:"cpu-background"`
+	CPUSystem         float64                `xml:"cpu-system"`
+	CPUInterrupt      float64                `xml:"cpu-interrupt"`
+	CPUIdle           float64                `xml:"cpu-idle"`
+	UpTime            struct {
+		Seconds uint64 `xml:"seconds,attr"`
+	} `xml:"up-time"`
+	LoadAverageOne     float64 `xml:"load-average-one"`
+	LoadAverageFive    float64 `xml:"load-average-five"`
+	LoadAverageFifteen float64 `xml:"load-average-fifteen"`
 }
 
 type RouteEngineTemperature struct {


### PR DESCRIPTION
This PR adds two metrics to the routing_engine collector, one for the routing-engine status and one for the routing-engine uptime.

```
# HELP junos_route_engine_status Status of routing-engine (1 OK, 2 Testing, 3 Failed, 4 Absent, 5 Present)
# TYPE junos_route_engine_status gauge
junos_route_engine_status{slot="0",target="127.0.0.1:2200"} 4
```

```
# HELP junos_route_engine_uptime_seconds Seconds since boot
# TYPE junos_route_engine_uptime_seconds counter
junos_route_engine_uptime_seconds{slot="0",target="127.0.0.1:2200"} 315095
```
