### PR TITLE
Add security_policies module for SRX policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The following metrics are supported by now:
 * Routing engine statistics
 * Storage (total, available and used blocks, used percentage)
 * Firewall filters (counters and policers) - needs explicit rights beyond read-only
+* Security policy (SRX) statistics
 * Statistics about l2circuits (tunnel state, number of tunnels)
 * Interface queue statistics
 * Power (Power usage)

--- a/collectors.go
+++ b/collectors.go
@@ -31,6 +31,7 @@ import (
 	"github.com/czerwonk/junos_exporter/rpki"
 	"github.com/czerwonk/junos_exporter/rpm"
 	"github.com/czerwonk/junos_exporter/security"
+	"github.com/czerwonk/junos_exporter/security_policies"
 	"github.com/czerwonk/junos_exporter/storage"
 	"github.com/czerwonk/junos_exporter/system"
 	"github.com/czerwonk/junos_exporter/vrrp"
@@ -101,6 +102,7 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device) {
 	c.addCollectorIfEnabledForDevice(device, "rpki", f.RPKI, rpki.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "rpm", f.RPM, rpm.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "security", f.Security, security.NewCollector)
+	c.addCollectorIfEnabledForDevice(device, "security_policies", f.SecurityPolicies, security_policies.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "storage", f.Storage, storage.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "system", f.System, system.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "power", f.Power, power.NewCollector)

--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,7 @@ type FeatureConfig struct {
 	Accounting          bool `yaml:"accounting,omitempty"`
 	IPSec               bool `yaml:"ipsec,omitempty"`
 	Security            bool `yaml:"security,omitempty"`
+	SecurityPolicies    bool `yaml:"security_policies,omitempty"`
 	FPC                 bool `yaml:"fpc,omitempty"`
 	RPKI                bool `yaml:"rpki,omitempty"`
 	RPM                 bool `yaml:"rpm,omitempty"`
@@ -120,6 +121,7 @@ func setDefaultValues(c *Config) {
 	f.Firewall = true
 	f.RoutingEngine = true
 	f.Security = false
+	f.SecurityPolicies = false
 	f.Storage = false
 	f.Accounting = false
 	f.FPC = false

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ var (
 	interfaceDiagnosticsEnabled = flag.Bool("ifdiag.enabled", true, "Scrape optical interface diagnostic metrics")
 	ipsecEnabled                = flag.Bool("ipsec.enabled", false, "Scrape IPSec metrics")
 	securityEnabled             = flag.Bool("security.enabled", false, "Scrape security metrics")
+	securityPoliciesEnabled     = flag.Bool("security_policies.enabled", false, "Scrape security policy metrics")
 	storageEnabled              = flag.Bool("storage.enabled", true, "Scrape system storage metrics")
 	fpcEnabled                  = flag.Bool("fpc.enabled", true, "Scrape line card metrics")
 	accountingEnabled           = flag.Bool("accounting.enabled", false, "Scrape accounting flow metrics")
@@ -202,6 +203,7 @@ func loadConfigFromFlags() *config.Config {
 	f.InterfaceQueue = *interfaceQueuesEnabled
 	f.IPSec = *ipsecEnabled
 	f.Security = *securityEnabled
+	f.SecurityPolicies = *securityPoliciesEnabled
 	f.ISIS = *isisEnabled
 	f.NAT = *natEnabled
 	f.NAT2 = *nat2Enabled

--- a/security_policies/collector.go
+++ b/security_policies/collector.go
@@ -129,7 +129,7 @@ func (c *securityPolicyCollector) CollectHits(client *rpc.Client, ch chan<- prom
 	}
 
 	for _, pol := range x.MultiRoutingEngineResults.RoutingEngine[0].HitCount.Policies {
-		ls := append(labelValues, pol.PolicyName, pol.FromZone, pol.ToZone)
+		ls := append(labelValues, pol.FromZone, pol.ToZone, pol.PolicyName)
 		ch <- prometheus.MustNewConstMetric(hitCount, prometheus.CounterValue, pol.Count, ls...)
 	}
 	return nil

--- a/security_policies/collector.go
+++ b/security_policies/collector.go
@@ -1,0 +1,178 @@
+package security_policies
+
+import (
+	"encoding/xml"
+	"strings"
+
+	"github.com/czerwonk/junos_exporter/collector"
+	"github.com/czerwonk/junos_exporter/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix string = "junos_security_policies_"
+
+var (
+	hitCount         *prometheus.Desc
+	sessionCreations *prometheus.Desc
+	sessionDeletions *prometheus.Desc
+	inputBytes       *prometheus.Desc
+	outputBytes      *prometheus.Desc
+	inputPackets     *prometheus.Desc
+	outputPackets    *prometheus.Desc
+)
+
+func init() {
+	la := []string{"target", "from_zone", "to_zone", "policy_name"}
+	lb := []string{"target", "from_zone", "to_zone", "policy_name", "direction"}
+
+	hitCount = prometheus.NewDesc(prefix+"hit_count", "Policy hit count", la, nil)
+
+	sessionCreations = prometheus.NewDesc(prefix+"session_creations", "Policy session creations", la, nil)
+	sessionDeletions = prometheus.NewDesc(prefix+"session_deletions", "Policy session deletions", la, nil)
+
+	inputBytes = prometheus.NewDesc(prefix+"input_bytes", "Policy input bytes", lb, nil)
+	outputBytes = prometheus.NewDesc(prefix+"output_bytes", "Policy output bytes", lb, nil)
+	inputPackets = prometheus.NewDesc(prefix+"input_packets", "Policy input packets", lb, nil)
+	outputPackets = prometheus.NewDesc(prefix+"output_packets", "Policy output packets", lb, nil)
+}
+
+type securityPolicyCollector struct {
+}
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector {
+	return &securityPolicyCollector{}
+}
+
+// Name returns the name of the collector
+func (*securityPolicyCollector) Name() string {
+	return "Security Policies"
+}
+
+// Describe describes the metrics
+func (*securityPolicyCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- hitCount
+	ch <- sessionCreations
+	ch <- sessionDeletions
+	ch <- inputBytes
+	ch <- outputBytes
+	ch <- inputBytes
+	ch <- outputBytes
+}
+
+// Collect collects metrics from JunOS
+func (c *securityPolicyCollector) Collect(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	err := c.CollectStats(client, ch, labelValues)
+	if err != nil {
+		return err
+	}
+
+	err = c.CollectHits(client, ch, labelValues)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *securityPolicyCollector) CollectStats(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var x = StatsRpcReply{}
+	err := client.RunCommandAndParseWithParser("show security policies detail", func(b []byte) error {
+		return parseStatsXML(b, &x)
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, ctx := range x.MultiRoutingEngineResults.RoutingEngine[0].Policies.Contexts {
+		for _, pol := range ctx.Policies {
+			if pol.PolicyInformation.StatisticsInformation == nil {
+				continue
+			}
+
+			var ln, li, lr []string
+			if ctx.ContextInformation.GlobalContext == nil {
+				ln = append(labelValues, ctx.ContextInformation.FromZone, ctx.ContextInformation.ToZone)
+			} else {
+				ln = append(labelValues, "junos-global", "junos-global")
+			}
+			ln = append(ln, pol.PolicyInformation.Name)
+
+			li = append(li, ln...)
+			li = append(li, "initial")
+			lr = append(lr, ln...)
+			lr = append(lr, "reply")
+
+			ch <- prometheus.MustNewConstMetric(sessionCreations, prometheus.CounterValue, pol.PolicyInformation.StatisticsInformation.SessionCreations, ln...)
+			ch <- prometheus.MustNewConstMetric(sessionDeletions, prometheus.CounterValue, pol.PolicyInformation.StatisticsInformation.SessionDeletions, ln...)
+			ch <- prometheus.MustNewConstMetric(inputBytes, prometheus.CounterValue, pol.PolicyInformation.StatisticsInformation.InputBytesInit, li...)
+			ch <- prometheus.MustNewConstMetric(inputBytes, prometheus.CounterValue, pol.PolicyInformation.StatisticsInformation.InputBytesReply, lr...)
+			ch <- prometheus.MustNewConstMetric(outputBytes, prometheus.CounterValue, pol.PolicyInformation.StatisticsInformation.OutputBytesInit, li...)
+			ch <- prometheus.MustNewConstMetric(outputBytes, prometheus.CounterValue, pol.PolicyInformation.StatisticsInformation.OutputBytesReply, lr...)
+			ch <- prometheus.MustNewConstMetric(inputPackets, prometheus.CounterValue, pol.PolicyInformation.StatisticsInformation.InputPacketsInit, li...)
+			ch <- prometheus.MustNewConstMetric(inputPackets, prometheus.CounterValue, pol.PolicyInformation.StatisticsInformation.InputPacketsReply, lr...)
+			ch <- prometheus.MustNewConstMetric(outputPackets, prometheus.CounterValue, pol.PolicyInformation.StatisticsInformation.OutputPacketsInit, li...)
+			ch <- prometheus.MustNewConstMetric(outputPackets, prometheus.CounterValue, pol.PolicyInformation.StatisticsInformation.OutputPacketsReply, lr...)
+		}
+	}
+
+	return nil
+}
+
+func (c *securityPolicyCollector) CollectHits(client *rpc.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var x = HitsRpcReply{}
+	err := client.RunCommandAndParseWithParser("show security policies hit-count", func(b []byte) error {
+		return parseHitsXML(b, &x)
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, pol := range x.MultiRoutingEngineResults.RoutingEngine[0].HitCount.Policies {
+		ls := append(labelValues, pol.PolicyName, pol.FromZone, pol.ToZone)
+		ch <- prometheus.MustNewConstMetric(hitCount, prometheus.CounterValue, pol.Count, ls...)
+	}
+	return nil
+}
+
+func parseStatsXML(b []byte, res *StatsRpcReply) error {
+	if strings.Contains(string(b), "multi-routing-engine-results") {
+		return xml.Unmarshal(b, res)
+	}
+
+	fi := StatsRpcReplyNoRE{}
+
+	err := xml.Unmarshal(b, &fi)
+	if err != nil {
+		return err
+	}
+
+	res.MultiRoutingEngineResults.RoutingEngine = []StatsRoutingEngine{
+		{
+			Name:     "N/A",
+			Policies: fi.Policies,
+		},
+	}
+	return nil
+}
+
+func parseHitsXML(b []byte, res *HitsRpcReply) error {
+	if strings.Contains(string(b), "multi-routing-engine-results") {
+		return xml.Unmarshal(b, res)
+	}
+
+	fi := HitsRpcReplyNoRE{}
+
+	err := xml.Unmarshal(b, &fi)
+	if err != nil {
+		return err
+	}
+
+	res.MultiRoutingEngineResults.RoutingEngine = []HitsRoutingEngine{
+		{
+			Name:     "N/A",
+			HitCount: fi.HitCount,
+		},
+	}
+	return nil
+}

--- a/security_policies/rpc.go
+++ b/security_policies/rpc.go
@@ -1,0 +1,93 @@
+package security_policies
+
+import "encoding/xml"
+
+type StatsRpcReply struct {
+	XMLName                   xml.Name                       `xml:"rpc-reply"`
+	MultiRoutingEngineResults StatsMultiRoutingEngineResults `xml:"multi-routing-engine-results"`
+}
+
+type StatsMultiRoutingEngineResults struct {
+	RoutingEngine []StatsRoutingEngine `xml:"multi-routing-engine-item"`
+}
+
+type StatsRoutingEngine struct {
+	Name     string           `xml:"re-name"`
+	Policies SecurityPolicies `xml:"security-policies"`
+}
+
+type StatsRpcReplyNoRE struct {
+	XMLName  xml.Name         `xml:"rpc-reply"`
+	Policies SecurityPolicies `xml:"security-policies"`
+}
+
+type SecurityPolicies struct {
+	Contexts []SecurityContext `xml:"security-context"`
+}
+
+type SecurityContext struct {
+	ContextInformation SecurityContextInformation `xml:"context-information"`
+	Policies           []SecurityPolicy           `xml:"policies"`
+}
+
+type SecurityContextInformation struct {
+	FromZone      string    `xml:"source-zone-name"`
+	ToZone        string    `xml:"destination-zone-name"`
+	GlobalContext *struct{} `xml:"global-context"`
+}
+
+type SecurityPolicy struct {
+	PolicyInformation SecurityPolicyInformation `xml:"policy-information"`
+}
+
+type SecurityPolicyInformation struct {
+	Name   string `xml:"policy-name"`
+	Action struct {
+		ActionType string `xml:"action-type"`
+	} `xml:"policy-action"`
+	StatisticsInformation *SecurityPolicyStatisticsInformation `xml:"policy-statistics-information"`
+}
+
+type SecurityPolicyStatisticsInformation struct {
+	InputBytesInit     float64 `xml:"input-bytes-init"`
+	InputBytesReply    float64 `xml:"input-bytes-reply"`
+	OutputBytesInit    float64 `xml:"output-bytes-init"`
+	OutputBytesReply   float64 `xml:"output-bytes-reply"`
+	InputPacketsInit   float64 `xml:"input-packets-init"`
+	InputPacketsReply  float64 `xml:"input-packets-reply"`
+	OutputPacketsInit  float64 `xml:"output-packets-init"`
+	OutputPacketsReply float64 `xml:"output-packets-reply"`
+	SessionCreations   float64 `xml:"session-creations"`
+	SessionDeletions   float64 `xml:"session-deletions"`
+}
+
+type HitsRpcReply struct {
+	XMLName                   xml.Name                      `xml:"rpc-reply"`
+	MultiRoutingEngineResults HitsMultiRoutingEngineResults `xml:"multi-routing-engine-results"`
+}
+
+type HitsMultiRoutingEngineResults struct {
+	RoutingEngine []HitsRoutingEngine `xml:"multi-routing-engine-item"`
+}
+
+type HitsRoutingEngine struct {
+	Name     string   `xml:"re-name"`
+	HitCount HitCount `xml:"policy-hit-count"`
+}
+
+type HitsRpcReplyNoRE struct {
+	XMLName  xml.Name `xml:"rpc-reply"`
+	HitCount HitCount `xml:"policy-hit-count"`
+}
+
+type HitCount struct {
+	LSName   string          `xml:"logical-system-name"`
+	Policies []HitCountEntry `xml:"policy-hit-count-entry"`
+}
+
+type HitCountEntry struct {
+	PolicyName string  `xml:"policy-hit-count-policy-name"`
+	FromZone   string  `xml:"policy-hit-count-from-zone"`
+	ToZone     string  `xml:"policy-hit-count-to-zone"`
+	Count      float64 `xml:"policy-hit-count-count"`
+}


### PR DESCRIPTION
This commit adds security policy (SRX) statistics;
* Hit counts for all policies
* In/out bytes+packets, plus state creation+deletion counters for policies with the `count` action