### PR TITLE
Fix dynamic label regex parsing behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ Label value: 202739
 
 ### Custom Label RegEx
 
-To override the default behavior a `interface_description_regex` can be supplied.  
+To override the default behavior a `interface_description_regex` can be supplied. This parameter can be given at a global level or per device. To use per-device regexes the target devices need to be defined in the exporter config. Per-device regex cannot be used in combination with `-config.ignore-targets`.
+ 
 #### Example
 The default regex `\[([^=\]]+)(=[^\]]+)?\]` would match interface descriptions like `"Description [foo] [bar=123]"`.  
 If we use `[[\s]([^=\[\]]+)(=[^,\]]+)?[,\]]` we can now match for `"Description [foo, bar=123]"` instead.  

--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ Label value: 202739
 
 To override the default behavior a `interface_description_regex` can be supplied.  
 #### Example
-The default regex `\[([^=\]]+)(=[^\]]+)?\]` would match interface descriptions like `"Description [foo] [bar=123]".  
-If we use `[[\s]([^=\[\]]+)(=[^,\]]+)?[,\]]` we can now match for `Description [foo, bar=123]` instead.  
+The default regex `\[([^=\]]+)(=[^\]]+)?\]` would match interface descriptions like `"Description [foo] [bar=123]"`.  
+If we use `[[\s]([^=\[\]]+)(=[^,\]]+)?[,\]]` we can now match for `"Description [foo, bar=123]"` instead.  
 
 
 ### Grafana Dashboards

--- a/junos_collector.go
+++ b/junos_collector.go
@@ -50,10 +50,20 @@ func newJunosCollector(devices []*connector.Device, connectionManager *connector
 
 		if *dynamicIfaceLabels {
 			regex := defaultIfDescReg
-			if cfg.Devices[index].IfDescReg != "" {
-				regex = regexp.MustCompile(cfg.Devices[index].IfDescReg)
-			} else if cfg.IfDescReg != "" {
-				regex = regexp.MustCompile(cfg.IfDescReg)
+			if cfg.IfDescReg != "" {
+				regex, err = regexp.Compile(cfg.IfDescReg)
+				if err != nil {
+				        log.Errorf("Global dynamic label regex invalid: %s", cfg.IfDescReg)
+			                regex = defaultIfDescReg
+				}
+			} else if !(*ignoreConfigTargets) && index <= len(cfg.Devices) {
+				if cfg.Devices[index].IfDescReg != "" {
+				    regex, err = regexp.Compile(cfg.Devices[index].IfDescReg)
+				    if err != nil {
+				         log.Errorf("Device specific dynamic label regex invalid: %s", cfg.Devices[index].IfDescReg)
+			                 regex = defaultIfDescReg
+				    }
+				}
 			}
 
 			err = l.CollectDescriptions(d, cl, regex)

--- a/junos_collector.go
+++ b/junos_collector.go
@@ -54,14 +54,14 @@ func newJunosCollector(devices []*connector.Device, connectionManager *connector
 				regex, err = regexp.Compile(cfg.IfDescReg)
 				if err != nil {
 				        log.Errorf("Global dynamic label regex invalid: %s", cfg.IfDescReg)
-			                regex = defaultIfDescReg
+                                        regex = defaultIfDescReg
 				}
 			} else if !(*ignoreConfigTargets) && index <= len(cfg.Devices) {
 				if cfg.Devices[index].IfDescReg != "" {
 				    regex, err = regexp.Compile(cfg.Devices[index].IfDescReg)
 				    if err != nil {
 				         log.Errorf("Device specific dynamic label regex invalid: %s", cfg.Devices[index].IfDescReg)
-			                 regex = defaultIfDescReg
+                                         regex = defaultIfDescReg
 				    }
 				}
 			}

--- a/junos_collector.go
+++ b/junos_collector.go
@@ -54,14 +54,14 @@ func newJunosCollector(devices []*connector.Device, connectionManager *connector
 				regex, err = regexp.Compile(cfg.IfDescReg)
 				if err != nil {
 				        log.Errorf("Global dynamic label regex invalid: %s", cfg.IfDescReg)
-                                        regex = defaultIfDescReg
+				        regex = defaultIfDescReg
 				}
 			} else if !(*ignoreConfigTargets) && index <= len(cfg.Devices) {
 				if cfg.Devices[index].IfDescReg != "" {
 				    regex, err = regexp.Compile(cfg.Devices[index].IfDescReg)
 				    if err != nil {
 				         log.Errorf("Device specific dynamic label regex invalid: %s", cfg.Devices[index].IfDescReg)
-                                         regex = defaultIfDescReg
+				         regex = defaultIfDescReg
 				    }
 				}
 			}

--- a/junos_collector.go
+++ b/junos_collector.go
@@ -56,13 +56,11 @@ func newJunosCollector(devices []*connector.Device, connectionManager *connector
 				        log.Errorf("Global dynamic label regex invalid: %s", cfg.IfDescReg)
 				        regex = defaultIfDescReg
 				}
-			} else if !(*ignoreConfigTargets) && index <= len(cfg.Devices) {
-				if cfg.Devices[index].IfDescReg != "" {
-				    regex, err = regexp.Compile(cfg.Devices[index].IfDescReg)
-				    if err != nil {
-				         log.Errorf("Device specific dynamic label regex invalid: %s", cfg.Devices[index].IfDescReg)
-				         regex = defaultIfDescReg
-				    }
+			} else if !(*ignoreConfigTargets) && index < len(cfg.Devices) && cfg.Devices[index].IfDescReg != "" {
+				regex, err = regexp.Compile(cfg.Devices[index].IfDescReg)
+				if err != nil {
+				     log.Errorf("Device specific dynamic label regex invalid: %s", cfg.Devices[index].IfDescReg)
+				     regex = defaultIfDescReg
 				}
 			}
 


### PR DESCRIPTION
This is supposed to fix !163. Basically introduces additional constraints for user supplied regexes and ensures that at least the default regex is loaded in all cases.

If there's any feedback for the code it's more than welcome since I'm a go novice.

Also clarifies the README.md a bit.