### PR TITLE
Use device hostnames as a pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ devices:
     # interface_description_regex: '\[([^=\]]+)(=[^\]]+)?\]'
     features:
       isis: true
+  - host: switch\d+
+    # Tell the exporter that this hostname should be used as a pattern when loading
+    # device-specific configurations. This example would match against a hostname
+    # like "switch123".
+    host_pattern: true
+    features:
+      bgp: false
 
 # Optional
 # interface_description_regex: '\[([^=\]]+)(=[^\]]+)?\]'

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"io"
 	"io/ioutil"
+	"regexp"
 
 	"gopkg.in/yaml.v2"
 )
@@ -19,12 +20,14 @@ type Config struct {
 
 // DeviceConfig is the config representation of 1 device
 type DeviceConfig struct {
-	Host      string         `yaml:"host"`
-	Username  string         `yaml:"username,omitempty"`
-	Password  string         `yaml:"password,omitempty"`
-	KeyFile   string         `yaml:"key_file,omitempty"`
-	Features  *FeatureConfig `yaml:"features,omitempty"`
-	IfDescReg string         `yaml:"interface_description_regex,omitempty"`
+	Host          string         `yaml:"host"`
+	Username      string         `yaml:"username,omitempty"`
+	Password      string         `yaml:"password,omitempty"`
+	KeyFile       string         `yaml:"key_file,omitempty"`
+	Features      *FeatureConfig `yaml:"features,omitempty"`
+	IfDescReg     string         `yaml:"interface_description_regex,omitempty"`
+	IsHostPattern bool           `yaml:"host_pattern,omitempty"`
+	HostPattern   *regexp.Regexp
 }
 
 // FeatureConfig is the list of collectors enabled or disabled
@@ -81,6 +84,16 @@ func Load(reader io.Reader) (*Config, error) {
 		return nil, err
 	}
 
+	for _, device := range c.Devices {
+		if device.IsHostPattern {
+			hostPattern, err := regexp.Compile(device.Host)
+			if err != nil {
+				return nil, err
+			}
+			device.HostPattern = hostPattern
+		}
+	}
+
 	return c, nil
 }
 
@@ -128,8 +141,14 @@ func (c *Config) FeaturesForDevice(host string) *FeatureConfig {
 
 func (c *Config) findDeviceConfig(host string) *DeviceConfig {
 	for _, dc := range c.Devices {
-		if dc.Host == host {
-			return dc
+		if dc.HostPattern != nil {
+			if dc.HostPattern.MatchString(host) {
+				return dc
+			}
+		} else {
+			if dc.Host == host {
+				return dc
+			}
 		}
 	}
 

--- a/config/tests/config4.yml
+++ b/config/tests/config4.yml
@@ -1,0 +1,28 @@
+devices:
+  - host: router1
+    username: router
+  - host: switch\-[a-z]{3}\d+
+    host_pattern: true
+    username: switch
+    password: secret
+    features:
+      bgp: false
+      ospf: false
+      isis: false
+      nat: false
+      environment: true
+      routes: false
+      routing_engine: false
+      interface_diagnostic: true
+      interface_queue: true
+      interfaces: true
+      l2circuit: false
+      storage: false
+      fpc: false
+      firewall: false
+      ldp: false
+      accounting: false
+      ipsec: false
+      rpki: false
+      power: true
+

--- a/config/tests/config5.yml
+++ b/config/tests/config5.yml
@@ -1,0 +1,3 @@
+devices:
+  - host: asw[a-z]3}\k+-\d+
+    host_pattern: true


### PR DESCRIPTION
This PR adds support for hostname based pattern matching to select devices.

Background: We have a lot of devices we want to scrape metrics from and we don't want to list every device with the enabled features in the config file to keep the setup as dynamic as possible (we use this together with the "ignore-targets" flag).

This change adds a new option to the device configuration named `host_pattern` which tells the exporter to use the given hostname as a pattern which is later matched against the target hostnames.