### PR TITLE
add metrics for TX/RX broadcast, multicast, unicasts, CRC error packets

### DIFF
--- a/interfaces/collector.go
+++ b/interfaces/collector.go
@@ -79,14 +79,14 @@ func (c *interfaceCollector) init() {
 	c.operStatusDesc = prometheus.NewDesc(prefix+"up", "Interface operational status", l, nil)
 	c.errorStatusDesc = prometheus.NewDesc(prefix+"error_status", "Admin and operational status differ", l, nil)
 	c.lastFlappedDesc = prometheus.NewDesc(prefix+"last_flapped_seconds", "Seconds since last flapped (-1 if never)", l, nil)
-	c.receiveUnicastsDesc = prometheus.NewDesc(prefix+"receive_unicasts", "Received unicast packets", l, nil)
-	c.receiveBroadcastsDesc = prometheus.NewDesc(prefix+"receive_broadcasts", "Received broadcast packets", l, nil)
-	c.receiveMulticastsDesc = prometheus.NewDesc(prefix+"receive_multicasts", "Received multicast packets", l, nil)
-	c.receiveCrcErrorsDesc = prometheus.NewDesc(prefix+"receive_errors_crc", "Number of CRC error incoming packets", l, nil)
-	c.transmitUnicastsDesc = prometheus.NewDesc(prefix+"transmit_unicasts", "Transmitted unicast packets", l, nil)
-	c.transmitBroadcastsDesc = prometheus.NewDesc(prefix+"transmit_broadcasts", "Transmitted broadcast packets", l, nil)
-	c.transmitMulticastsDesc = prometheus.NewDesc(prefix+"transmit_multicasts", "Transmitted multicast packets", l, nil)
-	c.transmitCrcErrorsDesc = prometheus.NewDesc(prefix+"transmit_errors_crc", "Number of CRC error outgoing packets", l, nil)
+        c.receiveUnicastsDesc = prometheus.NewDesc(prefix+"receive_unicasts_packets", "Received unicast packets", l, nil)
+	c.receiveBroadcastsDesc = prometheus.NewDesc(prefix+"receive_broadcasts_packets", "Received broadcast packets", l, nil)
+	c.receiveMulticastsDesc = prometheus.NewDesc(prefix+"receive_multicasts_packets", "Received multicast packets", l, nil)
+	c.receiveCrcErrorsDesc = prometheus.NewDesc(prefix+"receive_errors_crc_packets", "Number of CRC error incoming packets", l, nil)
+	c.transmitUnicastsDesc = prometheus.NewDesc(prefix+"transmit_unicasts_packets", "Transmitted unicast packets", l, nil)
+	c.transmitBroadcastsDesc = prometheus.NewDesc(prefix+"transmit_broadcasts_packets", "Transmitted broadcast packets", l, nil)
+	c.transmitMulticastsDesc = prometheus.NewDesc(prefix+"transmit_multicasts_packets", "Transmitted multicast packets", l, nil)
+	c.transmitCrcErrorsDesc = prometheus.NewDesc(prefix+"transmit_errors_crc_packets", "Number of CRC error outgoing packets", l, nil)
 }
 
 // Describe describes the metrics

--- a/interfaces/collector.go
+++ b/interfaces/collector.go
@@ -33,6 +33,14 @@ type interfaceCollector struct {
 	operStatusDesc          *prometheus.Desc
 	errorStatusDesc         *prometheus.Desc
 	lastFlappedDesc         *prometheus.Desc
+	receiveUnicastsDesc     *prometheus.Desc
+	receiveBroadcastsDesc   *prometheus.Desc
+	receiveMulticastsDesc   *prometheus.Desc
+	receiveCrcErrorsDesc    *prometheus.Desc
+	transmitUnicastsDesc    *prometheus.Desc
+	transmitBroadcastsDesc  *prometheus.Desc
+	transmitMulticastsDesc  *prometheus.Desc
+	transmitCrcErrorsDesc   *prometheus.Desc
 }
 
 // NewCollector creates a new collector
@@ -71,6 +79,14 @@ func (c *interfaceCollector) init() {
 	c.operStatusDesc = prometheus.NewDesc(prefix+"up", "Interface operational status", l, nil)
 	c.errorStatusDesc = prometheus.NewDesc(prefix+"error_status", "Admin and operational status differ", l, nil)
 	c.lastFlappedDesc = prometheus.NewDesc(prefix+"last_flapped_seconds", "Seconds since last flapped (-1 if never)", l, nil)
+	c.receiveUnicastsDesc = prometheus.NewDesc(prefix+"receive_unicasts", "Received unicast packets", l, nil)
+	c.receiveBroadcastsDesc = prometheus.NewDesc(prefix+"receive_broadcasts", "Received broadcast packets", l, nil)
+	c.receiveMulticastsDesc = prometheus.NewDesc(prefix+"receive_multicasts", "Received multicast packets", l, nil)
+	c.receiveCrcErrorsDesc = prometheus.NewDesc(prefix+"receive_errors_crc", "Number of CRC error incoming packets", l, nil)
+	c.transmitUnicastsDesc = prometheus.NewDesc(prefix+"transmit_unicasts", "Transmitted unicast packets", l, nil)
+	c.transmitBroadcastsDesc = prometheus.NewDesc(prefix+"transmit_broadcasts", "Transmitted broadcast packets", l, nil)
+	c.transmitMulticastsDesc = prometheus.NewDesc(prefix+"transmit_multicasts", "Transmitted multicast packets", l, nil)
+	c.transmitCrcErrorsDesc = prometheus.NewDesc(prefix+"transmit_errors_crc", "Number of CRC error outgoing packets", l, nil)
 }
 
 // Describe describes the metrics
@@ -92,6 +108,14 @@ func (c *interfaceCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.operStatusDesc
 	ch <- c.errorStatusDesc
 	ch <- c.lastFlappedDesc
+	ch <- c.receiveUnicastsDesc
+	ch <- c.receiveBroadcastsDesc
+	ch <- c.receiveMulticastsDesc
+	ch <- c.receiveCrcErrorsDesc
+	ch <- c.transmitUnicastsDesc
+	ch <- c.transmitBroadcastsDesc
+	ch <- c.transmitMulticastsDesc
+	ch <- c.transmitCrcErrorsDesc
 }
 
 // Collect collects metrics from JunOS
@@ -110,7 +134,7 @@ func (c *interfaceCollector) Collect(client *rpc.Client, ch chan<- prometheus.Me
 
 func (c *interfaceCollector) interfaceStats(client *rpc.Client) ([]*InterfaceStats, error) {
 	var x = InterfaceRpc{}
-	err := client.RunCommandAndParse("show interfaces statistics detail", &x)
+	err := client.RunCommandAndParse("show interfaces extensive", &x)
 	if err != nil {
 		return nil, err
 	}
@@ -139,6 +163,14 @@ func (c *interfaceCollector) interfaceStats(client *rpc.Client) ([]*InterfaceSta
 			IPv6TransmitBytes:   float64(phy.Stats.IPv6Traffic.OutputBytes),
 			IPv6TransmitPackets: float64(phy.Stats.IPv6Traffic.OutputPackets),
 			LastFlapped:         -1,
+			ReceiveUnicasts:     float64(phy.EthernetMacStatistics.InputUnicasts),
+			ReceiveBroadcasts:   float64(phy.EthernetMacStatistics.InputBroadcasts),
+			ReceiveMulticasts:   float64(phy.EthernetMacStatistics.InputMulticasts),
+			ReceiveCrcErrors:    float64(phy.EthernetMacStatistics.InputCrcErrors),
+			TransmitUnicasts:    float64(phy.EthernetMacStatistics.OutputUnicasts),
+			TransmitBroadcasts:  float64(phy.EthernetMacStatistics.OutputBroadcasts),
+			TransmitMulticasts:  float64(phy.EthernetMacStatistics.OutputMulticasts),
+			TransmitCrcErrors:   float64(phy.EthernetMacStatistics.OutputCrcErrors),
 		}
 
 		if phy.InterfaceFlapped.Value != "Never" {
@@ -239,5 +271,14 @@ func (c *interfaceCollector) collectForInterface(s *InterfaceStats, device *conn
 		if s.LastFlapped != 0 {
 			ch <- prometheus.MustNewConstMetric(c.lastFlappedDesc, prometheus.GaugeValue, s.LastFlapped, l...)
 		}
+
+	        ch <- prometheus.MustNewConstMetric(c.receiveUnicastsDesc, prometheus.GaugeValue, s.ReceiveUnicasts, l...)
+	        ch <- prometheus.MustNewConstMetric(c.receiveBroadcastsDesc, prometheus.GaugeValue, s.ReceiveBroadcasts, l...)
+	        ch <- prometheus.MustNewConstMetric(c.receiveMulticastsDesc, prometheus.GaugeValue, s.ReceiveMulticasts, l...)
+	        ch <- prometheus.MustNewConstMetric(c.receiveCrcErrorsDesc, prometheus.GaugeValue, s.ReceiveCrcErrors, l...)
+	        ch <- prometheus.MustNewConstMetric(c.transmitUnicastsDesc, prometheus.GaugeValue, s.TransmitUnicasts, l...)
+	        ch <- prometheus.MustNewConstMetric(c.transmitBroadcastsDesc, prometheus.GaugeValue, s.TransmitBroadcasts, l...)
+	        ch <- prometheus.MustNewConstMetric(c.transmitMulticastsDesc, prometheus.GaugeValue, s.TransmitMulticasts, l...)
+	        ch <- prometheus.MustNewConstMetric(c.transmitCrcErrorsDesc, prometheus.GaugeValue, s.TransmitCrcErrors, l...)
 	}
 }

--- a/interfaces/interface_stats.go
+++ b/interfaces/interface_stats.go
@@ -22,4 +22,12 @@ type InterfaceStats struct {
 	IPv6TransmitBytes   float64
 	IPv6TransmitPackets float64
 	LastFlapped         float64
+	ReceiveUnicasts     float64
+	ReceiveBroadcasts   float64
+	ReceiveMulticasts   float64
+	ReceiveCrcErrors    float64
+	TransmitUnicasts     float64
+	TransmitBroadcasts   float64
+	TransmitMulticasts   float64
+	TransmitCrcErrors    float64
 }

--- a/interfaces/rpc.go
+++ b/interfaces/rpc.go
@@ -27,6 +27,7 @@ type PhyInterface struct {
 		Seconds uint64 `xml:"seconds,attr"`
 		Value   string `xml:",chardata"`
 	} `xml:"interface-flapped"`
+        EthernetMacStatistics EthernetMacStat `xml:"ethernet-mac-statistics"`
 }
 
 type LogInterface struct {
@@ -56,4 +57,15 @@ type LagTrafficStat struct {
 	Links []struct {
 		Name string `xml:"name"`
 	} `xml:"lag-link"`
+}
+
+type EthernetMacStat struct {
+	InputUnicasts    uint64 `xml:"input-unicasts"`
+	InputBroadcasts  uint64 `xml:"input-broadcasts"`
+	InputMulticasts  uint64 `xml:"input-multicasts"`
+	InputCrcErrors   uint64 `xml:"input-crc-errors"`
+	OutputUnicasts   uint64 `xml:"output-unicasts"`
+	OutputBroadcasts uint64 `xml:"output-broadcasts"`
+	OutputMulticasts uint64 `xml:"output-multicasts"`
+	OutputCrcErrors  uint64 `xml:"output-crc-errors"`
 }


### PR DESCRIPTION
This PR adds prometheus metrics for TX/RX broadcast, multicast, unicasts, CRC error packets entries.  

The following metrics are now exposed.  

```
# HELP junos_interface_receive_broadcasts Received broadcast packets
# TYPE junos_interface_receive_broadcasts gauge
junos_interface_receive_broadcasts{description="",mac="00:26:88:78:6b:03",name="ge-0/0/46",target="ex3200-1"} 5.06705251e+08

# HELP junos_interface_receive_errors_crc Number of CRC error incoming packets
# TYPE junos_interface_receive_errors_crc gauge
junos_interface_receive_errors_crc{description="",mac="00:26:88:78:6b:30",name="ge-0/0/45",target="ex3200-1"} 1

# HELP junos_interface_receive_multicasts Received multicast packets
# TYPE junos_interface_receive_multicasts gauge
junos_interface_receive_multicasts{description="",mac="00:26:88:78:6b:03",name="ge-0/0/46",target="ex3200-1"} 1.054740167e+09

# HELP junos_interface_receive_unicasts Received unicast packets
# TYPE junos_interface_receive_unicasts gauge
junos_interface_receive_unicasts{description="",mac="00:26:88:78:6b:03",name="ge-0/0/46",target="ex3200-1"} 1.093475547e+09

# HELP junos_interface_transmit_broadcasts Transmitted broadcast packets
# TYPE junos_interface_transmit_broadcasts gauge
junos_interface_transmit_broadcasts{description="",mac="00:26:88:78:6b:03",name="ge-0/0/46",target="ex3200-1"} 4.22708706e+08

# HELP junos_interface_transmit_errors_crc Number of CRC error outgoing packets
# TYPE junos_interface_transmit_errors_crc gauge
junos_interface_transmit_errors_crc{description="",mac="00:26:88:78:6b:05",name="ge-0/0/2",target="ex3200-1"} 0

# HELP junos_interface_transmit_multicasts Transmitted multicast packets
# TYPE junos_interface_transmit_multicasts gauge
junos_interface_transmit_multicasts{description="",mac="00:26:88:78:6b:03",name="ge-0/0/46",target="ex3200-1"} 9.96547927e+08

# HELP junos_interface_transmit_unicasts Transmitted unicast packets
# TYPE junos_interface_transmit_unicasts gauge
junos_interface_transmit_unicasts{description="",mac="00:26:88:78:6b:03",name="ge-0/0/46",target="ex3200-1"} 1.246669437e+09
```

These metrics are based on the output of `show interfaces extensive | display xml` .  
The output of this command is the output of `show interfaces statistics detail | display xml`  with the following additions.  

```xml
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/12.3R12/junos">
    <interface-information xmlns="http://xml.juniper.net/junos/12.3R12/junos-interface" junos:style="normal">
        <physical-interface>
            <name>ge-0/0/0</name>

            ...snip

            <ethernet-mac-statistics junos:style="verbose">
                <input-bytes>4779885871833</input-bytes>
                <output-bytes>14355870285837</output-bytes>
                <input-packets>24156588355</input-packets>
                <output-packets>31789344367</output-packets>
                <input-unicasts>22993966350</input-unicasts>
                <output-unicasts>29940927110</output-unicasts>
                <input-broadcasts>153380313</input-broadcasts>
                <output-broadcasts>538903016</output-broadcasts>
                <input-multicasts>1009241692</input-multicasts>
                <output-multicasts>1309514241</output-multicasts>
                <input-crc-errors>0</input-crc-errors>
                <output-crc-errors>0</output-crc-errors>
                <input-fifo-errors>0</input-fifo-errors>
                <output-fifo-errors>0</output-fifo-errors>
                <input-mac-control-frames>0</input-mac-control-frames>
                <output-mac-control-frames>0</output-mac-control-frames>
                <input-mac-pause-frames>0</input-mac-pause-frames>
                <output-mac-pause-frames>0</output-mac-pause-frames>
                <input-oversized-frames>0</input-oversized-frames>
                <input-jabber-frames>0</input-jabber-frames>
                <input-fragment-frames>0</input-fragment-frames>
                <input-code-violations>0</input-code-violations>
            </ethernet-mac-statistics>
            <ethernet-autonegotiation>
                <autonegotiation-status>complete</autonegotiation-status>
                <link-partner-status>OK</link-partner-status>
                <link-partner-duplexity>full-duplex</link-partner-duplexity>
                <link-partner-speed>1000 Mbps</link-partner-speed>
                <flow-control>Symmetric</flow-control>
                <local-info>
                    <local-flow-control>Symmetric</local-flow-control>
                    <local-remote-fault>Link OK</local-remote-fault>
                </local-info>
            </ethernet-autonegotiation>
            <pfe-information>
                <destination-slot>0</destination-slot>
            </pfe-information>
            <cos-header/>
            <cos-information>
                <cos-stream-information>
                    <cos-direction>Output</cos-direction>
                    <cos-queue-configuration>
                        <cos-queue-number>0</cos-queue-number>
                        <cos-queue-forwarding-class>best-effort</cos-queue-forwarding-class>
                        <cos-queue-bandwidth>95</cos-queue-bandwidth>
                        <cos-queue-bandwidth-bps>950000000</cos-queue-bandwidth-bps>
                        <cos-queue-buffer>95</cos-queue-buffer>
                        <cos-queue-buffer-bytes>NA</cos-queue-buffer-bytes>
                        <cos-queue-priority>low</cos-queue-priority>
                        <cos-queue-limit>none</cos-queue-limit>
                    </cos-queue-configuration>
                    <cos-queue-configuration>
                        <cos-queue-number>7</cos-queue-number>
                        <cos-queue-forwarding-class>network-control</cos-queue-forwarding-class>
                        <cos-queue-bandwidth>5</cos-queue-bandwidth>
                        <cos-queue-bandwidth-bps>50000000</cos-queue-bandwidth-bps>
                        <cos-queue-buffer>5</cos-queue-buffer>
                        <cos-queue-buffer-bytes>NA</cos-queue-buffer-bytes>
                        <cos-queue-priority>low</cos-queue-priority>
                        <cos-queue-limit>none</cos-queue-limit>
                    </cos-queue-configuration>
                </cos-stream-information>
            </cos-information>

            ...snip
```