### PR TITLE
fixed routing engine panic when satellite is scraped

### DIFF
--- a/environment/collector.go
+++ b/environment/collector.go
@@ -94,7 +94,7 @@ func (c *environmentCollector) environmentItems(client *rpc.Client, ch chan<- pr
 				return nil
 			}
 
-			return parseXML(b, &x)
+			return parseXML(b, &y)
 		})
 		if err != nil {
 			return nil


### PR DESCRIPTION
This PR fixes a panic that occurs when a satellite device is scraped. 