### PR TITLE
Junos Satellite

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,7 @@ type FeatureConfig struct {
 	IPSec               bool `yaml:"ipsec,omitempty"`
 	FPC                 bool `yaml:"fpc,omitempty"`
 	RPKI                bool `yaml:"rpki,omitempty"`
+	Satellite           bool `yaml:"satellite,omitempty"`
 }
 
 // New creates a new config
@@ -96,6 +97,7 @@ func setDefaultValues(c *Config) {
 	f.FPC = false
 	f.L2Circuit = false
 	f.RPKI = false
+	f.Satellite = false
 }
 
 // FeaturesForDevice gets the feature set configured for a device

--- a/environment/collector.go
+++ b/environment/collector.go
@@ -79,20 +79,22 @@ func (c *environmentCollector) environmentItems(client *rpc.Client) ([]*temperat
 	}
 
 	// gather satellite data
-	var y = EnvironmentRpc{}
-	err = client.RunCommandAndParseWithParser("show chassis environment satellite", func(b []byte) error {
-		if string(b[:]) == "\nerror: syntax error, expecting <command>: satellite\n" {
-			log.Printf("system doesn't seem to have satellite enabled")
-			return nil
-		}
+	if client.Satellite {
+		var y = EnvironmentRpc{}
+		err = client.RunCommandAndParseWithParser("show chassis environment satellite", func(b []byte) error {
+			if string(b[:]) == "\nerror: syntax error, expecting <command>: satellite\n" {
+				log.Printf("system doesn't seem to have satellite enabled")
+				return nil
+			}
 
-		return xml.Unmarshal(b, &y)
-	})
-	if err != nil {
-		return nil, nil, err
-	} else {
-		// add satellite details
-		x.Information.Items = append(x.Information.Items, y.Information.Items...)
+			return xml.Unmarshal(b, &y)
+		})
+		if err != nil {
+			return nil, nil, err
+		} else {
+			// add satellite details
+			x.Information.Items = append(x.Information.Items, y.Information.Items...)
+		}
 	}
 
 	// remove duplicates

--- a/environment/collector.go
+++ b/environment/collector.go
@@ -1,6 +1,8 @@
 package environment
 
 import (
+	"encoding/xml"
+	"log"
 	"strings"
 
 	"github.com/czerwonk/junos_exporter/collector"
@@ -74,6 +76,23 @@ func (c *environmentCollector) environmentItems(client *rpc.Client) ([]*temperat
 	err := client.RunCommandAndParse("show chassis environment", &x)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// gather satellite data
+	var y = EnvironmentRpc{}
+	err = client.RunCommandAndParseWithParser("show chassis environment satellite", func(b []byte) error {
+		if string(b[:]) == "\nerror: syntax error, expecting <command>: satellite\n" {
+			log.Printf("system doesn't seem to have satellite enabled")
+			return nil
+		}
+
+		return xml.Unmarshal(b, &y)
+	})
+	if err != nil {
+		return nil, nil, err
+	} else {
+		// add satellite details
+		x.Information.Items = append(x.Information.Items, y.Information.Items...)
 	}
 
 	// remove duplicates

--- a/interfacediagnostics/collector.go
+++ b/interfacediagnostics/collector.go
@@ -81,12 +81,15 @@ func (c *interfaceDiagnosticsCollector) Collect(client *rpc.Client, ch chan<- pr
 		return err
 	}
 
-	diagnosticsSatellite, err := c.interfaceDiagnosticsSatellite(client)
-	if err != nil {
-		return err
-	}
+	// add satellite details if feature is enabled
+	if client.Satellite {
+		diagnosticsSatellite, err := c.interfaceDiagnosticsSatellite(client)
+		if err != nil {
+			return err
+		}
 
-	diagnostics = append(diagnostics, diagnosticsSatellite...)
+		diagnostics = append(diagnostics, diagnosticsSatellite...)
+	}
 
 	for _, d := range diagnostics {
 		l := append(labelValues, d.Name)

--- a/junos_collector.go
+++ b/junos_collector.go
@@ -73,6 +73,10 @@ func clientForDevice(device *connector.Device, connManager *connector.SSHConnect
 		c.EnableDebug()
 	}
 
+	if cfg.Features.Satellite {
+		c.EnableSatellite()
+	}
+
 	return c, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ var (
 	accountingEnabled           = flag.Bool("accounting.enabled", false, "Scrape accounting flow metrics")
 	interfaceQueuesEnabled      = flag.Bool("queues.enabled", false, "Scrape interface queue metrics")
 	rpkiEnabled                 = flag.Bool("rpki.enabled", false, "Scrape rpki metrics")
+	satelliteEnabled            = flag.Bool("satellite.enabled", false, "Scrape metrics from satellite devices")
 	alarmFilter                 = flag.String("alarms.filter", "", "Regex to filter for alerts to ignore")
 	configFile                  = flag.String("config.file", "", "Path to config file")
 	dynamicIfaceLabels          = flag.Bool("dynamic-interface-labels", true, "Parse interface descriptions to get labels dynamicly")
@@ -200,6 +201,7 @@ func loadConfigFromFlags() *config.Config {
 	f.FPC = *fpcEnabled
 	f.RPKI = *rpkiEnabled
 	f.Storage = *storageEnabled
+	f.Satellite = *satelliteEnabled
 
 	return c
 }

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -10,11 +10,15 @@ import (
 )
 
 type Parser func([]byte) error
+type ClientCfg struct {
+	SatelliteEnabled bool
+}
 
 // Client sends commands to JunOS and parses results
 type Client struct {
-	conn  *connector.SSHConnection
-	debug bool
+	conn      *connector.SSHConnection
+	debug     bool
+	Satellite bool
 }
 
 // NewClient creates a new client to connect to
@@ -63,4 +67,9 @@ func (c *Client) EnableDebug() {
 // DisableDebug disables the debug mode
 func (c *Client) DisableDebug() {
 	c.debug = false
+}
+
+// EnableSatellite enables satellite device metrics gathering
+func (c *Client) EnableSatellite() {
+	c.Satellite = true
 }


### PR DESCRIPTION
This PR adds support for satellite information of interface diagnostics and chassis environment. It adds to the existing collectors meaning there is no metric distinction between local and satellite resource.

Note: There is a bug in Junos whereas xml output of the interface diagnostics causes malformed XML to be returned. In particular the `<interface-information>` tag is opened twice. To work around this issue, duplicated lines are first removed from the rpc response and then parsed using `encoding/xml`.

Note2: Due to `RunCommandAndParseWithParser()` logging the response in debug mode, on systems not using satellite, an error message will be displayed. The error handling in this PR takes are of this and ensures that all other metrics come through as they do now. However, it should be noted that this error message can display thus another log messages is added in this PR to put some context to the rpc reply.

Comments and suggestions welcome :)