### PR TITLE
Change SSH to NETCONF-RPC

### DIFF
--- a/accounting/collector.go
+++ b/accounting/collector.go
@@ -96,7 +96,8 @@ func (c *accountingCollector) Collect(client *rpc.Client, ch chan<- prometheus.M
 
 func (c *accountingCollector) accountingFlows(client *rpc.Client) (*AccountingFlow, error) {
 	var x = AccountingFlowRpc{}
-	err := client.RunCommandAndParse("show services accounting flow inline-jflow", &x)
+//	err := client.RunCommandAndParse("show services accounting flow inline-jflow", &x)
+	err := client.RunCommandAndParse("<get-service-accounting-error-inline-jflow-information></get-service-accounting-error-inline-jflow-information>", &x)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +120,8 @@ func (c *accountingCollector) accountingFlows(client *rpc.Client) (*AccountingFl
 
 func (c *accountingCollector) accountingFailures(client *rpc.Client) (*AccountingError, error) {
 	var x = AccountingFlowErrorRpc{}
-	err := client.RunCommandAndParse("show services accounting errors inline-jflow fpc-slot 0", &x)
+//	err := client.RunCommandAndParse("show services accounting errors inline-jflow fpc-slot 0", &x)
+	err := client.RunCommandAndParse("<get-service-accounting-error-inline-jflow-information><inline-jflow-error-information>0</inline-jflow-error-information></get-service-accounting-error-inline-jflow-information>", &x)
 	if err != nil {
 		return nil, err
 	}

--- a/alarm/collector.go
+++ b/alarm/collector.go
@@ -74,8 +74,8 @@ func (c *alarmCollector) alarmCounter(client *rpc.Client) (*AlarmCounter, *[]Ala
 	yellow := 0
 
 	cmds := []string{
-		"show system alarms",
-		"show chassis alarms",
+		"<get-system-alarm-information/>",
+		"<get-alarm-information/>",
 	}
 
 	var alarms []AlarmDetails

--- a/bfd/collector.go
+++ b/bfd/collector.go
@@ -44,7 +44,8 @@ func (*bfdCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect collects metrics from JunOS
 func (c *bfdCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
         var x = bfdRpc{}
-        err := client.RunCommandAndParse("show bfd session extensive", &x)
+//        err := client.RunCommandAndParse("show bfd session extensive", &x)
+        err := client.RunCommandAndParse("<get-bfd-session-information><extensive/></get-bfd-session-information>", &x)
 	if err != nil {
 		return err
 	}

--- a/bfd/collector.go
+++ b/bfd/collector.go
@@ -1,0 +1,58 @@
+package bfd
+
+import (
+	"github.com/czerwonk/junos_exporter/collector"
+	"github.com/czerwonk/junos_exporter/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix = "junos_bfd_"
+
+var (
+	bfdState    *prometheus.Desc
+	bfdStateMap = map[string]int{
+	"Down":          0,
+	"Up":            1,
+	}
+
+)
+
+func init() {
+	l := []string{"target", "neighbor", "interface", "client"}
+	bfdState = prometheus.NewDesc(prefix+"state", "bfd state (0: down, 1:up)", l, nil)
+}
+
+type bfdCollector struct {
+}
+
+// Name returns the name of the collector
+func (*bfdCollector) Name() string {
+	return "bfd"
+}
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector {
+	return &bfdCollector{}
+}
+
+// Describe describes the metrics
+func (*bfdCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- bfdState
+}
+
+
+// Collect collects metrics from JunOS
+func (c *bfdCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+        var x = bfdRpc{}
+        err := client.RunCommandAndParse("show bfd session extensive", &x)
+	if err != nil {
+		return err
+	}
+
+	for _, bfds := range x.Information.BfdSessions {
+                l := append(labelValues, bfds.Neighbor, bfds.Interface, bfds.Client.Name)
+                ch <- prometheus.MustNewConstMetric(bfdState, prometheus.GaugeValue, float64(bfdStateMap[bfds.State]), l...)
+	}
+
+	return nil
+}

--- a/bfd/rpc.go
+++ b/bfd/rpc.go
@@ -1,0 +1,21 @@
+package bfd
+
+type bfdRpc struct {
+	Information struct {
+		BfdSessions []bfdSession `xml:"bfd-session"`
+		sessions    int64 `xml:"sessions"`
+		clients     int64 `xml:"clients"`
+		CumTransRate  float64 `xml:"cumulative-transmission-rate"`
+		CumRecRate  float64 `xml:"cumulative-reception-rate"`
+	} `xml:"bfd-session-information"`
+}
+
+type bfdSession struct {
+	Neighbor           string    `xml:"session-neighbor"`
+	State              string    `xml:"session-state"`
+	Interface          string    `xml:"session-interface"`
+	Client             struct {
+		Name       string    `xml:"client-name"`
+	} `xml:"bfd-client"`
+}
+

--- a/bgp/collector.go
+++ b/bgp/collector.go
@@ -77,10 +77,11 @@ func (c *bgpCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, 
 func (c *bgpCollector) collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = BGPRPC{}
 	var cmd strings.Builder
-	cmd.WriteString("show bgp neighbor")
-	if c.LogicalSystem != "" {
-		cmd.WriteString(" logical-system " + c.LogicalSystem)
-	}
+//	cmd.WriteString("show bgp neighbor")
+//	if c.LogicalSystem != "" {
+//		cmd.WriteString(" logical-system " + c.LogicalSystem)
+//	}
+	cmd.WriteString("<get-bgp-neighbor-information/>")
 
 	err := client.RunCommandAndParse(cmd.String(), &x)
 	if err != nil {

--- a/collectors.go
+++ b/collectors.go
@@ -17,6 +17,7 @@ import (
 	"github.com/czerwonk/junos_exporter/ipsec"
 	"github.com/czerwonk/junos_exporter/isis"
 	"github.com/czerwonk/junos_exporter/l2circuit"
+	"github.com/czerwonk/junos_exporter/lacp"
 	"github.com/czerwonk/junos_exporter/ldp"
 	"github.com/czerwonk/junos_exporter/mac"
 	"github.com/czerwonk/junos_exporter/nat"
@@ -85,6 +86,7 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device) {
 	c.addCollectorIfEnabledForDevice(device, "ipsec", f.IPSec, ipsec.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "isis", f.ISIS, isis.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "l2c", f.L2Circuit, l2circuit.NewCollector)
+	c.addCollectorIfEnabledForDevice(device, "lacp", f.LACP, lacp.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "ldp", f.LDP, ldp.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "nat", f.NAT, nat.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "nat2", f.NAT2, nat2.NewCollector)

--- a/collectors.go
+++ b/collectors.go
@@ -21,6 +21,7 @@ import (
 	"github.com/czerwonk/junos_exporter/lacp"
 	"github.com/czerwonk/junos_exporter/ldp"
 	"github.com/czerwonk/junos_exporter/mac"
+	"github.com/czerwonk/junos_exporter/mpls_lsp"
 	"github.com/czerwonk/junos_exporter/nat"
 	"github.com/czerwonk/junos_exporter/nat2"
 	"github.com/czerwonk/junos_exporter/ospf"
@@ -106,6 +107,7 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device) {
 	c.addCollectorIfEnabledForDevice(device, "mac", f.MAC, mac.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "vrrp", f.VRRP, vrrp.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "vpws", f.VPWS, vpws.NewCollector)
+	c.addCollectorIfEnabledForDevice(device, "mpls_lsp", f.MPLS_LSP, mpls_lsp.NewCollector)
 }
 
 func (c *collectors) addCollectorIfEnabledForDevice(device *connector.Device, key string, enabled bool, newCollector func() collector.RPCCollector) {

--- a/collectors.go
+++ b/collectors.go
@@ -33,6 +33,7 @@ import (
 	"github.com/czerwonk/junos_exporter/storage"
 	"github.com/czerwonk/junos_exporter/system"
 	"github.com/czerwonk/junos_exporter/vrrp"
+	"github.com/czerwonk/junos_exporter/vpws"
 )
 
 type collectors struct {
@@ -104,6 +105,7 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device) {
 	c.addCollectorIfEnabledForDevice(device, "power", f.Power, power.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "mac", f.MAC, mac.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "vrrp", f.VRRP, vrrp.NewCollector)
+	c.addCollectorIfEnabledForDevice(device, "vpws", f.VPWS, vpws.NewCollector)
 }
 
 func (c *collectors) addCollectorIfEnabledForDevice(device *connector.Device, key string, enabled bool, newCollector func() collector.RPCCollector) {

--- a/collectors.go
+++ b/collectors.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/czerwonk/junos_exporter/accounting"
 	"github.com/czerwonk/junos_exporter/alarm"
+	"github.com/czerwonk/junos_exporter/bfd"
 	"github.com/czerwonk/junos_exporter/bgp"
 	"github.com/czerwonk/junos_exporter/collector"
 	"github.com/czerwonk/junos_exporter/config"
@@ -68,6 +69,7 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device) {
 	c.addCollectorIfEnabledForDevice(device, "alarm", f.Alarm, func() collector.RPCCollector {
 		return alarm.NewCollector(*alarmFilter)
 	})
+	c.addCollectorIfEnabledForDevice(device, "bfd", f.BFD, bfd.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "bgp", f.BGP, func() collector.RPCCollector {
 		return bgp.NewCollector(c.logicalSystem)
 	})

--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,7 @@ type FeatureConfig struct {
 	NAT                 bool `yaml:"nat,omitempty"`
 	NAT2                bool `yaml:"nat2,omitempty"`
 	L2Circuit           bool `yaml:"l2circuit,omitempty"`
+	LACP                bool `yaml:"lacp,omitempty"`
 	LDP                 bool `yaml:"ldp,omitempty"`
 	Routes              bool `yaml:"routes,omitempty"`
 	RoutingEngine       bool `yaml:"routing_engine,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type DeviceConfig struct {
 type FeatureConfig struct {
 	Alarm               bool `yaml:"alarm,omitempty"`
 	Environment         bool `yaml:"environment,omitempty"`
+	BFD                 bool `yaml:"bfd,omitempty"`
 	BGP                 bool `yaml:"bgp,omitempty"`
 	OSPF                bool `yaml:"ospf,omitempty"`
 	ISIS                bool `yaml:"isis,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,7 @@ type FeatureConfig struct {
 	System              bool `yaml:"system,omitempty"`
 	Power               bool `yaml:"power,omitempty"`
 	MAC                 bool `yaml:"mac,omitempty"`
+	MPLS_LSP            bool `yaml:"mpls_lsp,omitempty"`
 	VPWS                bool `yaml:"vpws,omitempty"`
 	VRRP                bool `yaml:"vrrp,omitempty"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,7 @@ type FeatureConfig struct {
 	System              bool `yaml:"system,omitempty"`
 	Power               bool `yaml:"power,omitempty"`
 	MAC                 bool `yaml:"mac,omitempty"`
+	VPWS                bool `yaml:"vpws,omitempty"`
 	VRRP                bool `yaml:"vrrp,omitempty"`
 }
 

--- a/environment/collector.go
+++ b/environment/collector.go
@@ -89,7 +89,7 @@ func (c *environmentCollector) environmentItems(client *rpc.Client, ch chan<- pr
 	// gather satellite data
 	if client.Satellite {
 		var y = RpcReply{}
-		err = client.RunCommandAndParseWithParser("show chassis environment satellite", func(b []byte) error {
+		err = client.RunCommandAndParseWithParser("<get-chassis-environment-satellite-information/>", func(b []byte) error {
 			if string(b[:]) == "\nerror: syntax error, expecting <command>: satellite\n" {
 				log.Printf("system doesn't seem to have satellite enabled")
 				return nil

--- a/environment/collector.go
+++ b/environment/collector.go
@@ -78,7 +78,8 @@ func (c *environmentCollector) environmentItems(client *rpc.Client, ch chan<- pr
 		"Present": 5,
 	}
 
-	err := client.RunCommandAndParseWithParser("show chassis environment", func(b []byte) error {
+//	err := client.RunCommandAndParseWithParser("show chassis environment", func(b []byte) error {
+	err := client.RunCommandAndParseWithParser("<get-environment-information/>", func(b []byte) error {
 		return parseXML(b, &x)
 	})
 	if err != nil {
@@ -132,7 +133,8 @@ func (c *environmentCollector) environmentPEMItems(client *rpc.Client, ch chan<-
 		"Empty":   3,
 	}
 
-	err := client.RunCommandAndParseWithParser("show chassis environment pem", func(b []byte) error {
+//	err := client.RunCommandAndParseWithParser("show chassis environment pem", func(b []byte) error {
+	err := client.RunCommandAndParseWithParser("<get-environment-pem-information/>", func(b []byte) error {
 		return parseXML(b, &x)
 	})
 	if err != nil {

--- a/firewall/collector.go
+++ b/firewall/collector.go
@@ -49,7 +49,7 @@ func (*firewallCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *firewallCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = FirewallRpc{}
 //	err := client.RunCommandAndParse("show firewall filter regex .*", &x)
-	err := client.RunCommandAndParse("<get-firewall-filter-regex-information><filtername>.*</filtername><get-firewall-filter-regex-information/>", &x)
+	err := client.RunCommandAndParse("<get-firewall-filter-regex-information><filtername>.*</filtername></get-firewall-filter-regex-information>", &x)
 	if err != nil {
 		return err
 	}

--- a/firewall/collector.go
+++ b/firewall/collector.go
@@ -48,7 +48,8 @@ func (*firewallCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect collects metrics from JunOS
 func (c *firewallCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = FirewallRpc{}
-	err := client.RunCommandAndParse("show firewall filter regex .*", &x)
+//	err := client.RunCommandAndParse("show firewall filter regex .*", &x)
+	err := client.RunCommandAndParse("<get-firewall-filter-regex-information><filtername>.*</filtername><get-firewall-filter-regex-information/>", &x)
 	if err != nil {
 		return err
 	}

--- a/fpc/collector.go
+++ b/fpc/collector.go
@@ -100,7 +100,8 @@ func (c *fpcCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, 
 // CollectFPC collects metrics from JunOS
 func (c *fpcCollector) CollectFPCDetail(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	r := RpcReply{}
-	err := client.RunCommandAndParseWithParser("show chassis fpc detail", func(b []byte) error {
+//	err := client.RunCommandAndParseWithParser("show chassis fpc detail", func(b []byte) error {
+	err := client.RunCommandAndParseWithParser("<get-fpc-information><detail/></get-fpc-information>", func(b []byte) error {
 		return parseXML(b, &r)
 	})
 

--- a/fpc/collector.go
+++ b/fpc/collector.go
@@ -122,7 +122,8 @@ func (c *fpcCollector) CollectFPCDetail(client *rpc.Client, ch chan<- prometheus
 // Collect collects metrics from JunOS
 func (c *fpcCollector) CollectFPC(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	r := RpcReply{}
-	err := client.RunCommandAndParseWithParser("show chassis fpc", func(b []byte) error {
+//	err := client.RunCommandAndParseWithParser("show chassis fpc", func(b []byte) error {
+	err := client.RunCommandAndParseWithParser("<get-fpc-information/>", func(b []byte) error {
 		return parseXML(b, &r)
 	})
 	if err != nil {
@@ -140,7 +141,8 @@ func (c *fpcCollector) CollectFPC(client *rpc.Client, ch chan<- prometheus.Metri
 
 func (c *fpcCollector) CollectPIC(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	r := RpcReply{}
-	err := client.RunCommandAndParseWithParser("show chassis fpc pic-status", func(b []byte) error {
+//	err := client.RunCommandAndParseWithParser("show chassis fpc pic-status", func(b []byte) error {
+	err := client.RunCommandAndParseWithParser("<get-pic-information/>", func(b []byte) error {
 		return parseXML(b, &r)
 	})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 )
 
 require (
+	github.com/Juniper/go-netconf v0.1.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -21,6 +22,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/ziutek/telnet v0.0.0-20180329124119-c3b780dc415b // indirect
 	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
 	google.golang.org/protobuf v1.26.0-rc.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/Juniper/go-netconf v0.1.1 h1:5fx/T7L2Fwq51UnESPOP1CXgGCs7IYxR/pnyC5quu/k=
+github.com/Juniper/go-netconf v0.1.1/go.mod h1:2Fy6tQTWnL//D/Ll1hb0RYXN4jndcTyneRn6xj5E1VE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -97,6 +99,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/ziutek/telnet v0.0.0-20180329124119-c3b780dc415b h1:VfPXB/wCGGt590QhD1bOpv2J/AmC/RJNTg/Q59HKSB0=
+github.com/ziutek/telnet v0.0.0-20180329124119-c3b780dc415b/go.mod h1:IZpXDfkJ6tWD3PhBK5YzgQT+xJWh7OsdwiG8hA2MkO4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/interfacediagnostics/collector.go
+++ b/interfacediagnostics/collector.go
@@ -280,7 +280,8 @@ func (c *interfaceDiagnosticsCollector) interfaceDiagnosticsSatellite(client *rp
 	//  </rpc-reply>
 
 	// workaround: go through all lines of the XML and remove identical, consecutive lines
-	err := client.RunCommandAndParseWithParser("show interfaces diagnostics optics satellite", func(b []byte) error {
+//	err := client.RunCommandAndParseWithParser("show interfaces diagnostics optics satellite", func(b []byte) error {
+	err := client.RunCommandAndParseWithParser("<show-interface-optics-diagnostics-satellite/>", func(b []byte) error {
 		var (
 			lines     []string = strings.Split(string(b[:]), "\n")
 			lineIndex int

--- a/interfacediagnostics/collector.go
+++ b/interfacediagnostics/collector.go
@@ -255,7 +255,8 @@ func (c *interfaceDiagnosticsCollector) Collect(client *rpc.Client, ch chan<- pr
 
 func (c *interfaceDiagnosticsCollector) interfaceDiagnostics(client *rpc.Client) ([]*InterfaceDiagnostics, error) {
 	var x = InterfaceDiagnosticsRPC{}
-	err := client.RunCommandAndParse("show interfaces diagnostics optics", &x)
+//	err := client.RunCommandAndParse("show interfaces diagnostics optics", &x)
+	err := client.RunCommandAndParse("<get-interface-optics-diagnostics-information/>", &x)
 	if err != nil {
 		return nil, err
 	}

--- a/interfacelabels/dynamic_labels.go
+++ b/interfacelabels/dynamic_labels.go
@@ -47,7 +47,7 @@ type interfaceLabel struct {
 // CollectDescriptions collects labels from descriptions
 func (l *DynamicLabels) CollectDescriptions(device *connector.Device, client *rpc.Client, ifDescReg *regexp.Regexp) error {
 	r := &InterfaceRPC{}
-	err := client.RunCommandAndParse("show interfaces descriptions", r)
+	err := client.RunCommandAndParse("<get-interface-information/>", r)
 	if err != nil {
 		return errors.Wrap(err, "could not retrieve interface descriptions for "+device.Host)
 	}

--- a/interfacelabels/dynamic_labels.go
+++ b/interfacelabels/dynamic_labels.go
@@ -47,7 +47,7 @@ type interfaceLabel struct {
 // CollectDescriptions collects labels from descriptions
 func (l *DynamicLabels) CollectDescriptions(device *connector.Device, client *rpc.Client, ifDescReg *regexp.Regexp) error {
 	r := &InterfaceRPC{}
-	err := client.RunCommandAndParse("<get-interface-information/>", r)
+	err := client.RunCommandAndParse("<get-interface-information><descriptions/></get-interface-information>", r)
 	if err != nil {
 		return errors.Wrap(err, "could not retrieve interface descriptions for "+device.Host)
 	}

--- a/interfacequeue/collector.go
+++ b/interfacequeue/collector.go
@@ -101,7 +101,8 @@ func (c *interfaceQueueCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *interfaceQueueCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	q := InterfaceQueueRPC{}
 
-	err := client.RunCommandAndParse("show interfaces queue", &q)
+//	err := client.RunCommandAndParse("show interfaces queue", &q)
+	err := client.RunCommandAndParse("<get-interface-queue-information/>", &q)
 	if err != nil {
 		return err
 	}

--- a/interfaces/collector.go
+++ b/interfaces/collector.go
@@ -146,7 +146,8 @@ func (c *interfaceCollector) Collect(client *rpc.Client, ch chan<- prometheus.Me
 
 func (c *interfaceCollector) interfaceStats(client *rpc.Client) ([]*InterfaceStats, error) {
 	var x = InterfaceRpc{}
-	err := client.RunCommandAndParse("show interfaces extensive", &x)
+//	err := client.RunCommandAndParse("show interfaces extensive", &x)
+	err := client.RunCommandAndParse("<get-interface-information><extensive/></get-interface-information>", &x)
 	if err != nil {
 		return nil, err
 	}

--- a/ipsec/collector.go
+++ b/ipsec/collector.go
@@ -49,7 +49,8 @@ func (*ipsecCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect collects metrics from JunOS
 func (c *ipsecCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = RpcReply{}
-	err := client.RunCommandAndParse("show security ipsec security-associations", &x)
+//	err := client.RunCommandAndParse("show security ipsec security-associations", &x)
+	err := client.RunCommandAndParse("<get-security-associations-information/>", &x)
 	if err != nil {
 		return err
 	}
@@ -64,7 +65,8 @@ func (c *ipsecCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric
 	}
 
 	var conf = ConfigurationSecurityIpsec{}
-	err = client.RunCommandAndParse("show configuration security ipsec", &conf)
+//	err = client.RunCommandAndParse("show configuration security ipsec", &conf)
+	err = client.RunCommandAndParse("<get-configuration><filter type='sub-tree'><security><ipsec></ipsec></security></filter></get-configuration>", &conf)
 	if err != nil {
 		return err
 	}

--- a/ipsec/collector.go
+++ b/ipsec/collector.go
@@ -66,7 +66,7 @@ func (c *ipsecCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric
 
 	var conf = ConfigurationSecurityIpsec{}
 //	err = client.RunCommandAndParse("show configuration security ipsec", &conf)
-	err = client.RunCommandAndParse("<get-configuration><filter type='sub-tree'><security><ipsec></ipsec></security></filter></get-configuration>", &conf)
+	err = client.RunCommandAndParse("<get-config><source><running/></source><filter type='subtree'><configuration><security><ipsec></ipsec></security></configuration></filter></get-config>", &conf)
 	if err != nil {
 		return err
 	}

--- a/isis/collector.go
+++ b/isis/collector.go
@@ -56,7 +56,8 @@ func (c *isisCollector) isisAdjancies(client *rpc.Client) (*IsisAdjacencies, err
 	total := 0
 
 	var x = IsisRpc{}
-	err := client.RunCommandAndParse("show isis adjacency", &x)
+//	err := client.RunCommandAndParse("show isis adjacency", &x)
+	err := client.RunCommandAndParse("<get-isis-adjacency-information/>", &x)
 	if err != nil {
 		return nil, err
 	}

--- a/l2circuit/collector.go
+++ b/l2circuit/collector.go
@@ -78,7 +78,8 @@ func (c *l2circuitCollector) Collect(client *rpc.Client, ch chan<- prometheus.Me
 
 func (c *l2circuitCollector) collectL2circuitMetrics(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = L2circuitRpc{}
-	err := client.RunCommandAndParse("show l2circuit connections brief", &x)
+//	err := client.RunCommandAndParse("show l2circuit connections brief", &x)
+	err := client.RunCommandAndParse("<get-l2ckt-connection-information><brief/></get-l2ckt-connection-information>", &x)
 	if err != nil {
 		return err
 	}

--- a/lacp/collector.go
+++ b/lacp/collector.go
@@ -1,0 +1,65 @@
+package lacp
+
+import (
+	"github.com/czerwonk/junos_exporter/collector"
+	"github.com/czerwonk/junos_exporter/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix = "junos_lacp_"
+
+var (
+	lacpMuxState    *prometheus.Desc
+	lacpMuxStateMap = map[string]int{
+	"Detached":                  1,
+	"Waiting":                   2,
+	"Attached":                  3,
+	"Collecting":                4,
+	"Distributing":              5,
+	"Collecting distributing":   6,
+}
+)
+
+func init() {
+	l := []string{"target", "name", "member"}
+	lacpMuxState = prometheus.NewDesc(prefix+"muxstate", "lacp mux state (1: detached, 2: waiting, 3: attached, 4: collecting, 5: distributing, 6: collecting distribuging)", l, nil)
+}
+
+type lacpCollector struct {
+}
+
+// Name returns the name of the collector
+func (*lacpCollector) Name() string {
+	return "lacp"
+}
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector {
+	return &lacpCollector{}
+}
+
+// Describe describes the metrics
+func (*lacpCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- lacpMuxState
+}
+
+
+// Collect collects metrics from JunOS
+func (c *lacpCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+        var x = lacpRpc{}
+        err := client.RunCommandAndParse("show lacp interfaces", &x)
+	if err != nil {
+		return err
+	}
+
+	for _, iface := range x.Information.LacpInterfaces {
+
+                for _, member := range iface.LagLacpProtocols {
+                    l := append(labelValues, iface.LagLacpHeader.Name, member.Member)
+                    ch <- prometheus.MustNewConstMetric(lacpMuxState, prometheus.GaugeValue, float64(lacpMuxStateMap[member.LacpMuxState]), l...)
+                }
+
+	}
+
+	return nil
+}

--- a/lacp/collector.go
+++ b/lacp/collector.go
@@ -47,7 +47,8 @@ func (*lacpCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect collects metrics from JunOS
 func (c *lacpCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
         var x = lacpRpc{}
-        err := client.RunCommandAndParse("show lacp interfaces", &x)
+//        err := client.RunCommandAndParse("show lacp interfaces", &x)
+        err := client.RunCommandAndParse("<get-lacp-interface-information/>", &x)
 	if err != nil {
 		return err
 	}

--- a/lacp/rpc.go
+++ b/lacp/rpc.go
@@ -1,0 +1,25 @@
+package lacp
+
+type lacpRpc struct {
+	Information struct {
+		LacpInterfaces []lacpInterface `xml:"lacp-interface-information"`
+	} `xml:"lacp-interface-information-list"`
+}
+
+type lacpInterface struct {
+	LagLacpHeader struct {
+		Name         string `xml:"aggregate-name"`
+        } `xml:"lag-lacp-header"`
+	LagLacpStates        []LagLacpStateStruct      `xml:"lag-lacp-state"`
+	LagLacpProtocols     []LagLacpProtocolStruct   `xml:"lag-lacp-protocol"`
+}
+
+
+type LagLacpStateStruct struct{
+}
+
+type LagLacpProtocolStruct struct{
+	Member                string  `xml:"name"`
+	LacpMuxState          string  `xml:"lacp-mux-state"`
+}
+

--- a/ldp/collector.go
+++ b/ldp/collector.go
@@ -76,7 +76,8 @@ func (c *ldpCollector) collectLDPMetrics(client *rpc.Client, ch chan<- prometheu
 
 func (c *ldpCollector) collectLDPSessions(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = LDPSessionRpc{}
-	err := client.RunCommandAndParse("show ldp session", &x)
+//	err := client.RunCommandAndParse("show ldp session", &x)
+	err := client.RunCommandAndParse("<get-ldp-session-information/>", &x)
 	if err != nil {
 		return err
 	}

--- a/ldp/collector.go
+++ b/ldp/collector.go
@@ -62,7 +62,8 @@ func (c *ldpCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, 
 
 func (c *ldpCollector) collectLDPMetrics(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = LDPRpc{}
-	err := client.RunCommandAndParse("show ldp neighbor", &x)
+//	err := client.RunCommandAndParse("show ldp neighbor", &x)
+	err := client.RunCommandAndParse("<get-ldp-session-information/>", &x)
 	if err != nil {
 		return err
 	}

--- a/mac/collector.go
+++ b/mac/collector.go
@@ -47,7 +47,8 @@ func (*macCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect collects metrics from JunOS
 func (c *macCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = MacRpc{}
-	err := client.RunCommandAndParse("show ethernet-switching table summary", &x)
+//	err := client.RunCommandAndParse("show ethernet-switching table summary", &x)
+	err := client.RunCommandAndParse("<get-ethernet-switching-table-information><summary/></get-ethernet-switching-table-information>", &x)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ var (
 	interfaceDescriptionRegex   = flag.String("interface-description-regex", "", "give a regex to retrieve the interface description labels")
 	lsEnabled                   = flag.Bool("logical-systems.enabled", false, "Enable logical systems support")
 	powerEnabled                = flag.Bool("power.enabled", true, "Scrape power metrics")
+	lacpEnabled                 = flag.Bool("lacp.enabled", true, "Scrape lacp metrics")
 	cfg                         *config.Config
 	devices                     []*connector.Device
 	connManager                 *connector.SSHConnectionManager

--- a/main.go
+++ b/main.go
@@ -225,7 +225,6 @@ func loadConfigFromFlags() *config.Config {
 func connectionManager() *connector.SSHConnectionManager {
 	opts := []connector.Option{
 		connector.WithReconnectInterval(*sshReconnectInterval),
-		connector.WithKeepAliveInterval(*sshKeepAliveInterval),
 		connector.WithKeepAliveTimeout(*sshKeepAliveTimeout),
 	}
 

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ var (
 	lsEnabled                   = flag.Bool("logical-systems.enabled", false, "Enable logical systems support")
 	powerEnabled                = flag.Bool("power.enabled", true, "Scrape power metrics")
 	lacpEnabled                 = flag.Bool("lacp.enabled", true, "Scrape lacp metrics")
+	bfdEnabled                  = flag.Bool("bfd.enabled", true, "Scrape bfd metrics")
 	cfg                         *config.Config
 	devices                     []*connector.Device
 	connManager                 *connector.SSHConnectionManager

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ var (
 	lacpEnabled                 = flag.Bool("lacp.enabled", true, "Scrape lacp metrics")
 	bfdEnabled                  = flag.Bool("bfd.enabled", true, "Scrape bfd metrics")
 	vpwsEnabled                 = flag.Bool("vpws.enabled", true, "Scrape evpn vpws metrics")
+	mpls_lspEnabled             = flag.Bool("mpls_lsp.enabled", true, "Scrape mpls LSP metrics")
 	cfg                         *config.Config
 	devices                     []*connector.Device
 	connManager                 *connector.SSHConnectionManager

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ var (
 	powerEnabled                = flag.Bool("power.enabled", true, "Scrape power metrics")
 	lacpEnabled                 = flag.Bool("lacp.enabled", true, "Scrape lacp metrics")
 	bfdEnabled                  = flag.Bool("bfd.enabled", true, "Scrape bfd metrics")
+	vpwsEnabled                 = flag.Bool("vpws.enabled", true, "Scrape evpn vpws metrics")
 	cfg                         *config.Config
 	devices                     []*connector.Device
 	connManager                 *connector.SSHConnectionManager

--- a/mpls_lsp/collector.go
+++ b/mpls_lsp/collector.go
@@ -51,7 +51,8 @@ func (*mpls_lspCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect collects metrics from JunOS
 func (c *mpls_lspCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
         var x = mpls_lspRpc{}
-        err := client.RunCommandAndParse("show mpls lsp ingress extensive", &x) //ingress:Display LSPs originating at this router
+//        err := client.RunCommandAndParse("show mpls lsp ingress extensive", &x) //ingress:Display LSPs originating at this router
+        err := client.RunCommandAndParse("<get-mpls-lsp-information><ingress/><extensive/></get-mpls-lsp-information>", &x) //ingress:Display LSPs originating at this router
 	if err != nil {
 		return err
 	}

--- a/mpls_lsp/collector.go
+++ b/mpls_lsp/collector.go
@@ -1,0 +1,71 @@
+package mpls_lsp
+
+import (
+	"github.com/czerwonk/junos_exporter/collector"
+	"github.com/czerwonk/junos_exporter/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix = "junos_mpls_lsp_"
+
+var (
+	mpls_lspState            *prometheus.Desc
+	mpls_lspPathState        *prometheus.Desc
+	mpls_lspPathFlapCount    *prometheus.Desc
+
+	mpls_lspStateMap = map[string]int{
+	"Dn":          0,
+	"Up":          1,
+	}
+
+)
+
+func init() {
+	ls := []string{"target", "lspname", "lspsrc", "lspdst" }
+	mpls_lspState = prometheus.NewDesc(prefix+"state", "mpls_lsp state (0: down, 1:up)", ls, nil)
+
+	lps := []string{"target", "lspname", "lspsrc", "lspdst", "title", "name"}
+	mpls_lspPathState = prometheus.NewDesc(prefix+"path_state", "mpls_lsp pathstate (0: down, 1:up)", lps, nil)
+	mpls_lspPathFlapCount = prometheus.NewDesc(prefix+"path_flapcount", "mpls_lsp path flap count", lps, nil)
+}
+
+type mpls_lspCollector struct {
+}
+
+// Name returns the name of the collector
+func (*mpls_lspCollector) Name() string {
+	return "mpls_lsp"
+}
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector {
+	return &mpls_lspCollector{}
+}
+
+// Describe describes the metrics
+func (*mpls_lspCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- mpls_lspState
+}
+
+
+// Collect collects metrics from JunOS
+func (c *mpls_lspCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+        var x = mpls_lspRpc{}
+        err := client.RunCommandAndParse("show mpls lsp ingress extensive", &x) //ingress:Display LSPs originating at this router
+	if err != nil {
+		return err
+	}
+
+	for _, lsp := range x.Information.Sessions {
+                l := append(labelValues, lsp.Name, lsp.SrcIP, lsp.DstIP)
+                ch <- prometheus.MustNewConstMetric(mpls_lspState, prometheus.GaugeValue, float64(mpls_lspStateMap[lsp.LSPState]), l...)
+
+		for _, path := range lsp.Path {
+	                l := append(labelValues, lsp.Name, lsp.SrcIP, lsp.DstIP, path.Title, path.Name)
+	                ch <- prometheus.MustNewConstMetric(mpls_lspPathState, prometheus.GaugeValue, float64(mpls_lspStateMap[path.State]), l...)
+	                ch <- prometheus.MustNewConstMetric(mpls_lspPathFlapCount, prometheus.GaugeValue, float64(path.FlapCount), l...)
+		}
+	}
+
+	return nil
+}

--- a/mpls_lsp/rpc.go
+++ b/mpls_lsp/rpc.go
@@ -1,0 +1,24 @@
+package mpls_lsp
+
+type mpls_lspRpc struct {
+	Information struct {
+		Sessions []mpls_lspSession `xml:"rsvp-session"`
+	} `xml:"mpls-lsp-information>rsvp-session-data"`
+}
+
+type mpls_lspSession struct {
+	DstIP              string    `xml:"mpls-lsp>destination-address"`
+	SrcIP              string    `xml:"mpls-lsp>source-address"`
+	LSPState           string    `xml:"mpls-lsp>lsp-state"`
+	Name               string    `xml:"mpls-lsp>name"`
+
+	Path               []mpls_lspPath  `xml:"mpls-lsp>mpls-lsp-path"`
+}
+
+type mpls_lspPath struct {
+	Title             string    `xml:"title"`
+	Name              string    `xml:"name"`
+	State             string    `xml:"path-state"`
+	FlapCount         int64     `xml:"path-flap-count"`
+}
+

--- a/nat/collector.go
+++ b/nat/collector.go
@@ -506,7 +506,8 @@ func (c *natCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, 
 
 func (c *natCollector) NatInterfaces(client *rpc.Client) ([]*NatInterface, error) {
 	var x = NatRpc{}
-	err := client.RunCommandAndParse("show services nat statistics", &x)
+//	err := client.RunCommandAndParse("show services nat statistics", &x)
+	err := client.RunCommandAndParse("<get-service-nat-statistics-information/>", &x)
 	if err != nil {
 		return nil, err
 	}

--- a/nat2/collector.go
+++ b/nat2/collector.go
@@ -321,7 +321,8 @@ func (*natCollector) collectForInterface(s *NatInterface, ch chan<- prometheus.M
 
 func (c *natCollector) SrcNatPools(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) ([]SrcNatPool, error) {
 	var x = SrcNatPoolRpc{}
-	err := client.RunCommandAndParse("show services nat source pool all", &x)
+//	err := client.RunCommandAndParse("show services nat source pool all", &x)
+	err := client.RunCommandAndParse("<retrieve-srv-source-nat-pool-information><all/></retrieve-srv-source-nat-pool-information>", &x)
 	if err != nil {
 		return nil, err
 	}
@@ -393,7 +394,8 @@ func (c *natCollector) collectForSrcNatPool(s []SrcNatPool, ch chan<- prometheus
 
 func (c *natCollector) ServiceSetsCpuInterfaces(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) ([]*ServiceSetsCpuInterface, error) {
 	var x = ServiceSetsCpuRpc{}
-	err := client.RunCommandAndParse("show services service-sets cpu-usage", &x)
+//	err := client.RunCommandAndParse("show services service-sets cpu-usage", &x)
+	err := client.RunCommandAndParse("<get-service-set-cpu-statistics/>", &x)
 	if err != nil {
 		return nil, err
 	}

--- a/nat2/collector.go
+++ b/nat2/collector.go
@@ -225,7 +225,8 @@ func (c *natCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, 
 
 func (c *natCollector) NatInterfaces(client *rpc.Client) ([]*NatInterface, error) {
 	var x = NatRpc{}
-	err := client.RunCommandAndParse("show services nat statistics", &x)
+//	err := client.RunCommandAndParse("show services nat statistics", &x)
+	err := client.RunCommandAndParse("<get-service-nat-statistics-information/>", &x)
 	if err != nil {
 		return nil, err
 	}

--- a/ospf/collector.go
+++ b/ospf/collector.go
@@ -64,10 +64,12 @@ func (c *ospfCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric,
 func (c *ospfCollector) collectOSPFMetrics(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = OspfRpc{}
 	var cmd strings.Builder
-	cmd.WriteString("show ospf overview")
-	if c.LogicalSystem != "" {
-		cmd.WriteString(" logical-system " + c.LogicalSystem)
-	}
+//	cmd.WriteString("show ospf overview")
+//	cmd.WriteString("show ospf overview")
+//	if c.LogicalSystem != "" {
+//		cmd.WriteString(" logical-system " + c.LogicalSystem)
+//	}
+	cmd.WriteString("<get-ospf-overview-information/>")
 
 	err := client.RunCommandAndParse(cmd.String(), &x)
 	if err != nil {

--- a/ospf/collector.go
+++ b/ospf/collector.go
@@ -96,10 +96,11 @@ func (c *ospfCollector) collectOSPFMetrics(client *rpc.Client, ch chan<- prometh
 func (c *ospfCollector) collectOSPFv3Metrics(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = Ospf3Rpc{}
 	var cmd strings.Builder
-	cmd.WriteString("show ospf3 overview")
-	if c.LogicalSystem != "" {
-		cmd.WriteString(" logical-system " + c.LogicalSystem)
-	}
+//	cmd.WriteString("show ospf3 overview")
+	cmd.WriteString("<get-ospf3-overview-information/>")
+//	if c.LogicalSystem != "" {
+//		cmd.WriteString(" logical-system " + c.LogicalSystem)
+//	}
 
 	err := client.RunCommandAndParse(cmd.String(), &x)
 	if err != nil {

--- a/power/collector.go
+++ b/power/collector.go
@@ -88,7 +88,8 @@ func (c *powerCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric
 	}
 
 	var x = RpcReply{}
-	err := client.RunCommandAndParseWithParser("show chassis power", func(b []byte) error {
+//	err := client.RunCommandAndParseWithParser("show chassis power", func(b []byte) error {
+	err := client.RunCommandAndParseWithParser("<get-power-usage-information/>", func(b []byte) error {
 		return parseXML(b, &x)
 	})
 	if err != nil {

--- a/route/collector.go
+++ b/route/collector.go
@@ -52,7 +52,8 @@ func (*routeCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect collects metrics from JunOS
 func (c *routeCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = RouteRpc{}
-	err := client.RunCommandAndParse("show route summary", &x)
+//	err := client.RunCommandAndParse("show route summary", &x)
+	err := client.RunCommandAndParse("<get-route-summary-information/>", &x)
 	if err != nil {
 		return err
 	}

--- a/routingengine/collector.go
+++ b/routingengine/collector.go
@@ -168,7 +168,8 @@ func (*routingEngineCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect collects metrics from JunOS
 func (c *routingEngineCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = RpcReply{}
-	err := client.RunCommandAndParseWithParser("show chassis routing-engine", func(b []byte) error {
+//	err := client.RunCommandAndParseWithParser("show chassis routing-engine", func(b []byte) error {
+	err := client.RunCommandAndParseWithParser("<get-route-engine-information/>", func(b []byte) error {
 		return parseXML(b, &x)
 	})
 	if err != nil {

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"encoding/xml"
-	"fmt"
 
 	"log"
 
@@ -41,7 +40,7 @@ func (c *Client) RunCommandAndParseWithParser(cmd string, parser Parser) error {
 		log.Printf("Running command on %s: %s\n", c.conn.Host(), cmd)
 	}
 
-	b, err := c.conn.RunCommand(fmt.Sprintf("%s | display xml", cmd))
+	b, err := c.conn.RunCommand(cmd)
 	if err != nil {
 		return err
 	}

--- a/rpc/rpc_client.go
+++ b/rpc/rpc_client.go
@@ -2,7 +2,7 @@ package rpc
 
 import (
 	"encoding/xml"
-
+	"bytes"
 	"log"
 
 	"github.com/czerwonk/junos_exporter/connector"
@@ -30,7 +30,8 @@ func NewClient(ssh *connector.SSHConnection) *Client {
 // RunCommandAndParse runs a command on JunOS and unmarshals the XML result
 func (c *Client) RunCommandAndParse(cmd string, obj interface{}) error {
 	return c.RunCommandAndParseWithParser(cmd, func(b []byte) error {
-		return xml.Unmarshal(b, obj)
+		//in junos the xml interfaces contains line returns in the values
+		return xml.Unmarshal(bytes.ReplaceAll(b, []byte("\n"), []byte("")), obj)
 	})
 }
 

--- a/rpki/collector.go
+++ b/rpki/collector.go
@@ -79,7 +79,8 @@ func (c *rpkiCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric,
 
 func (c *rpkiCollector) collectSessions(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = RpkiSessionRpc{}
-	err := client.RunCommandAndParse("show validation session", &x)
+//	err := client.RunCommandAndParse("show validation session", &x)
+	err := client.RunCommandAndParse("<get-validation-session-information/>", &x)
 	if err != nil {
 		return err
 	}
@@ -129,7 +130,8 @@ func (c *rpkiCollector) collectForSession(s RpkiSession, ch chan<- prometheus.Me
 func (c *rpkiCollector) collectStatistics(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = RpkiStatisticsRpc{}
 
-	err := client.RunCommandAndParse("show validation statistics", &x)
+//	err := client.RunCommandAndParse("show validation statistics", &x)
+	err := client.RunCommandAndParse("<get-validation-statistics-information/>", &x)
 	if err != nil {
 		return err
 	}

--- a/rpm/collector.go
+++ b/rpm/collector.go
@@ -68,7 +68,8 @@ func (c *rpmCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, 
 func (c *rpmCollector) collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = RPMRPC{}
 
-	err := client.RunCommandAndParse("show services rpm probe-results", &x)
+//	err := client.RunCommandAndParse("show services rpm probe-results", &x)
+	err := client.RunCommandAndParse("<get-probe-results/>", &x)
 	if err != nil {
 		return err
 	}

--- a/security/collector.go
+++ b/security/collector.go
@@ -63,7 +63,8 @@ func (*securityCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect collects metrics from JunOS
 func (c *securityCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = RpcReply{}
-	err := client.RunCommandAndParse("show security monitoring", &x)
+//	err := client.RunCommandAndParse("show security monitoring", &x)
+	err := client.RunCommandAndParse("<get-performance-summary-information/>", &x)
 	if err != nil {
 		return err
 	}

--- a/storage/collector.go
+++ b/storage/collector.go
@@ -51,7 +51,8 @@ func (*storageCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect collects metrics from JunOS
 func (c *storageCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
 	var x = RpcReply{}
-	err := client.RunCommandAndParseWithParser("show system storage", func(b []byte) error {
+//	err := client.RunCommandAndParseWithParser("show system storage", func(b []byte) error {
+	err := client.RunCommandAndParseWithParser("<get-system-storage/>", func(b []byte) error {
 		return parseXML(b, &x)
 	})
 	if err != nil {

--- a/system/collector.go
+++ b/system/collector.go
@@ -300,7 +300,8 @@ func (c *systemCollector) CollectSystem(client *rpc.Client, ch chan<- prometheus
 
 		// system information of satellites
 		r3 = new(SatelliteChassisRPC)
-		err = client.RunCommandAndParse("show chassis satellite detail", r3)
+//		err = client.RunCommandAndParse("show chassis satellite detail", r3)
+		err = client.RunCommandAndParse("<get-chassis-satellite-information><detail/></get-chassis-satellite-information>", r3)
 		// there are various error messages when satellite is not enabled; thus here we just ignore the error and continue
 		if err == nil {
 			for i = range r3.SatelliteInfo.Satellite {

--- a/system/collector.go
+++ b/system/collector.go
@@ -162,7 +162,8 @@ func (c *systemCollector) CollectSystem(client *rpc.Client, ch chan<- prometheus
 
 	r = new(BuffersRPC)
 
-	err = client.RunCommandAndParse("show system buffers", r)
+//	err = client.RunCommandAndParse("show system buffers", r)
+	err = client.RunCommandAndParse("<get-buffer-informations/>", r)
 	if err != nil {
 		return err
 	}
@@ -277,7 +278,8 @@ func (c *systemCollector) CollectSystem(client *rpc.Client, ch chan<- prometheus
 
 	// system information
 	r2 = new(SystemInformationRPC)
-	err = client.RunCommandAndParse("show system information", r2)
+//	err = client.RunCommandAndParse("show system information", r2)
+	err = client.RunCommandAndParse("<get-system-information/>", r2)
 	if err != nil {
 		return err
 	}

--- a/vpws/collector.go
+++ b/vpws/collector.go
@@ -1,0 +1,82 @@
+package vpws
+
+import (
+	"github.com/czerwonk/junos_exporter/collector"
+	"github.com/czerwonk/junos_exporter/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix = "junos_vpws_"
+
+var (
+	vpwsStatus    *prometheus.Desc
+	vpwsSid    *prometheus.Desc
+
+	vpwsStatusMap = map[string]int{
+	"Down":          0,
+	"Up":      1,
+	}
+
+	vpwsSidMap = map[string]int{
+	"Unresolved":          0,
+	"Resolved":      1,
+	}
+
+)
+
+func init() {
+	l := []string{"target", "vpwsinstance", "rd", "interface", "esi", "mode", "role"}
+	vpwsStatus = prometheus.NewDesc(prefix+"status", "vpws status (0: down, 1:up)", l, nil)
+
+	ls := []string{"target", "vpwsinstance", "rd", "interface", "sidorigin", "sid", "ip", "esi", "mode", "role"}
+	vpwsSid = prometheus.NewDesc(prefix+"sid", "vpws sid (0: Unresolved, 1:Resolved)", ls, nil)
+}
+
+type vpwsCollector struct {
+}
+
+// Name returns the name of the collector
+func (*vpwsCollector) Name() string {
+	return "vpws"
+}
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector {
+	return &vpwsCollector{}
+}
+
+// Describe describes the metrics
+func (*vpwsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- vpwsStatus
+	ch <- vpwsSid
+}
+
+
+// Collect collects metrics from JunOS
+func (c *vpwsCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+        var x = vpwsRpc{}
+        err := client.RunCommandAndParse("show evpn vpws-instance", &x)
+	if err != nil {
+		return err
+	}
+
+	for _, vInst := range x.Information.VpwsInstances {
+		for _, vIf := range vInst.VpwsInterfaces {
+	                l := append(labelValues, vInst.Name, vInst.RD, vIf.Name, vIf.Esi, vIf.Mode, vIf.Role  )
+	                ch <- prometheus.MustNewConstMetric(vpwsStatus, prometheus.GaugeValue, float64(vpwsStatusMap[vIf.Status]), l...)
+
+			for _, vSid := range vIf.LocalStatus.SidPeInfo {
+		                l := append(labelValues, vInst.Name, vInst.RD, vIf.Name, "local", vIf.LocalStatus.Sid, vSid.IP, vSid.Esi, vSid.Mode, vSid.Role  )
+		                ch <- prometheus.MustNewConstMetric(vpwsSid, prometheus.GaugeValue, float64(vpwsSidMap[vSid.Status]), l...)
+			}
+
+			for _, vSid := range vIf.RemoteStatus.SidPeInfo {
+		                l := append(labelValues, vInst.Name, vInst.RD, vIf.Name, "remote", vIf.RemoteStatus.Sid, vSid.IP, vSid.Esi, vSid.Mode, vSid.Role  )
+		                ch <- prometheus.MustNewConstMetric(vpwsSid, prometheus.GaugeValue, float64(vpwsSidMap[vSid.Status]), l...)
+			}
+
+		}
+	}
+
+	return nil
+}

--- a/vpws/collector.go
+++ b/vpws/collector.go
@@ -55,7 +55,8 @@ func (*vpwsCollector) Describe(ch chan<- *prometheus.Desc) {
 // Collect collects metrics from JunOS
 func (c *vpwsCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
         var x = vpwsRpc{}
-        err := client.RunCommandAndParse("show evpn vpws-instance", &x)
+//        err := client.RunCommandAndParse("show evpn vpws-instance", &x)
+        err := client.RunCommandAndParse("<get-evpn-vpws-information/>", &x)
 	if err != nil {
 		return err
 	}

--- a/vpws/rpc.go
+++ b/vpws/rpc.go
@@ -1,0 +1,48 @@
+package vpws
+
+
+type vpwsRpc struct {
+	Information struct {
+		VpwsInstances []vpwsInstance `xml:"evpn-vpws-instance"`
+	} `xml:"evpn-vpws-information"`
+}
+
+
+type vpwsInstance struct {
+	Name               string    `xml:"evpn-vpws-instance-name"`
+	RD                 string    `xml:"route-distinguisher"`
+	LocalInterfaces    int64     `xml:"local-interfaces"`
+	LocalInterfacesUp  int64     `xml:"local-interfaces-up"`
+
+	VpwsInterfaces     []vpwsInterface `xml:"evpn-vpws-interface-status-table>evpn-vpws-interface"`
+}
+
+
+
+type vpwsInterface struct {
+	Name               string     `xml:"evpn-vpws-interface-name"`
+	Esi                string     `xml:"evpn-vpws-interface-esi"`
+	Mode               string     `xml:"evpn-vpws-interface-mode"`
+	Role               string     `xml:"evpn-vpws-interface-role"`
+	Status             string     `xml:"evpn-vpws-interface-status"`
+
+	LocalStatus       struct {
+		    Sid            string     `xml:"evpn-vpws-sid-local-value"`
+		    SidPeInfo      []vpwsSidPeInfo     `xml:"evpn-vpws-sid-pe-status-table>evpn-vpws-sid-pe-info"`
+	} `xml:"evpn-vpws-service-id-local-status-table>evpn-vpws-sid-local"`
+
+	RemoteStatus       struct {
+		    Sid            string     `xml:"evpn-vpws-sid-remote-value"`
+		    SidPeInfo      []vpwsSidPeInfo     `xml:"evpn-vpws-sid-pe-status-table>evpn-vpws-sid-pe-info"`
+	} `xml:"evpn-vpws-service-id-remote-status-table>evpn-vpws-sid-remote"`
+
+}
+
+
+type vpwsSidPeInfo struct {
+	Esi                string     `xml:"evpn-vpws-sid-interface-esi"`
+	IP                 string     `xml:"evpn-vpws-sid-pe-ipaddr"`
+	Mode               string     `xml:"evpn-vpws-sid-pe-mode"`
+	Role               string     `xml:"evpn-vpws-sid-pe-role"`
+	Status             string     `xml:"evpn-vpws-sid-pe-status"`
+}

--- a/vrrp/collector.go
+++ b/vrrp/collector.go
@@ -45,7 +45,8 @@ func (c *vrrpCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric,
 	}
 
         var x = VrrpRpc{}
-        err := client.RunCommandAndParse("show vrrp summary", &x)
+//        err := client.RunCommandAndParse("show vrrp summary", &x)
+        err := client.RunCommandAndParse("<get-vrrp-information/>", &x)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request is an improvement idea, i'll run it in test for the next days, but i think it's the right way to go.

Maybe it should be integrated with an option parameter instead of replacing the ssh-cli connectivity by a ssh-netconf a so the user can choose one or another?

Also this code should be double-checked: I'm a golang newbie. I'm not sure it's correctly implemented, thinking of connection optimizations, race conditions, memory leaking, and so far, consider this change experimental quality at this stage.

I've updated 99% of them, but all "modules" should be revalidated, the "nat" commands aren't working on my routers. Also i don't have "logical systems".


The ssh-cli-xml paradigm worked nicely on MX, but when i tried to deploy it on our EX, it had terrible performance, worse than snmp: even the 'alarm' module (show chassis alarm/show system alarm) took 3 seconds to run on an EX.

The problem was the CLI piping requiring more CPU.

The obvious solution is to change the ssh by netconf, and execute the commands directly in xml-rpc which seems to be native to juniper, and produces (almost) exactly the same output without the cli overhead.
Almost because there are lots of unnecessary "\n" in the interfaces xml replies.

Performance wise: it now works correctly on EX. And about halves the polling time on MX.

To activate netconf on your device:
set system services netconf ssh port 830


To find your show command:
show command | display xml rpc

It comes out like:
<get-command/>

or for the extensive option:
<get-command><extensive/></get-command>



