### PR TITLE
change the lacp metric name/member

### DIFF
--- a/lacp/collector.go
+++ b/lacp/collector.go
@@ -21,7 +21,7 @@ var (
 )
 
 func init() {
-	l := []string{"target", "name", "member"}
+	l := []string{"target", "aggregate", "name"}
 	lacpMuxState = prometheus.NewDesc(prefix+"muxstate", "lacp mux state (1: detached, 2: waiting, 3: attached, 4: collecting, 5: distributing, 6: collecting distribuging)", l, nil)
 }
 


### PR DESCRIPTION
change the lacp metric name-member to aggregate-name so you can match the interface with other metrics

Since i need descriptions, i use it like this:
junos_lacp_muxstate * ignoring(aggregate, description, mac) group_left(description) junos_interface_up{description!~".*--IGNORE-LACP.*"} != 6

