### PR TITLE
Fix "Could not connect to x: not connected" errors

### DIFF
--- a/pkg/connector/connection_manager.go
+++ b/pkg/connector/connection_manager.go
@@ -88,11 +88,9 @@ func (m *SSHConnectionManager) lockForDevice(device *Device) *sync.Mutex {
 // Connect connects to a device or returns an long living connection
 func (m *SSHConnectionManager) Connect(device *Device) (*SSHConnection, error) {
 	if connection, found := m.connections[device.Host]; found {
-		if !connection.isConnected() {
-			return nil, errors.New("not connected")
+		if connection.isConnected() {
+			return connection, nil
 		}
-
-		return connection, nil
 	}
 
 	mu := m.lockForDevice(device)
@@ -100,7 +98,9 @@ func (m *SSHConnectionManager) Connect(device *Device) (*SSHConnection, error) {
 	defer mu.Unlock()
 
 	if connection, found := m.connections[device.Host]; found {
-		return connection, nil
+		if connection.isConnected() {
+			return connection, nil
+		}
 	}
 
 	return m.connect(device)


### PR DESCRIPTION
Tweak SSHConnectionManager.Connect() to return a new connection if the previous one is not connected. (This occurs with expired connections.)

Maybe fixes: https://github.com/czerwonk/junos_exporter/issues/56