### PR TITLE
fixed panic with non satellite device and routing engines

### DIFF
--- a/environment/collector.go
+++ b/environment/collector.go
@@ -99,8 +99,10 @@ func (c *environmentCollector) environmentItems(client *rpc.Client, ch chan<- pr
 		if err != nil {
 			return nil
 		} else {
-			// add satellite details
-			x.MultiRoutingEngineResults.RoutingEngine[0].EnvironmentInformation.Items = append(x.MultiRoutingEngineResults.RoutingEngine[0].EnvironmentInformation.Items, y.MultiRoutingEngineResults.RoutingEngine[0].EnvironmentInformation.Items...)
+			// add satellite details (only if y.MultiRoutingEngineResults.RoutingEngine has elements)
+			if len(y.MultiRoutingEngineResults.RoutingEngine) > 0 {
+				x.MultiRoutingEngineResults.RoutingEngine[0].EnvironmentInformation.Items = append(x.MultiRoutingEngineResults.RoutingEngine[0].EnvironmentInformation.Items, y.MultiRoutingEngineResults.RoutingEngine[0].EnvironmentInformation.Items...)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a panic when satellite scraping is enabled, but the target device is not using satellites. This issue should only affect users that scrape with the satellite option in the exporter enabled and no satellite device attached.