### PR TITLE
Add statistics for interfaces with schedulers configured

### DIFF
--- a/interfacequeue/collector.go
+++ b/interfacequeue/collector.go
@@ -28,6 +28,17 @@ type interfaceQueueCollector struct {
 	transferedBytes      *prometheus.Desc
 	rateLimitDropPackets *prometheus.Desc
 	rateLimitDropBytes   *prometheus.Desc
+	redPackets           *prometheus.Desc
+	redBytes             *prometheus.Desc
+	redPacketsLow        *prometheus.Desc
+	redBytesLow          *prometheus.Desc
+	redPacketsMediumLow  *prometheus.Desc
+	redBytesMediumLow    *prometheus.Desc
+	redPacketsMediumHigh *prometheus.Desc
+	redBytesMediumHigh   *prometheus.Desc
+	redPacketsHigh       *prometheus.Desc
+	redBytesHigh         *prometheus.Desc
+	tailDropPackets      *prometheus.Desc
 	totalDropPackets     *prometheus.Desc
 	totalDropBytes       *prometheus.Desc
 }
@@ -48,6 +59,17 @@ func (c *interfaceQueueCollector) init() {
 	c.transferedBytes = prometheus.NewDesc(prefix+"transfered_bytes_count", "Number of bytes of transfered packets", l, nil)
 	c.rateLimitDropPackets = prometheus.NewDesc(prefix+"rate_limit_drop_packets_count", "Number of packets droped by rate limit", l, nil)
 	c.rateLimitDropBytes = prometheus.NewDesc(prefix+"rate_limit_drop_bytes_count", "Number of bytes droped by rate limit", l, nil)
+	c.redPackets = prometheus.NewDesc(prefix+"red_packets_count", "Number of queued packets", l, nil)
+	c.redBytes = prometheus.NewDesc(prefix+"red_bytes_count", "Number of bytes of queued packets", l, nil)
+	c.redPacketsLow = prometheus.NewDesc(prefix+"red_packets_low_count", "Number of queued packets", l, nil)
+	c.redBytesLow = prometheus.NewDesc(prefix+"red_bytes_low_count", "Number of bytes of queued packets", l, nil)
+	c.redPacketsMediumLow = prometheus.NewDesc(prefix+"red_packets_medium_low_count", "Number of queued packets", l, nil)
+	c.redBytesMediumLow = prometheus.NewDesc(prefix+"red_bytes_medium_low_count", "Number of bytes of queued packets", l, nil)
+	c.redPacketsMediumHigh = prometheus.NewDesc(prefix+"red_packets_medium_high_count", "Number of queued packets", l, nil)
+	c.redBytesMediumHigh = prometheus.NewDesc(prefix+"red_bytes_medium_high_count", "Number of bytes of queued packets", l, nil)
+	c.redPacketsHigh = prometheus.NewDesc(prefix+"red_packets_high_count", "Number of queued packets", l, nil)
+	c.redBytesHigh = prometheus.NewDesc(prefix+"red_bytes_high_count", "Number of bytes of queued packets", l, nil)
+	c.tailDropPackets = prometheus.NewDesc(prefix+"tail_drop_packets_count", "Number of tail droped packets", l, nil)
 	c.totalDropPackets = prometheus.NewDesc(prefix+"drop_packets_count", "Number of packets droped", l, nil)
 	c.totalDropBytes = prometheus.NewDesc(prefix+"drop_bytes_count", "Number of bytes droped", l, nil)
 }
@@ -60,6 +82,17 @@ func (c *interfaceQueueCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.transferedPackets
 	ch <- c.rateLimitDropBytes
 	ch <- c.rateLimitDropPackets
+	ch <- c.redPackets
+	ch <- c.redBytes
+	ch <- c.redPacketsLow
+	ch <- c.redBytesLow
+	ch <- c.redPacketsMediumLow
+	ch <- c.redBytesMediumLow
+	ch <- c.redPacketsMediumHigh
+	ch <- c.redBytesMediumHigh
+	ch <- c.redPacketsHigh
+	ch <- c.redBytesHigh
+	ch <- c.tailDropPackets
 	ch <- c.totalDropBytes
 	ch <- c.totalDropPackets
 }
@@ -98,6 +131,17 @@ func (c *interfaceQueueCollector) collectForQueue(queue Queue, ch chan<- prometh
 	ch <- prometheus.MustNewConstMetric(c.transferedBytes, prometheus.CounterValue, float64(queue.TransferedBytes), l...)
 	ch <- prometheus.MustNewConstMetric(c.rateLimitDropPackets, prometheus.CounterValue, float64(queue.RateLimitDropPackets), l...)
 	ch <- prometheus.MustNewConstMetric(c.rateLimitDropBytes, prometheus.CounterValue, float64(queue.RateLimitDropBytes), l...)
+	ch <- prometheus.MustNewConstMetric(c.redPackets, prometheus.CounterValue, float64(queue.RedPackets), l...)
+	ch <- prometheus.MustNewConstMetric(c.redBytes, prometheus.CounterValue, float64(queue.RedBytes), l...)
+	ch <- prometheus.MustNewConstMetric(c.redPacketsLow, prometheus.CounterValue, float64(queue.RedPacketsLow), l...)
+	ch <- prometheus.MustNewConstMetric(c.redBytesLow, prometheus.CounterValue, float64(queue.RedBytesLow), l...)
+	ch <- prometheus.MustNewConstMetric(c.redPacketsMediumLow, prometheus.CounterValue, float64(queue.RedPacketsMediumLow), l...)
+	ch <- prometheus.MustNewConstMetric(c.redBytesMediumLow, prometheus.CounterValue, float64(queue.RedBytesMediumLow), l...)
+	ch <- prometheus.MustNewConstMetric(c.redPacketsMediumHigh, prometheus.CounterValue, float64(queue.RedPacketsMediumHigh), l...)
+	ch <- prometheus.MustNewConstMetric(c.redBytesMediumHigh, prometheus.CounterValue, float64(queue.RedBytesMediumHigh), l...)
+	ch <- prometheus.MustNewConstMetric(c.redPacketsHigh, prometheus.CounterValue, float64(queue.RedPacketsHigh), l...)
+	ch <- prometheus.MustNewConstMetric(c.redBytesHigh, prometheus.CounterValue, float64(queue.RedBytesHigh), l...)
+	ch <- prometheus.MustNewConstMetric(c.tailDropPackets, prometheus.CounterValue, float64(queue.TailDropPackets), l...)
 	ch <- prometheus.MustNewConstMetric(c.totalDropPackets, prometheus.CounterValue, float64(queue.TotalDropPackets), l...)
 	ch <- prometheus.MustNewConstMetric(c.totalDropBytes, prometheus.CounterValue, float64(queue.TotalDropBytes), l...)
 }

--- a/interfacequeue/rpc.go
+++ b/interfacequeue/rpc.go
@@ -22,6 +22,17 @@ type Queue struct {
 	TransferedBytes      uint64 `xml:"queue-counters-trans-bytes"`
 	RateLimitDropPackets uint64 `xml:"queue-counters-rate-limit-drop-packets"`
 	RateLimitDropBytes   uint64 `xml:"queue-counters-rate-limit-drop-bytes"`
+	RedPackets           uint64 `xml:"queue-counters-red-packets"`
+	RedBytes             uint64 `xml:"queue-counters-red-bytes"`
+	RedPacketsLow        uint64 `xml:"queue-counters-red-packets-low"`
+	RedBytesLow          uint64 `xml:"queue-counters-red-bytes-low"`
+	RedPacketsMediumLow  uint64 `xml:"queue-counters-red-packets-medium-low"`
+	RedBytesMediumLow    uint64 `xml:"queue-counters-red-bytes-medium-low"`
+	RedPacketsMediumHigh uint64 `xml:"queue-counters-red-packets-medium-high"`
+	RedBytesMediumHigh   uint64 `xml:"queue-counters-red-bytes-medium-high"`
+	RedPacketsHigh       uint64 `xml:"queue-counters-red-packets-high"`
+	RedBytesHigh         uint64 `xml:"queue-counters-red-bytes-high"`
+	TailDropPackets      uint64 `xml:"queue-counters-tail-drop-packets"`
 	TotalDropPackets     uint64 `xml:"queue-counters-total-drop-packets"`
 	TotalDropBytes       uint64 `xml:"queue-counters-total-drop-bytes"`
 }


### PR DESCRIPTION
Interfaces with class of service schedulers configured supply additional fields about Random Early Detection and tail dropping.

Example RPC output 

```
> show interfaces queue ge-0/0/0 | display xml
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/12.3X48/junos">
    <interface-information xmlns="http://xml.juniper.net/junos/12.3X48/junos-interface" junos:style="normal">
        <physical-interface>
            <name>ge-0/0/0</name>
            <admin-status junos:format="Enabled">up</admin-status>
            <oper-status>up</oper-status>
            <local-index>134</local-index>
            <snmp-index>508</snmp-index>
            <queue-counters junos:style="detail">
                <interface-cos-summary>
                    <intf-cos-forwarding-classes-supported>8</intf-cos-forwarding-classes-supported>
                    <intf-cos-forwarding-classes-in-use>5</intf-cos-forwarding-classes-in-use>
                    <intf-cos-queue-type>Egress queues</intf-cos-queue-type>
                    <intf-cos-num-queues-supported>8</intf-cos-num-queues-supported>
                    <intf-cos-num-queues-in-use>5</intf-cos-num-queues-in-use>
                </interface-cos-summary>
                <queue>
                    <queue-number>0</queue-number>
                    <forwarding-class-name>best-effort</forwarding-class-name>
                    <queue-counters-queued-packets>23556129</queue-counters-queued-packets>
                    <queue-counters-queued-packets-rate>249</queue-counters-queued-packets-rate>
                    <queue-counters-queued-bytes>4843383817</queue-counters-queued-bytes>
                    <queue-counters-queued-bytes-rate>1192480</queue-counters-queued-bytes-rate>
                    <queue-counters-trans-packets>23555097</queue-counters-trans-packets>
                    <queue-counters-trans-packets-rate>248</queue-counters-trans-packets-rate>
                    <queue-counters-trans-bytes>4841846657</queue-counters-trans-bytes>
                    <queue-counters-trans-bytes-rate>1192184</queue-counters-trans-bytes-rate>
                    <queue-counters-tail-drop-packets>1032</queue-counters-tail-drop-packets>
                    <queue-counters-tail-drop-packets-rate>0</queue-counters-tail-drop-packets-rate>
                    <queue-counters-red-packets>0</queue-counters-red-packets>
                    <queue-counters-red-packets-rate>0</queue-counters-red-packets-rate>
                    <queue-counters-red-packets-low>0</queue-counters-red-packets-low>
                    <queue-counters-red-packets-rate-low>0</queue-counters-red-packets-rate-low>
                    <queue-counters-red-packets-medium-low>0</queue-counters-red-packets-medium-low>
                    <queue-counters-red-packets-rate-medium-low>0</queue-counters-red-packets-rate-medium-low>
                    <queue-counters-red-packets-medium-high>0</queue-counters-red-packets-medium-high>
                    <queue-counters-red-packets-rate-medium-high>0</queue-counters-red-packets-rate-medium-high>
                    <queue-counters-red-packets-high>0</queue-counters-red-packets-high>
                    <queue-counters-red-packets-rate-high>0</queue-counters-red-packets-rate-high>
                    <queue-counters-red-bytes>0</queue-counters-red-bytes>
                    <queue-counters-red-bytes-rate>0</queue-counters-red-bytes-rate>
                    <queue-counters-red-bytes-low>0</queue-counters-red-bytes-low>
                    <queue-counters-red-bytes-rate-low>0</queue-counters-red-bytes-rate-low>
                    <queue-counters-red-bytes-medium-low>0</queue-counters-red-bytes-medium-low>
                    <queue-counters-red-bytes-rate-medium-low>0</queue-counters-red-bytes-rate-medium-low>
                    <queue-counters-red-bytes-medium-high>0</queue-counters-red-bytes-medium-high>
                    <queue-counters-red-bytes-rate-medium-high>0</queue-counters-red-bytes-rate-medium-high>
                    <queue-counters-red-bytes-high>0</queue-counters-red-bytes-high>
                    <queue-counters-red-bytes-rate-high>0</queue-counters-red-bytes-rate-high>
                </queue>
                ...
            </queue-counters>
        </physical-interface>
    </interface-information>
    <cli>
        <banner></banner>
    </cli>
</rpc-reply>
```

Built into a local docker image and it is producing expected output