### PR TITLE
remove connection and query deadlocks

### DIFF
--- a/connector/connection.go
+++ b/connector/connection.go
@@ -21,8 +21,8 @@ type SSHConnection struct {
 
 // RunCommand runs a command against the device
 func (c *SSHConnection) RunCommand(cmd string) ([]byte, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+//	c.mu.Lock()
+//	defer c.mu.Unlock()
 
 	if c.client == nil {
 		return nil, errors.New("not connected")

--- a/connector/connection_manager.go
+++ b/connector/connection_manager.go
@@ -66,8 +66,8 @@ func NewConnectionManager(opts ...Option) *SSHConnectionManager {
 
 // Connect connects to a device or returns an long living connection
 func (m *SSHConnectionManager) Connect(device *Device) (*SSHConnection, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+//	m.mu.Lock()
+//	defer m.mu.Unlock()
 
 	if connection, found := m.connections[device.Host]; found {
 		if !connection.isConnected() {


### PR DESCRIPTION
By removing these locks, i fixed one of my performance issue:
When i uses prometheus with junos_exporter on a poll rate of 1 minute with 20 devices, it worked perfectly.

But when i tried to use it with 250 devices, i had a quick rampup of non reply, devices looking unresponsive, the http://junosurl/metrics took minutes to reply with a duration metric of some seconds when the answer came.

At each prometheus/junos exporter restart, I had to make a "rampup" to bypass: adjust the polling rate&timeout at 5 minutes, waiting that every device got connected, and then change the configuration to lower the polling rate at 1 minute.

Removing those deadlocks fixed this issue for me. Especially the newconnection one.
I'm not sure why they were needed.
