### PR TITLE
Added thresholds for interface diagnostics

### DIFF
--- a/interfacediagnostics/collector.go
+++ b/interfacediagnostics/collector.go
@@ -17,14 +17,49 @@ import (
 const prefix = "junos_interface_diagnostics_"
 
 type interfaceDiagnosticsCollector struct {
-	labels                         *interfacelabels.DynamicLabels
-	laserBiasCurrentDesc           *prometheus.Desc
-	laserOutputPowerDesc           *prometheus.Desc
-	laserOutputPowerDbmDesc        *prometheus.Desc
-	moduleTemperatureDesc          *prometheus.Desc
-	laserRxOpticalPowerDesc        *prometheus.Desc
-	laserRxOpticalPowerDbmDesc     *prometheus.Desc
-	moduleVoltageDesc              *prometheus.Desc
+	labels                                 *interfacelabels.DynamicLabels
+	laserBiasCurrentDesc                   *prometheus.Desc
+	laserBiasCurrentHighAlarmThresholdDesc *prometheus.Desc
+	laserBiasCurrentLowAlarmThresholdDesc  *prometheus.Desc
+	laserBiasCurrentHighWarnThresholdDesc  *prometheus.Desc
+	laserBiasCurrentLowWarnThresholdDesc   *prometheus.Desc
+
+	laserOutputPowerDesc                   *prometheus.Desc
+	laserOutputPowerHighAlarmThresholdDesc *prometheus.Desc
+	laserOutputPowerLowAlarmThresholdDesc  *prometheus.Desc
+	laserOutputPowerHighWarnThresholdDesc  *prometheus.Desc
+	laserOutputPowerLowWarnThresholdDesc   *prometheus.Desc
+
+	laserOutputPowerDbmDesc                   *prometheus.Desc
+	laserOutputPowerHighAlarmThresholdDbmDesc *prometheus.Desc
+	laserOutputPowerLowAlarmThresholdDbmDesc  *prometheus.Desc
+	laserOutputPowerHighWarnThresholdDbmDesc  *prometheus.Desc
+	laserOutputPowerLowWarnThresholdDbmDesc   *prometheus.Desc
+
+	moduleTemperatureDesc                   *prometheus.Desc
+	moduleTemperatureHighAlarmThresholdDesc *prometheus.Desc
+	moduleTemperatureLowAlarmThresholdDesc  *prometheus.Desc
+	moduleTemperatureHighWarnThresholdDesc  *prometheus.Desc
+	moduleTemperatureLowWarnThresholdDesc   *prometheus.Desc
+
+	laserRxOpticalPowerDesc                   *prometheus.Desc
+	laserRxOpticalPowerHighAlarmThresholdDesc *prometheus.Desc
+	laserRxOpticalPowerLowAlarmThresholdDesc  *prometheus.Desc
+	laserRxOpticalPowerHighWarnThresholdDesc  *prometheus.Desc
+	laserRxOpticalPowerLowWarnThresholdDesc   *prometheus.Desc
+
+	laserRxOpticalPowerDbmDesc                   *prometheus.Desc
+	laserRxOpticalPowerHighAlarmThresholdDbmDesc *prometheus.Desc
+	laserRxOpticalPowerLowAlarmThresholdDbmDesc  *prometheus.Desc
+	laserRxOpticalPowerHighWarnThresholdDbmDesc  *prometheus.Desc
+	laserRxOpticalPowerLowWarnThresholdDbmDesc   *prometheus.Desc
+
+	moduleVoltageDesc                   *prometheus.Desc
+	moduleVoltageHighAlarmThresholdDesc *prometheus.Desc
+	moduleVoltageLowAlarmThresholdDesc  *prometheus.Desc
+	moduleVoltageHighWarnThresholdDesc  *prometheus.Desc
+	moduleVoltageLowWarnThresholdDesc   *prometheus.Desc
+
 	rxSignalAvgOpticalPowerDesc    *prometheus.Desc
 	rxSignalAvgOpticalPowerDbmDesc *prometheus.Desc
 }
@@ -49,27 +84,91 @@ func (c *interfaceDiagnosticsCollector) init() {
 	l = append(l, c.labels.LabelNames()...)
 
 	c.moduleVoltageDesc = prometheus.NewDesc(prefix+"module_voltage", "Module voltage", l, nil)
+	c.moduleVoltageHighAlarmThresholdDesc = prometheus.NewDesc(prefix+"module_voltage_high_alarm_threshold", "Module voltage high alarm threshold", l, nil)
+	c.moduleVoltageLowAlarmThresholdDesc = prometheus.NewDesc(prefix+"module_voltage_low_alarm_threshold", "Module voltage low alarm threshold", l, nil)
+	c.moduleVoltageHighWarnThresholdDesc = prometheus.NewDesc(prefix+"module_voltage_high_warn_threshold", "Module voltage high warn threshold", l, nil)
+	c.moduleVoltageLowWarnThresholdDesc = prometheus.NewDesc(prefix+"module_voltage_low_warn_threshold", "Module voltage low warn threshold", l, nil)
+
 	c.moduleTemperatureDesc = prometheus.NewDesc(prefix+"temp", "Module temperature in degrees Celsius", l, nil)
+	c.moduleTemperatureHighAlarmThresholdDesc = prometheus.NewDesc(prefix+"temp_high_alarm_threshold", "Module temperature high alarm threshold in degrees Celsius", l, nil)
+	c.moduleTemperatureLowAlarmThresholdDesc = prometheus.NewDesc(prefix+"temp_low_alarm_threshold", "Module temperature low alarm threshold in degrees Celsius", l, nil)
+	c.moduleTemperatureHighWarnThresholdDesc = prometheus.NewDesc(prefix+"temp_high_warn_threshold", "Module temperature high warn threshold in degrees Celsius", l, nil)
+	c.moduleTemperatureLowWarnThresholdDesc = prometheus.NewDesc(prefix+"temp_low_warn_threshold", "Module temperature low warn threshold in degrees Celsius", l, nil)
+
 	c.rxSignalAvgOpticalPowerDesc = prometheus.NewDesc(prefix+"rx_signal_avg", "Receiver signal average optical power in mW", l, nil)
 	c.rxSignalAvgOpticalPowerDbmDesc = prometheus.NewDesc(prefix+"rx_signal_avg_dbm", "Receiver signal average optical power in mW", l, nil)
 
 	l = append(l, "lane")
 	c.laserBiasCurrentDesc = prometheus.NewDesc(prefix+"laser_bias", "Laser bias current in mA", l, nil)
+	c.laserBiasCurrentHighAlarmThresholdDesc = prometheus.NewDesc(prefix+"laser_bias_high_alarm_threshold", "Laser bias current high alarm threshold", l, nil)
+	c.laserBiasCurrentLowAlarmThresholdDesc = prometheus.NewDesc(prefix+"laser_bias_low_alarm_threshold", "Laser bias current low alarm threshold", l, nil)
+	c.laserBiasCurrentHighWarnThresholdDesc = prometheus.NewDesc(prefix+"laser_bias_high_warn_threshold", "Laser bias current high warn threshold", l, nil)
+	c.laserBiasCurrentLowWarnThresholdDesc = prometheus.NewDesc(prefix+"laser_bias_low_warn_threshold", "Laser bias current low warn threshold", l, nil)
 	c.laserOutputPowerDesc = prometheus.NewDesc(prefix+"laser_output", "Laser output power in mW", l, nil)
+	c.laserOutputPowerHighAlarmThresholdDesc = prometheus.NewDesc(prefix+"laser_output_high_alarm_threshold", "Laser output power high alarm threshold in mW", l, nil)
+	c.laserOutputPowerLowAlarmThresholdDesc = prometheus.NewDesc(prefix+"laser_output_low_alarm_threshold", "Laser output power low alarm threshold in mW", l, nil)
+	c.laserOutputPowerHighWarnThresholdDesc = prometheus.NewDesc(prefix+"laser_output_high_warn_threshold", "Laser output power high warn threshold in mW", l, nil)
+	c.laserOutputPowerLowWarnThresholdDesc = prometheus.NewDesc(prefix+"laser_output_low_warn_threshold", "Laser output power low warn threshold in mW", l, nil)
+
 	c.laserOutputPowerDbmDesc = prometheus.NewDesc(prefix+"laser_output_dbm", "Laser output power in dBm", l, nil)
+	c.laserOutputPowerHighAlarmThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_output_high_alarm_threshold_dbm", "Laser output power high alarm threshold in dBm", l, nil)
+	c.laserOutputPowerLowAlarmThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_output_low_alarm_threshold_dbm", "Laser output power low alarm threshold in dBm", l, nil)
+	c.laserOutputPowerHighWarnThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_output_high_warn_threshold_dbm", "Laser output power high warn threshold in dBm", l, nil)
+	c.laserOutputPowerLowWarnThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_output_low_warn_threshold_dbm", "Laser output power low warn threshold in dBm", l, nil)
+
 	c.laserRxOpticalPowerDesc = prometheus.NewDesc(prefix+"laser_rx", "Laser rx power in mW", l, nil)
+	c.laserRxOpticalPowerHighAlarmThresholdDesc = prometheus.NewDesc(prefix+"laser_rx_high_alarm_threshold", "Laser rx power high alarm threshold in mW", l, nil)
+	c.laserRxOpticalPowerLowAlarmThresholdDesc = prometheus.NewDesc(prefix+"laser_rx_low_alarm_threshold", "Laser rx power low alarm threshold in mW", l, nil)
+	c.laserRxOpticalPowerHighWarnThresholdDesc = prometheus.NewDesc(prefix+"laser_rx_high_warn_threshold", "Laser rx power high warn threshold in mW", l, nil)
+	c.laserRxOpticalPowerLowWarnThresholdDesc = prometheus.NewDesc(prefix+"laser_rx_low_warn_threshold", "Laser rx power low warn threshold in mW", l, nil)
+
 	c.laserRxOpticalPowerDbmDesc = prometheus.NewDesc(prefix+"laser_rx_dbm", "Laser rx power in dBm", l, nil)
+	c.laserRxOpticalPowerHighAlarmThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_rx_high_alarm_threshold_dbm", "Laser rx power high alarm threshold_dbm in dBm", l, nil)
+	c.laserRxOpticalPowerLowAlarmThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_rx_low_alarm_threshold_dbm", "Laser rx power low alarm threshold_dbm in dBm", l, nil)
+	c.laserRxOpticalPowerHighWarnThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_rx_high_warn_threshold_dbm", "Laser rx power high warn threshold_dbm in dBm", l, nil)
+	c.laserRxOpticalPowerLowWarnThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_rx_low_warn_threshold_dbm", "Laser rx power low warn threshold_dbm in dBm", l, nil)
 }
 
 // Describe describes the metrics
 func (c *interfaceDiagnosticsCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.laserBiasCurrentDesc
+	ch <- c.laserBiasCurrentHighAlarmThresholdDesc
+	ch <- c.laserBiasCurrentLowAlarmThresholdDesc
+	ch <- c.laserBiasCurrentHighWarnThresholdDesc
+	ch <- c.laserBiasCurrentLowWarnThresholdDesc
 	ch <- c.laserOutputPowerDesc
+	ch <- c.laserOutputPowerHighAlarmThresholdDesc
+	ch <- c.laserOutputPowerLowAlarmThresholdDesc
+	ch <- c.laserOutputPowerHighWarnThresholdDesc
+	ch <- c.laserOutputPowerLowWarnThresholdDesc
 	ch <- c.laserOutputPowerDbmDesc
+	ch <- c.laserOutputPowerHighAlarmThresholdDbmDesc
+	ch <- c.laserOutputPowerLowAlarmThresholdDbmDesc
+	ch <- c.laserOutputPowerHighWarnThresholdDbmDesc
+	ch <- c.laserOutputPowerLowWarnThresholdDbmDesc
 	ch <- c.moduleTemperatureDesc
+	ch <- c.moduleTemperatureHighAlarmThresholdDesc
+	ch <- c.moduleTemperatureLowAlarmThresholdDesc
+	ch <- c.moduleTemperatureHighWarnThresholdDesc
+	ch <- c.moduleTemperatureLowWarnThresholdDesc
+
 	ch <- c.laserRxOpticalPowerDesc
+	ch <- c.laserRxOpticalPowerHighAlarmThresholdDesc
+	ch <- c.laserRxOpticalPowerLowAlarmThresholdDesc
+	ch <- c.laserRxOpticalPowerHighWarnThresholdDesc
+	ch <- c.laserRxOpticalPowerLowWarnThresholdDesc
 	ch <- c.laserRxOpticalPowerDbmDesc
+	ch <- c.laserRxOpticalPowerHighAlarmThresholdDbmDesc
+	ch <- c.laserRxOpticalPowerLowAlarmThresholdDbmDesc
+	ch <- c.laserRxOpticalPowerHighWarnThresholdDbmDesc
+	ch <- c.laserRxOpticalPowerLowWarnThresholdDbmDesc
+
 	ch <- c.moduleVoltageDesc
+	ch <- c.moduleVoltageHighAlarmThresholdDesc
+	ch <- c.moduleVoltageLowAlarmThresholdDesc
+	ch <- c.moduleVoltageHighWarnThresholdDesc
+	ch <- c.moduleVoltageLowWarnThresholdDesc
+
 	ch <- c.rxSignalAvgOpticalPowerDesc
 	ch <- c.rxSignalAvgOpticalPowerDbmDesc
 }
@@ -96,9 +195,19 @@ func (c *interfaceDiagnosticsCollector) Collect(client *rpc.Client, ch chan<- pr
 		l = append(l, c.labels.ValuesForInterface(client.Device(), d.Name)...)
 
 		ch <- prometheus.MustNewConstMetric(c.moduleTemperatureDesc, prometheus.GaugeValue, d.ModuleTemperature, l...)
+		ch <- prometheus.MustNewConstMetric(c.moduleTemperatureHighAlarmThresholdDesc, prometheus.GaugeValue, d.ModuleTemperatureHighAlarmThreshold, l...)
+		ch <- prometheus.MustNewConstMetric(c.moduleTemperatureLowAlarmThresholdDesc, prometheus.GaugeValue, d.ModuleTemperatureLowAlarmThreshold, l...)
+		ch <- prometheus.MustNewConstMetric(c.moduleTemperatureHighWarnThresholdDesc, prometheus.GaugeValue, d.ModuleTemperatureHighWarnThreshold, l...)
+		ch <- prometheus.MustNewConstMetric(c.moduleTemperatureLowWarnThresholdDesc, prometheus.GaugeValue, d.ModuleTemperatureLowWarnThreshold, l...)
+
 		if d.ModuleVoltage > 0 {
 			ch <- prometheus.MustNewConstMetric(c.moduleVoltageDesc, prometheus.GaugeValue, d.ModuleVoltage, l...)
+			ch <- prometheus.MustNewConstMetric(c.moduleVoltageHighAlarmThresholdDesc, prometheus.GaugeValue, d.ModuleVoltageHighAlarmThreshold, l...)
+			ch <- prometheus.MustNewConstMetric(c.moduleVoltageLowAlarmThresholdDesc, prometheus.GaugeValue, d.ModuleVoltageLowAlarmThreshold, l...)
+			ch <- prometheus.MustNewConstMetric(c.moduleVoltageHighWarnThresholdDesc, prometheus.GaugeValue, d.ModuleVoltageHighWarnThreshold, l...)
+			ch <- prometheus.MustNewConstMetric(c.moduleVoltageLowWarnThresholdDesc, prometheus.GaugeValue, d.ModuleVoltageLowWarnThreshold, l...)
 		}
+
 		if d.RxSignalAvgOpticalPower > 0 {
 			ch <- prometheus.MustNewConstMetric(c.rxSignalAvgOpticalPowerDesc, prometheus.GaugeValue, d.RxSignalAvgOpticalPower, l...)
 			ch <- prometheus.MustNewConstMetric(c.rxSignalAvgOpticalPowerDbmDesc, prometheus.GaugeValue, d.RxSignalAvgOpticalPowerDbm, l...)
@@ -114,10 +223,30 @@ func (c *interfaceDiagnosticsCollector) Collect(client *rpc.Client, ch chan<- pr
 		for _, e := range data {
 			l2 := append(l, e.Index)
 			ch <- prometheus.MustNewConstMetric(c.laserBiasCurrentDesc, prometheus.GaugeValue, e.LaserBiasCurrent, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserBiasCurrentHighAlarmThresholdDesc, prometheus.GaugeValue, d.LaserBiasCurrentHighAlarmThreshold, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserBiasCurrentLowAlarmThresholdDesc, prometheus.GaugeValue, d.LaserBiasCurrentLowAlarmThreshold, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserBiasCurrentHighWarnThresholdDesc, prometheus.GaugeValue, d.LaserBiasCurrentHighWarnThreshold, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserBiasCurrentLowWarnThresholdDesc, prometheus.GaugeValue, d.LaserBiasCurrentLowWarnThreshold, l2...)
 			ch <- prometheus.MustNewConstMetric(c.laserOutputPowerDesc, prometheus.GaugeValue, e.LaserOutputPower, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserOutputPowerHighAlarmThresholdDesc, prometheus.GaugeValue, d.LaserOutputPowerHighAlarmThreshold, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserOutputPowerLowAlarmThresholdDesc, prometheus.GaugeValue, d.LaserOutputPowerLowAlarmThreshold, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserOutputPowerHighWarnThresholdDesc, prometheus.GaugeValue, d.LaserOutputPowerHighWarnThreshold, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserOutputPowerLowWarnThresholdDesc, prometheus.GaugeValue, d.LaserOutputPowerLowWarnThreshold, l2...)
 			ch <- prometheus.MustNewConstMetric(c.laserOutputPowerDbmDesc, prometheus.GaugeValue, e.LaserOutputPowerDbm, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserOutputPowerHighAlarmThresholdDbmDesc, prometheus.GaugeValue, d.LaserOutputPowerHighAlarmThresholdDbm, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserOutputPowerLowAlarmThresholdDbmDesc, prometheus.GaugeValue, d.LaserOutputPowerLowAlarmThresholdDbm, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserOutputPowerHighWarnThresholdDbmDesc, prometheus.GaugeValue, d.LaserOutputPowerHighWarnThresholdDbm, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserOutputPowerLowWarnThresholdDbmDesc, prometheus.GaugeValue, d.LaserOutputPowerLowWarnThresholdDbm, l2...)
 			ch <- prometheus.MustNewConstMetric(c.laserRxOpticalPowerDesc, prometheus.GaugeValue, e.LaserRxOpticalPower, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserRxOpticalPowerHighAlarmThresholdDesc, prometheus.GaugeValue, d.LaserRxOpticalPowerHighAlarmThreshold, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserRxOpticalPowerLowAlarmThresholdDesc, prometheus.GaugeValue, d.LaserRxOpticalPowerLowAlarmThreshold, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserRxOpticalPowerHighWarnThresholdDesc, prometheus.GaugeValue, d.LaserRxOpticalPowerHighWarnThreshold, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserRxOpticalPowerLowWarnThresholdDesc, prometheus.GaugeValue, d.LaserRxOpticalPowerLowWarnThreshold, l2...)
 			ch <- prometheus.MustNewConstMetric(c.laserRxOpticalPowerDbmDesc, prometheus.GaugeValue, e.LaserRxOpticalPowerDbm, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserRxOpticalPowerHighAlarmThresholdDbmDesc, prometheus.GaugeValue, d.LaserRxOpticalPowerHighAlarmThresholdDbm, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserRxOpticalPowerLowAlarmThresholdDbmDesc, prometheus.GaugeValue, d.LaserRxOpticalPowerLowAlarmThresholdDbm, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserRxOpticalPowerHighWarnThresholdDbmDesc, prometheus.GaugeValue, d.LaserRxOpticalPowerHighWarnThresholdDbm, l2...)
+			ch <- prometheus.MustNewConstMetric(c.laserRxOpticalPowerLowWarnThresholdDbmDesc, prometheus.GaugeValue, d.LaserRxOpticalPowerLowWarnThresholdDbm, l2...)
 		}
 	}
 
@@ -200,18 +329,53 @@ func interfaceDiagnosticsFromRPCResult(result InterfaceDiagnosticsRPC) []*Interf
 		}
 
 		d := &InterfaceDiagnostics{
-			Index:                      "",
-			Name:                       diag.Name,
-			LaserBiasCurrent:           float64(diag.Diagnostics.LaserBiasCurrent),
-			LaserOutputPower:           float64(diag.Diagnostics.LaserOutputPower),
-			ModuleTemperature:          float64(diag.Diagnostics.ModuleTemperature.Value),
-			LaserOutputPowerDbm:        dbmStringToFloat(diag.Diagnostics.LaserOutputPowerDbm),
-			ModuleVoltage:              float64(diag.Diagnostics.ModuleVoltage),
-			RxSignalAvgOpticalPower:    float64(diag.Diagnostics.RxSignalAvgOpticalPower),
-			RxSignalAvgOpticalPowerDbm: dbmStringToFloat(diag.Diagnostics.RxSignalAvgOpticalPowerDbm),
-			LaserRxOpticalPower:        float64(diag.Diagnostics.LaserRxOpticalPower),
-			LaserRxOpticalPowerDbm:     dbmStringToFloat(diag.Diagnostics.LaserRxOpticalPowerDbm),
+			Index:                              "",
+			Name:                               diag.Name,
+			LaserBiasCurrent:                   float64(diag.Diagnostics.LaserBiasCurrent),
+			LaserBiasCurrentHighAlarmThreshold: float64(diag.Diagnostics.LaserBiasCurrentHighAlarmThreshold),
+			LaserBiasCurrentLowAlarmThreshold:  float64(diag.Diagnostics.LaserBiasCurrentLowAlarmThreshold),
+			LaserBiasCurrentHighWarnThreshold:  float64(diag.Diagnostics.LaserBiasCurrentHighWarnThreshold),
+			LaserBiasCurrentLowWarnThreshold:   float64(diag.Diagnostics.LaserBiasCurrentLowWarnThreshold),
+
+			LaserOutputPower:                   float64(diag.Diagnostics.LaserOutputPower),
+			LaserOutputPowerHighAlarmThreshold: float64(diag.Diagnostics.LaserTxOpticalPowerHighAlarmThreshold),
+			LaserOutputPowerLowAlarmThreshold:  float64(diag.Diagnostics.LaserTxOpticalPowerLowAlarmThreshold),
+			LaserOutputPowerHighWarnThreshold:  float64(diag.Diagnostics.LaserTxOpticalPowerHighWarnThreshold),
+			LaserOutputPowerLowWarnThreshold:   float64(diag.Diagnostics.LaserTxOpticalPowerLowWarnThreshold),
+
+			ModuleTemperature:                   float64(diag.Diagnostics.ModuleTemperature.Value),
+			ModuleTemperatureHighAlarmThreshold: float64(diag.Diagnostics.ModuleTemperatureHighAlarmThreshold.Value),
+			ModuleTemperatureLowAlarmThreshold:  float64(diag.Diagnostics.ModuleTemperatureLowAlarmThreshold.Value),
+			ModuleTemperatureHighWarnThreshold:  float64(diag.Diagnostics.ModuleTemperatureHighWarnThreshold.Value),
+			ModuleTemperatureLowWarnThreshold:   float64(diag.Diagnostics.ModuleTemperatureLowWarnThreshold.Value),
+
+			LaserOutputPowerDbm:                   dbmStringToFloat(diag.Diagnostics.LaserOutputPowerDbm),
+			LaserOutputPowerHighAlarmThresholdDbm: dbmStringToFloat(diag.Diagnostics.LaserTxOpticalPowerHighAlarmThresholdDbm),
+			LaserOutputPowerLowAlarmThresholdDbm:  dbmStringToFloat(diag.Diagnostics.LaserTxOpticalPowerLowAlarmThresholdDbm),
+			LaserOutputPowerHighWarnThresholdDbm:  dbmStringToFloat(diag.Diagnostics.LaserTxOpticalPowerHighWarnThresholdDbm),
+			LaserOutputPowerLowWarnThresholdDbm:   dbmStringToFloat(diag.Diagnostics.LaserTxOpticalPowerLowWarnThresholdDbm),
+
+			ModuleVoltage:                   float64(diag.Diagnostics.ModuleVoltage),
+			ModuleVoltageHighAlarmThreshold: float64(diag.Diagnostics.ModuleVoltageHighAlarmThreshold),
+			ModuleVoltageLowAlarmThreshold:  float64(diag.Diagnostics.ModuleVoltageLowAlarmThreshold),
+			ModuleVoltageHighWarnThreshold:  float64(diag.Diagnostics.ModuleVoltageHighWarnThreshold),
+			ModuleVoltageLowWarnThreshold:   float64(diag.Diagnostics.ModuleVoltageLowWarnThreshold),
+
+			RxSignalAvgOpticalPower:               float64(diag.Diagnostics.RxSignalAvgOpticalPower),
+			RxSignalAvgOpticalPowerDbm:            dbmStringToFloat(diag.Diagnostics.RxSignalAvgOpticalPowerDbm),
+			LaserRxOpticalPower:                   float64(diag.Diagnostics.LaserRxOpticalPower),
+			LaserRxOpticalPowerHighAlarmThreshold: float64(diag.Diagnostics.LaserRxOpticalPowerHighAlarmThreshold),
+			LaserRxOpticalPowerLowAlarmThreshold:  float64(diag.Diagnostics.LaserRxOpticalPowerLowAlarmThreshold),
+			LaserRxOpticalPowerHighWarnThreshold:  float64(diag.Diagnostics.LaserRxOpticalPowerHighWarnThreshold),
+			LaserRxOpticalPowerLowWarnThreshold:   float64(diag.Diagnostics.LaserRxOpticalPowerLowWarnThreshold),
+
+			LaserRxOpticalPowerDbm:                   dbmStringToFloat(diag.Diagnostics.LaserRxOpticalPowerDbm),
+			LaserRxOpticalPowerHighAlarmThresholdDbm: dbmStringToFloat(diag.Diagnostics.LaserRxOpticalPowerHighAlarmThresholdDbm),
+			LaserRxOpticalPowerLowAlarmThresholdDbm:  dbmStringToFloat(diag.Diagnostics.LaserRxOpticalPowerLowAlarmThresholdDbm),
+			LaserRxOpticalPowerHighWarnThresholdDbm:  dbmStringToFloat(diag.Diagnostics.LaserRxOpticalPowerHighWarnThresholdDbm),
+			LaserRxOpticalPowerLowWarnThresholdDbm:   dbmStringToFloat(diag.Diagnostics.LaserRxOpticalPowerLowWarnThresholdDbm),
 		}
+		log.Printf("Low alarm threshold: %v", d.LaserOutputPowerLowAlarmThresholdDbm)
 
 		if len(diag.Diagnostics.Lanes) > 0 {
 			for _, lane := range diag.Diagnostics.Lanes {

--- a/interfacediagnostics/collector_test.go
+++ b/interfacediagnostics/collector_test.go
@@ -14,17 +14,53 @@ func TestInterfaceDiagnosticsFromRPCResult(t *testing.T) {
 		{
 			Name: "xe-0/0/0",
 			Diagnostics: PhyInterfaceDiagnostic{
-				LaserBiasCurrent:    1,
-				LaserOutputPower:    2,
-				LaserOutputPowerDbm: "3",
+				LaserBiasCurrent:                         1,
+				LaserBiasCurrentHighAlarmThreshold:       110,
+				LaserBiasCurrentLowAlarmThreshold:        10,
+				LaserBiasCurrentHighWarnThreshold:        19,
+				LaserBiasCurrentLowWarnThreshold:         11,
+				LaserOutputPower:                         2,
+				LaserTxOpticalPowerHighAlarmThreshold:    210,
+				LaserTxOpticalPowerLowAlarmThreshold:     20,
+				LaserTxOpticalPowerHighWarnThreshold:     29,
+				LaserTxOpticalPowerLowWarnThreshold:      21,
+				LaserOutputPowerDbm:                      "3",
+				LaserTxOpticalPowerHighAlarmThresholdDbm: "310",
+				LaserTxOpticalPowerLowAlarmThresholdDbm:  "30",
+				LaserTxOpticalPowerHighWarnThresholdDbm:  "39",
+				LaserTxOpticalPowerLowWarnThresholdDbm:   "31",
 				ModuleTemperature: Temperature{
 					Value: 4,
 				},
-				ModuleVoltage:              5,
-				RxSignalAvgOpticalPower:    6,
-				RxSignalAvgOpticalPowerDbm: "- Inf",
-				LaserRxOpticalPower:        7,
-				LaserRxOpticalPowerDbm:     "- Inf",
+				ModuleTemperatureHighAlarmThreshold: Temperature{
+					Value: 410,
+				},
+				ModuleTemperatureLowAlarmThreshold: Temperature{
+					Value: 40,
+				},
+				ModuleTemperatureHighWarnThreshold: Temperature{
+					Value: 49,
+				},
+				ModuleTemperatureLowWarnThreshold: Temperature{
+					Value: 41,
+				},
+				ModuleVoltage:                            5,
+				ModuleVoltageHighAlarmThreshold:          510,
+				ModuleVoltageLowAlarmThreshold:           50,
+				ModuleVoltageHighWarnThreshold:           59,
+				ModuleVoltageLowWarnThreshold:            51,
+				RxSignalAvgOpticalPower:                  6,
+				RxSignalAvgOpticalPowerDbm:               "- Inf",
+				LaserRxOpticalPower:                      7,
+				LaserRxOpticalPowerHighAlarmThreshold:    710,
+				LaserRxOpticalPowerLowAlarmThreshold:     70,
+				LaserRxOpticalPowerHighWarnThreshold:     79,
+				LaserRxOpticalPowerLowWarnThreshold:      71,
+				LaserRxOpticalPowerDbm:                   "- Inf",
+				LaserRxOpticalPowerHighAlarmThresholdDbm: "810",
+				LaserRxOpticalPowerLowAlarmThresholdDbm:  "80",
+				LaserRxOpticalPowerHighWarnThresholdDbm:  "89",
+				LaserRxOpticalPowerLowWarnThresholdDbm:   "81",
 				Lanes: []LaneValue{
 					{
 						LaneIndex:              "1",
@@ -46,14 +82,43 @@ func TestInterfaceDiagnosticsFromRPCResult(t *testing.T) {
 	iface := ifaces[0]
 
 	assert.Equal(t, float64(1), iface.LaserBiasCurrent)
+	assert.Equal(t, float64(110), iface.LaserBiasCurrentHighAlarmThreshold)
+	assert.Equal(t, float64(10), iface.LaserBiasCurrentLowAlarmThreshold)
+	assert.Equal(t, float64(19), iface.LaserBiasCurrentHighWarnThreshold)
+	assert.Equal(t, float64(11), iface.LaserBiasCurrentLowWarnThreshold)
 	assert.Equal(t, float64(2), iface.LaserOutputPower)
+	assert.Equal(t, float64(210), iface.LaserOutputPowerHighAlarmThreshold)
+	assert.Equal(t, float64(20), iface.LaserOutputPowerLowAlarmThreshold)
+	assert.Equal(t, float64(29), iface.LaserOutputPowerHighWarnThreshold)
+	assert.Equal(t, float64(21), iface.LaserOutputPowerLowWarnThreshold)
 	assert.Equal(t, float64(3), iface.LaserOutputPowerDbm)
+	assert.Equal(t, float64(310), iface.LaserOutputPowerHighAlarmThresholdDbm)
+	assert.Equal(t, float64(30), iface.LaserOutputPowerLowAlarmThresholdDbm)
+	assert.Equal(t, float64(39), iface.LaserOutputPowerHighWarnThresholdDbm)
+	assert.Equal(t, float64(31), iface.LaserOutputPowerLowWarnThresholdDbm)
 	assert.Equal(t, float64(4), iface.ModuleTemperature)
+	assert.Equal(t, float64(410), iface.ModuleTemperatureHighAlarmThreshold)
+	assert.Equal(t, float64(40), iface.ModuleTemperatureLowAlarmThreshold)
+	assert.Equal(t, float64(49), iface.ModuleTemperatureHighWarnThreshold)
+	assert.Equal(t, float64(41), iface.ModuleTemperatureLowWarnThreshold)
 	assert.Equal(t, float64(5), iface.ModuleVoltage)
+	assert.Equal(t, float64(510), iface.ModuleVoltageHighAlarmThreshold)
+	assert.Equal(t, float64(50), iface.ModuleVoltageLowAlarmThreshold)
+	assert.Equal(t, float64(59), iface.ModuleVoltageHighWarnThreshold)
+	assert.Equal(t, float64(51), iface.ModuleVoltageLowWarnThreshold)
 	assert.Equal(t, float64(6), iface.RxSignalAvgOpticalPower)
 	assert.Equal(t, math.Inf(-1), iface.RxSignalAvgOpticalPowerDbm)
 	assert.Equal(t, float64(7), iface.LaserRxOpticalPower)
+	assert.Equal(t, float64(710), iface.LaserRxOpticalPowerHighAlarmThreshold)
+	assert.Equal(t, float64(70), iface.LaserRxOpticalPowerLowAlarmThreshold)
+	assert.Equal(t, float64(79), iface.LaserRxOpticalPowerHighWarnThreshold)
+	assert.Equal(t, float64(71), iface.LaserRxOpticalPowerLowWarnThreshold)
+
 	assert.Equal(t, math.Inf(-1), iface.LaserRxOpticalPowerDbm)
+	assert.Equal(t, float64(810), iface.LaserRxOpticalPowerHighAlarmThresholdDbm)
+	assert.Equal(t, float64(80), iface.LaserRxOpticalPowerLowAlarmThresholdDbm)
+	assert.Equal(t, float64(89), iface.LaserRxOpticalPowerHighWarnThresholdDbm)
+	assert.Equal(t, float64(81), iface.LaserRxOpticalPowerLowWarnThresholdDbm)
 
 	assert.Equal(t, 1, len(iface.Lanes), "lane count")
 

--- a/interfacediagnostics/interface_diagnostics.go
+++ b/interfacediagnostics/interface_diagnostics.go
@@ -1,19 +1,51 @@
 package interfacediagnostics
 
 type InterfaceDiagnostics struct {
-	Index               string
-	Name                string
-	LaserBiasCurrent    float64
-	LaserOutputPower    float64
-	LaserOutputPowerDbm float64
-	ModuleTemperature   float64
+	Index                              string
+	Name                               string
+	LaserBiasCurrent                   float64
+	LaserBiasCurrentHighAlarmThreshold float64
+	LaserBiasCurrentLowAlarmThreshold  float64
+	LaserBiasCurrentHighWarnThreshold  float64
+	LaserBiasCurrentLowWarnThreshold   float64
 
-	LaserRxOpticalPower    float64
-	LaserRxOpticalPowerDbm float64
+	LaserOutputPower                   float64
+	LaserOutputPowerHighAlarmThreshold float64
+	LaserOutputPowerLowAlarmThreshold  float64
+	LaserOutputPowerHighWarnThreshold  float64
+	LaserOutputPowerLowWarnThreshold   float64
 
-	ModuleVoltage              float64
-	RxSignalAvgOpticalPower    float64
-	RxSignalAvgOpticalPowerDbm float64
+	LaserOutputPowerDbm                   float64
+	LaserOutputPowerHighAlarmThresholdDbm float64
+	LaserOutputPowerLowAlarmThresholdDbm  float64
+	LaserOutputPowerHighWarnThresholdDbm  float64
+	LaserOutputPowerLowWarnThresholdDbm   float64
+
+	ModuleTemperature                   float64
+	ModuleTemperatureHighAlarmThreshold float64
+	ModuleTemperatureLowAlarmThreshold  float64
+	ModuleTemperatureHighWarnThreshold  float64
+	ModuleTemperatureLowWarnThreshold   float64
+
+	LaserRxOpticalPower                   float64
+	LaserRxOpticalPowerHighAlarmThreshold float64
+	LaserRxOpticalPowerLowAlarmThreshold  float64
+	LaserRxOpticalPowerHighWarnThreshold  float64
+	LaserRxOpticalPowerLowWarnThreshold   float64
+
+	LaserRxOpticalPowerDbm                   float64
+	LaserRxOpticalPowerHighAlarmThresholdDbm float64
+	LaserRxOpticalPowerLowAlarmThresholdDbm  float64
+	LaserRxOpticalPowerHighWarnThresholdDbm  float64
+	LaserRxOpticalPowerLowWarnThresholdDbm   float64
+
+	ModuleVoltage                   float64
+	ModuleVoltageHighAlarmThreshold float64
+	ModuleVoltageLowAlarmThreshold  float64
+	ModuleVoltageHighWarnThreshold  float64
+	ModuleVoltageLowWarnThreshold   float64
+	RxSignalAvgOpticalPower         float64
+	RxSignalAvgOpticalPowerDbm      float64
 
 	Lanes []*InterfaceDiagnostics
 }

--- a/interfacediagnostics/rpc.go
+++ b/interfacediagnostics/rpc.go
@@ -12,17 +12,50 @@ type PhyDiagInterface struct {
 }
 
 type PhyInterfaceDiagnostic struct {
-	LaserBiasCurrent    float64     `xml:"laser-bias-current,omitempty"`
-	LaserOutputPower    float64     `xml:"laser-output-power,omitempty"`
-	LaserOutputPowerDbm string      `xml:"laser-output-power-dbm,omitempty"`
-	ModuleTemperature   Temperature `xml:"module-temperature"`
+	LaserBiasCurrent                   float64 `xml:"laser-bias-current,omitempty"`
+	LaserBiasCurrentHighAlarmThreshold float64 `xml:"laser-bias-current-high-alarm-threshold,omitempty"`
+	LaserBiasCurrentLowAlarmThreshold  float64 `xml:"laser-bias-current-low-alarm-threshold,omitempty"`
+	LaserBiasCurrentHighWarnThreshold  float64 `xml:"laser-bias-current-high-warn-threshold,omitempty"`
+	LaserBiasCurrentLowWarnThreshold   float64 `xml:"laser-bias-current-low-warn-threshold,omitempty"`
 
-	ModuleVoltage              float64 `xml:"module-voltage,omitempty"`
+	LaserOutputPower                    float64     `xml:"laser-output-power,omitempty"`
+	LaserOutputPowerDbm                 string      `xml:"laser-output-power-dbm,omitempty"`
+	ModuleTemperature                   Temperature `xml:"module-temperature"`
+	ModuleTemperatureHighAlarmThreshold Temperature `xml:"module-temperature-high-alarm-threshold,omitempty"`
+	ModuleTemperatureLowAlarmThreshold  Temperature `xml:"module-temperature-low-alarm-threshold,omitempty"`
+	ModuleTemperatureHighWarnThreshold  Temperature `xml:"module-temperature-high-warn-threshold,omitempty"`
+	ModuleTemperatureLowWarnThreshold   Temperature `xml:"module-temperature-low-warn-threshold,omitempty"`
+
+	ModuleVoltage                   float64 `xml:"module-voltage,omitempty"`
+	ModuleVoltageHighAlarmThreshold float64 `xml:"module-voltage-high-alarm-threshold,omitempty"`
+	ModuleVoltageLowAlarmThreshold  float64 `xml:"module-voltage-low-alarm-threshold,omitempty"`
+	ModuleVoltageHighWarnThreshold  float64 `xml:"module-voltage-high-warn-threshold,omitempty"`
+	ModuleVoltageLowWarnThreshold   float64 `xml:"module-voltage-low-warn-threshold,omitempty"`
+
 	RxSignalAvgOpticalPower    float64 `xml:"rx-signal-avg-optical-power,omitempty"`
 	RxSignalAvgOpticalPowerDbm string  `xml:"rx-signal-avg-optical-power-dbm,omitempty"`
 
-	LaserRxOpticalPower    float64 `xml:"laser-rx-optical-power,omitempty"`
-	LaserRxOpticalPowerDbm string  `xml:"laser-rx-optical-power-dbm,omitempty"`
+	LaserRxOpticalPower                   float64 `xml:"laser-rx-optical-power,omitempty"`
+	LaserRxOpticalPowerHighAlarmThreshold float64 `xml:"laser-rx-power-high-alarm-threshold,omitempty"`
+	LaserRxOpticalPowerLowAlarmThreshold  float64 `xml:"laser-rx-power-low-alarm-threshold,omitempty"`
+	LaserRxOpticalPowerHighWarnThreshold  float64 `xml:"laser-rx-power-high-warn-threshold,omitempty"`
+	LaserRxOpticalPowerLowWarnThreshold   float64 `xml:"laser-rx-power-low-warn-threshold,omitempty"`
+
+	LaserRxOpticalPowerDbm                   string `xml:"laser-rx-optical-power-dbm,omitempty"`
+	LaserRxOpticalPowerHighAlarmThresholdDbm string `xml:"laser-rx-power-high-alarm-threshold-dbm,omitempty"`
+	LaserRxOpticalPowerLowAlarmThresholdDbm  string `xml:"laser-rx-power-low-alarm-threshold-dbm,omitempty"`
+	LaserRxOpticalPowerHighWarnThresholdDbm  string `xml:"laser-rx-power-high-warn-threshold-dbm,omitempty"`
+	LaserRxOpticalPowerLowWarnThresholdDbm   string `xml:"laser-rx-power-low-warn-threshold-dbm,omitempty"`
+
+	LaserTxOpticalPowerHighAlarmThreshold float64 `xml:"laser-tx-power-high-alarm-threshold,omitempty"`
+	LaserTxOpticalPowerLowAlarmThreshold  float64 `xml:"laser-tx-power-low-alarm-threshold,omitempty"`
+	LaserTxOpticalPowerHighWarnThreshold  float64 `xml:"laser-tx-power-high-warn-threshold,omitempty"`
+	LaserTxOpticalPowerLowWarnThreshold   float64 `xml:"laser-tx-power-low-warn-threshold,omitempty"`
+
+	LaserTxOpticalPowerHighAlarmThresholdDbm string `xml:"laser-tx-power-high-alarm-threshold-dbm,omitempty"`
+	LaserTxOpticalPowerLowAlarmThresholdDbm  string `xml:"laser-tx-power-low-alarm-threshold-dbm,omitempty"`
+	LaserTxOpticalPowerHighWarnThresholdDbm  string `xml:"laser-tx-power-high-warn-threshold-dbm,omitempty"`
+	LaserTxOpticalPowerLowWarnThresholdDbm   string `xml:"laser-tx-power-low-warn-threshold-dbm,omitempty"`
 
 	NA string `xml:"optic-diagnostics-not-available"`
 


### PR DESCRIPTION
Hello,

this implements scraping of alarm and warning thresholds for the outputs of a `show interfaces diagnostics optics`.
These values are required for writing alerting rules in Prometheus and might be useful to detect a failing transceiver before hand.

I stuck with your naming conventions and extended the tests.

Please review,
Fluepke