### PR TITLE
add metrics for MAC address table

### DIFF
--- a/collectors.go
+++ b/collectors.go
@@ -18,6 +18,7 @@ import (
 	"github.com/czerwonk/junos_exporter/isis"
 	"github.com/czerwonk/junos_exporter/l2circuit"
 	"github.com/czerwonk/junos_exporter/ldp"
+	"github.com/czerwonk/junos_exporter/mac"
 	"github.com/czerwonk/junos_exporter/nat"
 	"github.com/czerwonk/junos_exporter/ospf"
 	"github.com/czerwonk/junos_exporter/power"
@@ -92,6 +93,7 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device) {
 	c.addCollectorIfEnabledForDevice(device, "storage", f.Storage, storage.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "system", f.System, system.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "power", f.Power, power.NewCollector)
+	c.addCollectorIfEnabledForDevice(device, "mac", f.MAC, mac.NewCollector)
 }
 
 func (c *collectors) addCollectorIfEnabledForDevice(device *connector.Device, key string, enabled bool, newCollector func() collector.RPCCollector) {

--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,7 @@ type FeatureConfig struct {
 	Satellite           bool `yaml:"satellite,omitempty"`
 	System              bool `yaml:"system,omitempty"`
 	Power               bool `yaml:"power,omitempty"`
+	MAC                 bool `yaml:"mac,omitempty"`
 }
 
 // New creates a new config
@@ -103,6 +104,7 @@ func setDefaultValues(c *Config) {
 	f.RPM = false
 	f.Satellite = false
 	f.Power = false
+	f.MAC = false
 }
 
 // FeaturesForDevice gets the feature set configured for a device

--- a/mac/collector.go
+++ b/mac/collector.go
@@ -1,0 +1,62 @@
+package mac
+
+import (
+	"github.com/czerwonk/junos_exporter/collector"
+	"github.com/czerwonk/junos_exporter/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix string = "junos_mac_table_"
+
+var (
+	totalCount    *prometheus.Desc
+	recieveCount  *prometheus.Desc
+	dynamicCount  *prometheus.Desc
+	floodCount    *prometheus.Desc
+)
+
+func init() {
+	l := []string{"target"}
+	totalCount = prometheus.NewDesc(prefix+"total_count", "Number of entries in table", l, nil)
+	recieveCount = prometheus.NewDesc(prefix+"recieve_count", "Number of L3 recieve route entries in table", l, nil)
+	dynamicCount = prometheus.NewDesc(prefix+"dynamic_count", "Number of dynamic entries in table", l, nil)
+	floodCount = prometheus.NewDesc(prefix+"flood_count", "Number of flood entries in table", l, nil)
+}
+
+type macCollector struct {
+}
+
+// Name returns the name of the collector
+func (*macCollector) Name() string {
+	return "Mac"
+}
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector {
+	return &macCollector{}
+}
+
+// Describe describes the metrics
+func (*macCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- totalCount
+	ch <- recieveCount
+	ch <- dynamicCount
+	ch <- floodCount
+}
+
+// Collect collects metrics from JunOS
+func (c *macCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var x = MacRpc{}
+	err := client.RunCommandAndParse("show ethernet-switching table summary", &x)
+	if err != nil {
+		return err
+	}
+
+	entry := x.Information.Table.Entry
+	ch <- prometheus.MustNewConstMetric(totalCount, prometheus.GaugeValue, float64(entry.TotalCount), labelValues...)
+	ch <- prometheus.MustNewConstMetric(recieveCount, prometheus.GaugeValue, float64(entry.ReceiveCount), labelValues...)
+	ch <- prometheus.MustNewConstMetric(dynamicCount, prometheus.GaugeValue, float64(entry.DynamicCount), labelValues...)
+	ch <- prometheus.MustNewConstMetric(floodCount, prometheus.GaugeValue, float64(entry.FloodCount), labelValues...)
+
+	return nil
+}

--- a/mac/rpc.go
+++ b/mac/rpc.go
@@ -1,0 +1,21 @@
+package mac
+
+type MacRpc struct {
+	Information EthernetSwitchingTableInformation `xml:"ethernet-switching-table-information"`
+}
+
+type EthernetSwitchingTableInformation struct {
+	Table EthernetSwitchingTable `xml:"ethernet-switching-table"`
+}
+
+type EthernetSwitchingTable struct {
+	Entry MacTableEntry `xml:"mac-table-entry"`
+}
+
+type MacTableEntry struct {
+	TotalCount   int64 `xml:"mac-table-total-count"`
+	ReceiveCount int64 `xml:"mac-table-recieve-count"`
+	DynamicCount int64 `xml:"mac-table-dynamic-count"`
+	FloodCount   int64 `xml:"mac-table-flood-count"`
+}
+

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ var (
 	rpkiEnabled                 = flag.Bool("rpki.enabled", false, "Scrape rpki metrics")
 	satelliteEnabled            = flag.Bool("satellite.enabled", false, "Scrape metrics from satellite devices")
 	systemEnabled               = flag.Bool("system.enabled", false, "Scrape system metrics")
+	macEnabled                  = flag.Bool("mac.enabled", false, "Scrape MAC address table metrics")
 	alarmFilter                 = flag.String("alarms.filter", "", "Regex to filter for alerts to ignore")
 	configFile                  = flag.String("config.file", "", "Path to config file")
 	dynamicIfaceLabels          = flag.Bool("dynamic-interface-labels", true, "Parse interface descriptions to get labels dynamicly")
@@ -206,6 +207,7 @@ func loadConfigFromFlags() *config.Config {
 	f.Satellite = *satelliteEnabled
 	f.System = *systemEnabled
 	f.Power = *powerEnabled
+	f.MAC = *macEnabled
 
 	return c
 }


### PR DESCRIPTION
This PR adds prometheus metrics for MAC address table entries. 

The following metrics are now exposed.

```
# HELP junos_mac_table_dynamic_count Number of dynamic entries in table
# TYPE junos_mac_table_dynamic_count gauge
junos_mac_table_dynamic_count{target="ex3200-1"} 23
# HELP junos_mac_table_flood_count Number of flood entries in table
# TYPE junos_mac_table_flood_count gauge
junos_mac_table_flood_count{target="ex3200-1"} 2
# HELP junos_mac_table_recieve_count Number of L3 recieve route entries in table
# TYPE junos_mac_table_recieve_count gauge
junos_mac_table_recieve_count{target="ex3200-1"} 2
# HELP junos_mac_table_total_count Number of entries in table
# TYPE junos_mac_table_total_count gauge
junos_mac_table_total_count{target="ex3200-1"} 27
```

This metrics is based on the output of `show ethernet-switching table summary | display xml`  

```xml

<rpc-reply xmlns:junos="http://xml.juniper.net/junos/12.3R12/junos">
    <ethernet-switching-table-information junos:style="summary">
        <ethernet-switching-table junos:style="summary">
            <mac-table-entry junos:style="summary">
                <mac-table-total-count>27</mac-table-total-count>
                <mac-table-recieve-count>2</mac-table-recieve-count>
                <mac-table-dynamic-count>23</mac-table-dynamic-count>
                <mac-table-flood-count>2</mac-table-flood-count>
            </mac-table-entry>
        </ethernet-switching-table>
    </ethernet-switching-table-information>
    <cli>
        <banner></banner>
    </cli>
</rpc-reply>
```