### PR TITLE
Add support for multiple bgp rib

### DIFF
--- a/bgp/collector.go
+++ b/bgp/collector.go
@@ -112,10 +112,12 @@ func (c *bgpCollector) collectForPeer(p BGPPeer, ch chan<- prometheus.Metric, la
 }
 
 func (*bgpCollector) collectRIBForPeer(p BGPPeer, ch chan<- prometheus.Metric, labelValues []string) {
-	l := append(labelValues, p.RIB.Name)
-	ch <- prometheus.MustNewConstMetric(receivedPrefixesDesc, prometheus.GaugeValue, float64(p.RIB.ReceivedPrefixes), l...)
-	ch <- prometheus.MustNewConstMetric(acceptedPrefixesDesc, prometheus.GaugeValue, float64(p.RIB.AcceptedPrefixes), l...)
-	ch <- prometheus.MustNewConstMetric(rejectedPrefixesDesc, prometheus.GaugeValue, float64(p.RIB.RejectedPrefixes), l...)
-	ch <- prometheus.MustNewConstMetric(activePrefixesDesc, prometheus.GaugeValue, float64(p.RIB.ActivePrefixes), l...)
-	ch <- prometheus.MustNewConstMetric(advertisedPrefixesDesc, prometheus.GaugeValue, float64(p.RIB.AdvertisedPrefixes), l...)
+	for _, rib := range p.RIBs {
+		l := append(labelValues, rib.Name)
+		ch <- prometheus.MustNewConstMetric(receivedPrefixesDesc, prometheus.GaugeValue, float64(rib.ReceivedPrefixes), l...)
+		ch <- prometheus.MustNewConstMetric(acceptedPrefixesDesc, prometheus.GaugeValue, float64(rib.AcceptedPrefixes), l...)
+		ch <- prometheus.MustNewConstMetric(rejectedPrefixesDesc, prometheus.GaugeValue, float64(rib.RejectedPrefixes), l...)
+		ch <- prometheus.MustNewConstMetric(activePrefixesDesc, prometheus.GaugeValue, float64(rib.ActivePrefixes), l...)
+		ch <- prometheus.MustNewConstMetric(advertisedPrefixesDesc, prometheus.GaugeValue, float64(rib.AdvertisedPrefixes), l...)
+	}
 }

--- a/bgp/rpc.go
+++ b/bgp/rpc.go
@@ -15,12 +15,14 @@ type BGPPeer struct {
 	Flaps          int64  `xml:"flap-count"`
 	InputMessages  int64  `xml:"input-messages"`
 	OutputMessages int64  `xml:"output-messages"`
-	RIB            struct {
-		Name               string `xml:"name"`
-		ActivePrefixes     int64  `xml:"active-prefix-count"`
-		ReceivedPrefixes   int64  `xml:"received-prefix-count"`
-		AcceptedPrefixes   int64  `xml:"accepted-prefix-count"`
-		RejectedPrefixes   int64  `xml:"suppressed-prefix-count"`
-		AdvertisedPrefixes int64  `xml:"advertised-prefix-count"`
-	} `xml:"bgp-rib"`
+	RIBs           []RIB  `xml:"bgp-rib"`
+}
+
+type RIB struct {
+	Name               string `xml:"name"`
+	ActivePrefixes     int64  `xml:"active-prefix-count"`
+	ReceivedPrefixes   int64  `xml:"received-prefix-count"`
+	AcceptedPrefixes   int64  `xml:"accepted-prefix-count"`
+	RejectedPrefixes   int64  `xml:"suppressed-prefix-count"`
+	AdvertisedPrefixes int64  `xml:"advertised-prefix-count"`
 }


### PR DESCRIPTION
For example, the show bgp neighbor (Layer 2 VPN) example in the sample-output section of [this site](https://www.juniper.net/documentation/us/en/software/junos/bgp/topics/ref/command/show-bgp-neighbor.html#show-bgp-neighbor-command__d40413e1530).

When there are multiple bgp ribs (table=bgp.l3vpn.0, bgp.l2vpn.0, etc.), the current implementation can only get one bgp rib.
So, this PR add support for collecting metrics of multiple bgp ribs.