### PR TITLE
add metrics for VRRP state

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,13 @@ States map to human readable names like this:
 4 = "Ex-Incr"
 5 = "Ex-Full"
 ```
+* VRRP (state per interface)
+States map to human readable names like this:
+```   
+1: "init"
+2: "backup"
+3: "master"
+```
 
 ## Install
 ```bash

--- a/collectors.go
+++ b/collectors.go
@@ -27,6 +27,7 @@ import (
 	"github.com/czerwonk/junos_exporter/rpm"
 	"github.com/czerwonk/junos_exporter/storage"
 	"github.com/czerwonk/junos_exporter/system"
+	"github.com/czerwonk/junos_exporter/vrrp"
 )
 
 type collectors struct {
@@ -92,6 +93,7 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device) {
 	c.addCollectorIfEnabledForDevice(device, "storage", f.Storage, storage.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "system", f.System, system.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "power", f.Power, power.NewCollector)
+	c.addCollectorIfEnabledForDevice(device, "vrrp", f.VRRP, vrrp.NewCollector)
 }
 
 func (c *collectors) addCollectorIfEnabledForDevice(device *connector.Device, key string, enabled bool, newCollector func() collector.RPCCollector) {

--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,7 @@ type FeatureConfig struct {
 	Satellite           bool `yaml:"satellite,omitempty"`
 	System              bool `yaml:"system,omitempty"`
 	Power               bool `yaml:"power,omitempty"`
+	VRRP                bool `yaml:"vrrp,omitempty"`
 }
 
 // New creates a new config
@@ -103,6 +104,7 @@ func setDefaultValues(c *Config) {
 	f.RPM = false
 	f.Satellite = false
 	f.Power = false
+	f.VRRP = false
 }
 
 // FeaturesForDevice gets the feature set configured for a device

--- a/vrrp/collector.go
+++ b/vrrp/collector.go
@@ -1,0 +1,60 @@
+package vrrp
+
+import (
+	"github.com/czerwonk/junos_exporter/collector"
+	"github.com/czerwonk/junos_exporter/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix = "junos_vrrp_"
+
+var (
+	vrrpState  *prometheus.Desc
+)
+
+func init() {
+	l := []string{"target", "interface", "group", "local_interface_address", "virtual_ip_address"}
+	vrrpState = prometheus.NewDesc(prefix+"state", "VRRP state (1: init, 2: backup, 3: master)", l, nil)
+}
+
+type vrrpCollector struct {
+}
+
+// Name returns the name of the collector
+func (*vrrpCollector) Name() string {
+	return "VRRP"
+}
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector {
+	return &vrrpCollector{}
+}
+
+// Describe describes the metrics
+func (*vrrpCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- vrrpState
+}
+
+
+// Collect collects metrics from JunOS
+func (c *vrrpCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+        statusValues := map[string]int{
+		"init":   1,
+		"backup": 2,
+		"master": 3,
+	}
+
+        var x = VrrpRpc{}
+        err := client.RunCommandAndParse("show vrrp summary", &x)
+	if err != nil {
+		return err
+	}
+
+	for _, iface := range x.Information.Interfaces {
+                l := labelValues
+                l = append(l, iface.Interface, iface.Group, iface.LocalInterfaceAddress, iface.VirtualIpAddress)
+                ch <- prometheus.MustNewConstMetric(vrrpState, prometheus.GaugeValue, float64(statusValues[iface.VrrpState]), l...)
+	}
+
+	return nil
+}

--- a/vrrp/rpc.go
+++ b/vrrp/rpc.go
@@ -1,0 +1,17 @@
+package vrrp
+
+type VrrpRpc struct {
+	Information struct {
+		Interfaces []VrrpInterface `xml:"vrrp-interface"`
+	} `xml:"vrrp-information"`
+}
+
+type VrrpInterface struct {
+	Interface             string `xml:"interface"`
+	InterfaceState        string `xml:"interface-state"`
+        Group                 string `xml:"group"`
+	VrrpState             string `xml:"vrrp-state"`
+	VrrpMode              string `xml:"vrrp-mode"`
+	LocalInterfaceAddress string `xml:"local-interface-address"`
+	VirtualIpAddress      string `xml:"virtual-ip-address"`
+}


### PR DESCRIPTION
This PR adds prometheus metrics for VRRP state.

The following metrics are now exposed.  

```
# HELP junos_vrrp_state VRRP state (1: init, 2: backup, 3: master)
# TYPE junos_vrrp_state gauge
junos_vrrp_state{group="255",interface="ge-0/0/0.10",local_interface_address="10.138.125.2",target="ex3200-1",virtual_ip_address="10.138.125.1"} 3
junos_vrrp_state{group="255",interface="ge-0/0/0.10",local_interface_address="10.138.125.3",target="ex3200-2",virtual_ip_address="10.138.125.1"} 2
junos_vrrp_state{group="255",interface="ge-0/0/0.11",local_interface_address="10.138.125.66",target="ex3200-1",virtual_ip_address="10.138.125.65"} 3
junos_vrrp_state{group="255",interface="ge-0/0/0.11",local_interface_address="10.138.125.67",target="ex3200-2",virtual_ip_address="10.138.125.65"} 2
```

This metrics is based on the output of `show vrrp summary | display xml`  

```xml
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/12.3R12/junos">
    <vrrp-information xmlns="http://xml.juniper.net/junos/12.3R12/junos-vrrpd" junos:style="summary">
        <vrrp-interface>
            <interface>ge-0/0/0.10</interface>
            <interface-state>up</interface-state>
            <group>255</group>
            <vrrp-state>backup</vrrp-state>
            <vrrp-mode>Active</vrrp-mode>
            <local-interface-address>10.138.125.3</local-interface-address>
            <virtual-ip-address>10.138.125.1</virtual-ip-address>
        </vrrp-interface>
        <vrrp-interface>
            <interface>ge-0/0/0.11</interface>
            <interface-state>up</interface-state>
            <group>255</group>
            <vrrp-state>backup</vrrp-state>
            <vrrp-mode>Active</vrrp-mode>
            <local-interface-address>10.138.125.67</local-interface-address>
            <virtual-ip-address>10.138.125.65</virtual-ip-address>
        </vrrp-interface>

...

    </vrrp-information>
    <cli>
        <banner></banner>
    </cli>
</rpc-reply>
```