### PR TITLE
Collect metrics on the IS-IS adjacency state

### DIFF
--- a/isis/collector.go
+++ b/isis/collector.go
@@ -21,7 +21,7 @@ func init() {
 	upCount = prometheus.NewDesc(prefix+"up_count", "Number of ISIS Adjacencies in state up", l, nil)
 	totalCount = prometheus.NewDesc(prefix+"total_count", "Number of ISIS Adjacencies", l, nil)
 	l = append(l, "interface_name", "sysem_name", "level")
-	adjState = prometheus.NewDesc(prefix+"adjacency_state", "The ISIS Adjacency state (1 = UP, 0 = DOWN)", l, nil)
+	adjState = prometheus.NewDesc(prefix+"adjacency_state", "The ISIS Adjacency state (0 = DOWN, 1 = UP, 2 = NEW, 3 = ONE-WAY, 4 =INITIALIZING , 5 = REJECTED)", l, nil)
 }
 
 type isisCollector struct {

--- a/isis/collector.go
+++ b/isis/collector.go
@@ -56,8 +56,19 @@ func (c *isisCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric,
 		for _, adj := range adjancies.Adjacencies {
 			localLabelvalues := append(labelValues, adj.InterfaceName, adj.SystemName, strconv.Itoa(int(adj.Level)))
 			state := 0.0
-			if adj.AdjacencyState == "Up" {
+			switch adj.AdjacencyState {
+			case "Down":
+				state = 0.0
+			case "Up":
 				state = 1.0
+			case "New":
+				state = 2.0
+			case "One-way":
+				state = 3.0
+			case "Initializing":
+				state = 4.0
+			case "Rejected":
+				state = 5.0
 			}
 			ch <- prometheus.MustNewConstMetric(adjState, prometheus.GaugeValue, state, localLabelvalues...)
 		}

--- a/isis/isis_adjacencies.go
+++ b/isis/isis_adjacencies.go
@@ -1,6 +1,7 @@
 package isis
 
 type IsisAdjacencies struct {
-	Up    float64
-	Total float64
+	Up          float64
+	Total       float64
+	Adjacencies []IsisAdjacenciesRpc
 }


### PR DESCRIPTION
The current IS-IS metrics only provide the total counters, i.e., number
of adjacencies and how many are up. This is great for a dashboard-like
approach, but insufficient when you need to look into a more granular
per-adjacency, for example for alerting.
Adding a new ``junos_isis_adjacency_state`` metrics family that provide
the adjacency state.
Closes https://github.com/czerwonk/junos_exporter/issues/113.