### PR TITLE
Move <rpc-reply> unpacking to RPC client

### DIFF
--- a/pkg/features/alarm/collector.go
+++ b/pkg/features/alarm/collector.go
@@ -93,7 +93,7 @@ func (c *alarmCollector) alarmCounter(client collector.Client) (*alarmCounter, *
 			return nil, nil, err
 		}
 
-		for _, engine := range a.Information.RoutingEngines {
+		for _, engine := range a.RoutingEngines {
 			for _, d := range engine.AlarmInfo.Details {
 				if _, found := messages[d.Description]; found {
 					continue
@@ -132,17 +132,17 @@ func parseXML(b []byte, res *multiEngineResult) error {
 		return xml.Unmarshal(b, res)
 	}
 
-	se := singleEngineResult{}
+	se := alarmInformation{}
 
 	err := xml.Unmarshal(b, &se)
 	if err != nil {
 		return err
 	}
 
-	res.Information.RoutingEngines = []routingEngine{
+	res.RoutingEngines = []routingEngine{
 		{
-			Name:        "N/A",
-			AlarmInfo: se.Information,
+			Name:      "N/A",
+			AlarmInfo: se,
 		},
 	}
 

--- a/pkg/features/alarm/rpc.go
+++ b/pkg/features/alarm/rpc.go
@@ -6,25 +6,18 @@ import (
 	"encoding/xml"
 )
 
-type singleEngineResult struct {
-	XMLName xml.Name `xml:"rpc-reply"`
-	Information alarmInformation `xml:"alarm-information"`
-}
-
 type multiEngineResult struct {
-	XMLName xml.Name `xml:"rpc-reply"`
-	Information struct {
-		RoutingEngines []routingEngine `xml:"multi-routing-engine-item"`
-	} `xml:"multi-routing-engine-results"`
+	XMLName        xml.Name        `xml:"multi-routing-engine-results"`
+	RoutingEngines []routingEngine `xml:"multi-routing-engine-item"`
 }
 
 type routingEngine struct {
-	Name    string    `xml:"re-name"`
+	Name      string           `xml:"re-name"`
 	AlarmInfo alarmInformation `xml:"alarm-information"`
 }
 
 type alarmInformation struct {
-	XMLName xml.Name `xml:"alarm-information"`
+	XMLName xml.Name  `xml:"alarm-information"`
 	Details []details `xml:"alarm-detail"`
 }
 

--- a/pkg/features/alarm/rpc_test.go
+++ b/pkg/features/alarm/rpc_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/czerwonk/junos_exporter/pkg/rpc"
 )
 
 // Test multi routing engine
@@ -69,22 +71,28 @@ func TestParseOutputMultiRESystemAlarms(t *testing.T) {
     </cli>
 </rpc-reply>`
 
-	rpc := multiEngineResult{}
-	err := parseXML([]byte(body), &rpc)
+	var b, err = rpc.UnpackRpcReply([]byte(body))
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, "node0", rpc.Information.RoutingEngines[0].Name, "re-name")
-	assert.Equal(t, "Autorecovery", rpc.Information.RoutingEngines[0].AlarmInfo.Details[0].Type, "alarm-type")
-	assert.Equal(t, "Minor", rpc.Information.RoutingEngines[0].AlarmInfo.Details[0].Class, "alarm-class")
-	assert.Equal(t, "Autorecovery information needs to be saved", rpc.Information.RoutingEngines[0].AlarmInfo.Details[0].Description, "alarm-description")
+	result := multiEngineResult{}
+	err = parseXML(b, &result)
 
-	assert.Equal(t, "node1", rpc.Information.RoutingEngines[1].Name, "re-name")
-	assert.Equal(t, "Configuration", rpc.Information.RoutingEngines[1].AlarmInfo.Details[1].Type, "alarm-type")
-	assert.Equal(t, "Minor", rpc.Information.RoutingEngines[1].AlarmInfo.Details[1].Class, "alarm-class")
-	assert.Equal(t, "Rescue configuration is not set", rpc.Information.RoutingEngines[1].AlarmInfo.Details[1].Description, "alarm-description")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "node0", result.RoutingEngines[0].Name, "re-name")
+	assert.Equal(t, "Autorecovery", result.RoutingEngines[0].AlarmInfo.Details[0].Type, "alarm-type")
+	assert.Equal(t, "Minor", result.RoutingEngines[0].AlarmInfo.Details[0].Class, "alarm-class")
+	assert.Equal(t, "Autorecovery information needs to be saved", result.RoutingEngines[0].AlarmInfo.Details[0].Description, "alarm-description")
+
+	assert.Equal(t, "node1", result.RoutingEngines[1].Name, "re-name")
+	assert.Equal(t, "Configuration", result.RoutingEngines[1].AlarmInfo.Details[1].Type, "alarm-type")
+	assert.Equal(t, "Minor", result.RoutingEngines[1].AlarmInfo.Details[1].Class, "alarm-class")
+	assert.Equal(t, "Rescue configuration is not set", result.RoutingEngines[1].AlarmInfo.Details[1].Description, "alarm-description")
 }
 
 // Test no multi routing engine
@@ -118,15 +126,21 @@ func TestParseOutputSingleRESystemAlarms(t *testing.T) {
     </cli>
 </rpc-reply>`
 
-	rpc := multiEngineResult{}
-	err := parseXML([]byte(body), &rpc)
+	var b, err = rpc.UnpackRpcReply([]byte(body))
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, "N/A", rpc.Information.RoutingEngines[0].Name, "re-name")
-	assert.Equal(t, "Autorecovery", rpc.Information.RoutingEngines[0].AlarmInfo.Details[0].Type, "alarm-type")
-	assert.Equal(t, "Minor", rpc.Information.RoutingEngines[0].AlarmInfo.Details[0].Class, "alarm-class")
-	assert.Equal(t, "Autorecovery information needs to be saved", rpc.Information.RoutingEngines[0].AlarmInfo.Details[0].Description, "alarm-description")
+	result := multiEngineResult{}
+	err = parseXML(b, &result)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "N/A", result.RoutingEngines[0].Name, "re-name")
+	assert.Equal(t, "Autorecovery", result.RoutingEngines[0].AlarmInfo.Details[0].Type, "alarm-type")
+	assert.Equal(t, "Minor", result.RoutingEngines[0].AlarmInfo.Details[0].Class, "alarm-class")
+	assert.Equal(t, "Autorecovery information needs to be saved", result.RoutingEngines[0].AlarmInfo.Details[0].Description, "alarm-description")
 }

--- a/pkg/features/bgp/collector.go
+++ b/pkg/features/bgp/collector.go
@@ -85,19 +85,22 @@ func (c *bgpCollector) Collect(client collector.Client, ch chan<- prometheus.Met
 }
 
 func (c *bgpCollector) collect(client collector.Client, ch chan<- prometheus.Metric, labelValues []string) error {
-	var x = result{}
-	var cmd strings.Builder
-	cmd.WriteString("show bgp neighbor")
-	if c.LogicalSystem != "" {
-		cmd.WriteString(" logical-system " + c.LogicalSystem)
+	var x = information{}
+
+	var cmd string
+
+	if c.LogicalSystem == "" {
+		cmd = "show bgp neighbor"
+	} else {
+		cmd = "show bgp neighbor logical-system" + c.LogicalSystem
 	}
 
-	err := client.RunCommandAndParse(cmd.String(), &x)
+	err := client.RunCommandAndParse(cmd, &x)
 	if err != nil {
 		return err
 	}
 
-	for _, peer := range x.Information.Peers {
+	for _, peer := range x.Peers {
 		c.collectForPeer(peer, ch, labelValues)
 	}
 

--- a/pkg/features/bgp/rpc.go
+++ b/pkg/features/bgp/rpc.go
@@ -2,10 +2,13 @@
 
 package bgp
 
-type result struct {
-	Information struct {
-		Peers []peer `xml:"bgp-peer"`
-	} `xml:"bgp-information"`
+import (
+	"encoding/xml"
+)
+
+type information struct {
+	XMLName xml.Name `xml:"bgp-information"`
+	Peers   []peer   `xml:"bgp-peer"`
 }
 
 type peer struct {

--- a/pkg/features/bgp/rpc_test.go
+++ b/pkg/features/bgp/rpc_test.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+
+package bgp
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/czerwonk/junos_exporter/pkg/rpc"
+)
+
+func TestParseOutput(t *testing.T) {
+	body := `<rpc-reply xmlns:junos="http://xml.juniper.net/junos/ZZZ/junos">
+    <bgp-information xmlns="http://xml.juniper.net/junos/ZZZ/junos-routing">
+        <bgp-peer junos:style="detail">
+            <peer-address>10.0.0.1+179</peer-address>
+            <peer-as>64496</peer-as>
+            <local-address>10.0.1.1+33333</local-address>
+            <local-as>64498</local-as>
+            <peer-group>group1</peer-group>
+            <peer-cfg-rti>CRI</peer-cfg-rti>
+            <peer-fwd-rti>CRI</peer-fwd-rti>
+            <peer-type>External</peer-type>
+            <peer-state>Established</peer-state>
+            <peer-flags>Sync</peer-flags>
+            <last-state>OpenConfirm</last-state>
+            <last-event>Refresh</last-event>
+            <last-error>Hold Timer Expired Error</last-error>
+            <bgp-option-information xmlns="http://xml.juniper.net/junos/ZZZ/junos-routing">
+                <export-policy>
+                    BGP-EXPORT-1
+                </export-policy>
+                <import-policy>
+                    BGP-IMPORT-1
+                </import-policy>
+                <bgp-options>Multihop Preference LocalAddress HoldTime PeerAS LocalAS Refresh</bgp-options>
+                <bgp-options2></bgp-options2>
+                <bgp-options-extended>GracefulShutdownRcv</bgp-options-extended>
+                <local-address>10.0.1.1</local-address>
+                <holdtime>10</holdtime>
+                <preference>170</preference>
+                <gshut-recv-local-preference>0</gshut-recv-local-preference>
+                <local-as>64498</local-as>
+                <local-system-as>0</local-system-as>
+            </bgp-option-information>
+            <flap-count>19</flap-count>
+            <last-flap-event>HoldTime</last-flap-event>
+            <bgp-error>
+                <name>Hold Timer Expired Error</name>
+                <send-count>21</send-count>
+                <receive-count>1</receive-count>
+            </bgp-error>
+            <peer-id>10.0.0.1</peer-id>
+            <local-id>10.0.1.1</local-id>
+            <active-holdtime>10</active-holdtime>
+            <keepalive-interval>3</keepalive-interval>
+            <group-index>2</group-index>
+            <peer-index>0</peer-index>
+            <snmp-index>0</snmp-index>
+            <bgp-peer-iosession>
+                <iosession-thread-name>bgpio-0</iosession-thread-name>
+                <iosession-state>Enabled</iosession-state>
+            </bgp-peer-iosession>
+            <bgp-bfd>
+                <bfd-configuration-state>disabled</bfd-configuration-state>
+                <bfd-operational-state>down</bfd-operational-state>
+            </bgp-bfd>
+            <peer-restart-nlri-configured>inet-unicast</peer-restart-nlri-configured>
+            <nlri-type-peer>inet-unicast</nlri-type-peer>
+            <nlri-type-session>inet-unicast</nlri-type-session>
+            <peer-refresh-capability>2</peer-refresh-capability>
+            <peer-stale-route-time-configured>120</peer-stale-route-time-configured>
+            <peer-restart-time-received>120</peer-restart-time-received>
+            <peer-restart-nlri-received>inet-unicast</peer-restart-nlri-received>
+            <peer-restart-nlri-can-save-state>inet-unicast</peer-restart-nlri-can-save-state>
+            <peer-restart-nlri-state-saved></peer-restart-nlri-state-saved>
+            <peer-restart-nlri-negotiated>inet-unicast</peer-restart-nlri-negotiated>
+            <peer-end-of-rib-received>inet-unicast</peer-end-of-rib-received>
+            <peer-end-of-rib-sent>inet-unicast</peer-end-of-rib-sent>
+            <peer-end-of-rib-scheduled></peer-end-of-rib-scheduled>
+            <peer-no-llgr-helper/>
+            <peer-4byte-as-capability-advertised>64496</peer-4byte-as-capability-advertised>
+            <peer-addpath-not-supported/>
+            <bgp-rib junos:style="detail">
+                <name>CRI.inet.0</name>
+                <rib-bit>20001</rib-bit>
+                <bgp-rib-state>BGP restart is complete</bgp-rib-state>
+                <vpn-rib-state>VPN restart is complete</vpn-rib-state>
+                <send-state>in sync</send-state>
+                <active-prefix-count>9</active-prefix-count>
+                <received-prefix-count>9</received-prefix-count>
+                <accepted-prefix-count>9</accepted-prefix-count>
+                <suppressed-prefix-count>0</suppressed-prefix-count>
+                <advertised-prefix-count>1</advertised-prefix-count>
+            </bgp-rib>
+            <last-received>0</last-received>
+            <last-sent>2</last-sent>
+            <last-checked>896903</last-checked>
+            <input-messages>349663</input-messages>
+            <input-updates>4</input-updates>
+            <input-refreshes>3</input-refreshes>
+            <input-octets>6643729</input-octets>
+            <output-messages>330655</output-messages>
+            <output-updates>4</output-updates>
+            <output-refreshes>0</output-refreshes>
+            <output-octets>6282561</output-octets>
+            <bgp-output-queue>
+                <number>1</number>
+                <count>0</count>
+                <table-name>CRI.inet.0</table-name>
+                <rib-adv-nlri>inet-unicast</rib-adv-nlri>
+            </bgp-output-queue>
+        </bgp-peer>
+        <bgp-peer junos:style="detail">
+            <peer-address>10.0.0.2+179</peer-address>
+            <peer-as>64497</peer-as>
+            <local-address>10.0.1.1+44444</local-address>
+            <local-as>64498</local-as>
+            <peer-group>group2</peer-group>
+            <peer-cfg-rti>CRI</peer-cfg-rti>
+            <peer-fwd-rti>CRI</peer-fwd-rti>
+            <peer-type>External</peer-type>
+            <peer-state>Established</peer-state>
+            <peer-flags>Sync</peer-flags>
+            <last-state>OpenConfirm</last-state>
+            <last-event>Refresh</last-event>
+            <last-error>Cease</last-error>
+            <bgp-option-information xmlns="http://xml.juniper.net/junos/ZZZ/junos-routing">
+                <export-policy>
+                    BGP-EXPORT-2
+                </export-policy>
+                <import-policy>
+                    BGP-IMPORT-2
+                </import-policy>
+                <bgp-options>Multihop Preference LocalAddress HoldTime PeerAS LocalAS Refresh</bgp-options>
+                <bgp-options2></bgp-options2>
+                <bgp-options-extended>GracefulShutdownRcv</bgp-options-extended>
+                <local-address>10.0.1.1</local-address>
+                <holdtime>10</holdtime>
+                <preference>170</preference>
+                <gshut-recv-local-preference>0</gshut-recv-local-preference>
+                <local-as>64498</local-as>
+                <local-system-as>0</local-system-as>
+            </bgp-option-information>
+            <flap-count>7</flap-count>
+            <last-flap-event>HoldTime</last-flap-event>
+            <bgp-error>
+                <name>Hold Timer Expired Error</name>
+                <send-count>5</send-count>
+                <receive-count>1</receive-count>
+            </bgp-error>
+            <bgp-error>
+                <name>Cease</name>
+                <send-count>3</send-count>
+                <receive-count>1</receive-count>
+            </bgp-error>
+            <peer-id>10.0.0.2</peer-id>
+            <local-id>10.0.1.1</local-id>
+            <active-holdtime>10</active-holdtime>
+            <keepalive-interval>3</keepalive-interval>
+            <group-index>3</group-index>
+            <peer-index>0</peer-index>
+            <snmp-index>1</snmp-index>
+            <bgp-peer-iosession>
+                <iosession-thread-name>bgpio-0</iosession-thread-name>
+                <iosession-state>Enabled</iosession-state>
+            </bgp-peer-iosession>
+            <bgp-bfd>
+                <bfd-configuration-state>disabled</bfd-configuration-state>
+                <bfd-operational-state>down</bfd-operational-state>
+            </bgp-bfd>
+            <peer-restart-nlri-configured>inet-unicast</peer-restart-nlri-configured>
+            <nlri-type-peer>inet-unicast</nlri-type-peer>
+            <nlri-type-session>inet-unicast</nlri-type-session>
+            <peer-refresh-capability>2</peer-refresh-capability>
+            <peer-stale-route-time-configured>120</peer-stale-route-time-configured>
+            <peer-restart-time-received>120</peer-restart-time-received>
+            <peer-restart-nlri-received>inet-unicast</peer-restart-nlri-received>
+            <peer-restart-nlri-can-save-state>inet-unicast</peer-restart-nlri-can-save-state>
+            <peer-restart-nlri-state-saved></peer-restart-nlri-state-saved>
+            <peer-restart-nlri-negotiated>inet-unicast</peer-restart-nlri-negotiated>
+            <peer-end-of-rib-received>inet-unicast</peer-end-of-rib-received>
+            <peer-end-of-rib-sent>inet-unicast</peer-end-of-rib-sent>
+            <peer-end-of-rib-scheduled></peer-end-of-rib-scheduled>
+            <peer-no-llgr-helper/>
+            <peer-4byte-as-capability-advertised>64497</peer-4byte-as-capability-advertised>
+            <peer-addpath-not-supported/>
+            <bgp-rib junos:style="detail">
+                <name>CRI.inet.0</name>
+                <rib-bit>20000</rib-bit>
+                <bgp-rib-state>BGP restart is complete</bgp-rib-state>
+                <vpn-rib-state>VPN restart is complete</vpn-rib-state>
+                <send-state>in sync</send-state>
+                <active-prefix-count>0</active-prefix-count>
+                <received-prefix-count>9</received-prefix-count>
+                <accepted-prefix-count>9</accepted-prefix-count>
+                <suppressed-prefix-count>0</suppressed-prefix-count>
+                <advertised-prefix-count>1</advertised-prefix-count>
+            </bgp-rib>
+            <last-received>3</last-received>
+            <last-sent>1</last-sent>
+            <last-checked>1247359</last-checked>
+            <input-messages>486332</input-messages>
+            <input-updates>3</input-updates>
+            <input-refreshes>1</input-refreshes>
+            <input-octets>9240448</input-octets>
+            <output-messages>459847</output-messages>
+            <output-updates>2</output-updates>
+            <output-refreshes>0</output-refreshes>
+            <output-octets>8737177</output-octets>
+            <bgp-output-queue>
+                <number>1</number>
+                <count>0</count>
+                <table-name>CRI.inet.0</table-name>
+                <rib-adv-nlri>inet-unicast</rib-adv-nlri>
+            </bgp-output-queue>
+        </bgp-peer>
+    </bgp-information>
+    <cli>
+        <banner>{primary:node0}</banner>
+    </cli>
+</rpc-reply>`
+
+	var b, err = rpc.UnpackRpcReply([]byte(body))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := information{}
+	err = xml.Unmarshal(b, &result)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 2, len(result.Peers), "bgp-peer count")
+
+	assert.Equal(t, "64496", result.Peers[0].ASN, "peer-as")
+	assert.Equal(t, "group1", result.Peers[0].Group, "peer-group")
+}

--- a/pkg/features/interfaces/collector.go
+++ b/pkg/features/interfaces/collector.go
@@ -178,7 +178,7 @@ func (c *interfaceCollector) interfaceStats(client collector.Client) ([]*interfa
 	}
 
 	stats := make([]*interfaceStats, 0)
-	for _, phy := range x.Information.Interfaces {
+	for _, phy := range x.Interfaces {
 		s := &interfaceStats{
 			IsPhysical:              true,
 			Name:                    phy.Name,

--- a/pkg/features/interfaces/rpc.go
+++ b/pkg/features/interfaces/rpc.go
@@ -2,10 +2,13 @@
 
 package interfaces
 
+import (
+	"encoding/xml"
+)
+
 type result struct {
-	Information struct {
-		Interfaces []phyInterface `xml:"physical-interface"`
-	} `xml:"interface-information"`
+	XMLName    xml.Name       `xml:"interface-information"`
+	Interfaces []phyInterface `xml:"physical-interface"`
 }
 
 type phyInterface struct {

--- a/pkg/features/ipsec/rpc.go
+++ b/pkg/features/ipsec/rpc.go
@@ -4,21 +4,18 @@ package ipsec
 
 import "encoding/xml"
 
-type multiEngineResult struct {
-	XMLName xml.Name           `xml:"rpc-reply"`
-	Results multiEngineResults `xml:"multi-routing-engine-results"`
-}
-
-type multiEngineResults struct {
+type multiRoutingEngineResults struct {
+	XMLName        xml.Name        `xml:"multi-routing-engine-results"`
 	RoutingEngines []routingEngine `xml:"multi-routing-engine-item"`
 }
 
 type routingEngine struct {
-	Name  string      `xml:"re-name"`
-	IPSec information `xml:"ipsec-security-associations-information"`
+	Name  string                          `xml:"re-name"`
+	IPSec securityAssociationsInformation `xml:"ipsec-security-associations-information"`
 }
 
-type information struct {
+type securityAssociationsInformation struct {
+	XMLName              xml.Name                   `xml:"ipsec-security-associations-information"`
 	ActiveTunnels        int                        `xml:"total-active-tunnels"`
 	SecurityAssociations []securityAssociationBlock `xml:"ipsec-security-associations-block"`
 }
@@ -46,39 +43,33 @@ type securityAssociation struct {
 	VirtualSystem          string `xml:"sa-virtual-system"`
 }
 
-type singleEngineResult struct {
-	XMLName xml.Name    `xml:"rpc-reply"`
-	IPSec   information `xml:"ipsec-security-associations-information"`
-}
-
 // ConfigurationSecurityIpsec is used for xml unmarshalling
 // In order to get the number of configured VPNs
 type configurationSecurityResult struct {
-	Configuration struct {
-		Security struct {
-			Ipsec struct {
-				Proposal struct {
-					Text                    string `xml:",chardata"`
-					Name                    string `xml:"name"`
-					Protocol                string `xml:"protocol"`
-					AuthenticationAlgorithm string `xml:"authentication-algorithm"`
-					EncryptionAlgorithm     string `xml:"encryption-algorithm"`
-					LifetimeSeconds         string `xml:"lifetime-seconds"`
-				} `xml:"proposal"`
-				Policy struct {
-					Name      string `xml:"name"`
-					Proposals string `xml:"proposals"`
-				} `xml:"policy"`
-				Vpn []struct {
-					Name          string `xml:"name"`
-					BindInterface string `xml:"bind-interface"`
-					Ike           struct {
-						Gateway     string `xml:"gateway"`
-						IPSecPolicy string `xml:"ipsec-policy"`
-					} `xml:"ike"`
-					EstablishTunnels string `xml:"establish-tunnels"`
-				} `xml:"vpn"`
-			} `xml:"ipsec"`
-		} `xml:"security"`
-	} `xml:"configuration"`
+	XMLName  xml.Name `xml:"configuration"`
+	Security struct {
+		Ipsec struct {
+			Proposal struct {
+				Text                    string `xml:",chardata"`
+				Name                    string `xml:"name"`
+				Protocol                string `xml:"protocol"`
+				AuthenticationAlgorithm string `xml:"authentication-algorithm"`
+				EncryptionAlgorithm     string `xml:"encryption-algorithm"`
+				LifetimeSeconds         string `xml:"lifetime-seconds"`
+			} `xml:"proposal"`
+			Policy struct {
+				Name      string `xml:"name"`
+				Proposals string `xml:"proposals"`
+			} `xml:"policy"`
+			Vpn []struct {
+				Name          string `xml:"name"`
+				BindInterface string `xml:"bind-interface"`
+				Ike           struct {
+					Gateway     string `xml:"gateway"`
+					IPSecPolicy string `xml:"ipsec-policy"`
+				} `xml:"ike"`
+				EstablishTunnels string `xml:"establish-tunnels"`
+			} `xml:"vpn"`
+		} `xml:"ipsec"`
+	} `xml:"security"`
 }

--- a/pkg/features/mac/collector.go
+++ b/pkg/features/mac/collector.go
@@ -47,13 +47,13 @@ func (*macCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect collects metrics from JunOS
 func (c *macCollector) Collect(client collector.Client, ch chan<- prometheus.Metric, labelValues []string) error {
-	var x = result{}
+	var x = ethernetSwitchingTableInformation{}
 	err := client.RunCommandAndParse("show ethernet-switching table summary", &x)
 	if err != nil {
 		return err
 	}
 
-	entry := x.Information.Table.Entry
+	entry := x.Table.Entry
 	ch <- prometheus.MustNewConstMetric(totalCount, prometheus.GaugeValue, float64(entry.TotalCount), labelValues...)
 	ch <- prometheus.MustNewConstMetric(recieveCount, prometheus.GaugeValue, float64(entry.ReceiveCount), labelValues...)
 	ch <- prometheus.MustNewConstMetric(dynamicCount, prometheus.GaugeValue, float64(entry.DynamicCount), labelValues...)

--- a/pkg/features/mac/rpc.go
+++ b/pkg/features/mac/rpc.go
@@ -2,12 +2,13 @@
 
 package mac
 
-type result struct {
-	Information ethernetSwitchingTableInformation `xml:"ethernet-switching-table-information"`
-}
+import (
+	"encoding/xml"
+)
 
 type ethernetSwitchingTableInformation struct {
-	Table ethernetSwitchingTable `xml:"ethernet-switching-table"`
+	XMLName xml.Name               `xml:"ethernet-switching-table-information"`
+	Table   ethernetSwitchingTable `xml:"ethernet-switching-table"`
 }
 
 type ethernetSwitchingTable struct {
@@ -15,7 +16,9 @@ type ethernetSwitchingTable struct {
 }
 
 type macTableEntry struct {
-	TotalCount   int64 `xml:"mac-table-total-count"`
+	TotalCount int64 `xml:"mac-table-total-count"`
+	Dot1XCount int64 `xml:"mac-table-dot1x-count"`
+	// JunOS actually returns recieve
 	ReceiveCount int64 `xml:"mac-table-recieve-count"`
 	DynamicCount int64 `xml:"mac-table-dynamic-count"`
 	FloodCount   int64 `xml:"mac-table-flood-count"`

--- a/pkg/features/mac/rpc_test.go
+++ b/pkg/features/mac/rpc_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+
+package mac
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/czerwonk/junos_exporter/pkg/rpc"
+)
+
+func TestParseOutput(t *testing.T) {
+	body := `<rpc-reply xmlns:junos="http://xml.juniper.net/junos/ZZZ/junos">
+    <ethernet-switching-table-information junos:style="summary">
+        <ethernet-switching-table junos:style="summary">
+            <mac-table-entry junos:style="summary">
+                <mac-table-total-count>37</mac-table-total-count>
+                <mac-table-dot1x-count>5</mac-table-dot1x-count>
+                <mac-table-recieve-count>1</mac-table-recieve-count>
+                <mac-table-dynamic-count>28</mac-table-dynamic-count>
+                <mac-table-flood-count>3</mac-table-flood-count>
+            </mac-table-entry>
+        </ethernet-switching-table>
+    </ethernet-switching-table-information>
+    <cli>
+        <banner>{master:1}</banner>
+    </cli>
+</rpc-reply>`
+
+	var b, err = rpc.UnpackRpcReply([]byte(body))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := ethernetSwitchingTableInformation{}
+	err = xml.Unmarshal(b, &result)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, int64(37), result.Table.Entry.TotalCount, "total-count")
+	assert.Equal(t, int64(5), result.Table.Entry.Dot1XCount, "dot1x-count")
+	assert.Equal(t, int64(1), result.Table.Entry.ReceiveCount, "receive-count")
+	assert.Equal(t, int64(28), result.Table.Entry.DynamicCount, "dynamic-count")
+	assert.Equal(t, int64(3), result.Table.Entry.FloodCount, "flood-count")
+}

--- a/pkg/features/rpm/collector.go
+++ b/pkg/features/rpm/collector.go
@@ -77,7 +77,7 @@ func (c *rpmCollector) collect(client collector.Client, ch chan<- prometheus.Met
 		return err
 	}
 
-	for _, probe := range x.Results.Probes {
+	for _, probe := range x.Probes {
 		c.collectForProbe(probe, ch, labelValues)
 	}
 

--- a/pkg/features/rpm/rpc.go
+++ b/pkg/features/rpm/rpc.go
@@ -2,10 +2,13 @@
 
 package rpm
 
+import (
+	"encoding/xml"
+)
+
 type result struct {
-	Results struct {
-		Probes []probe `xml:"probe-test-results"`
-	} `xml:"probe-results"`
+	XMLName xml.Name `xml:"probe-results"`
+	Probes  []probe  `xml:"probe-test-results"`
 }
 
 type probe struct {

--- a/pkg/interfacelabels/dynamic_labels.go
+++ b/pkg/interfacelabels/dynamic_labels.go
@@ -54,7 +54,7 @@ func (l *DynamicLabels) CollectDescriptions(device *connector.Device, client col
 		return errors.Wrap(err, "could not retrieve interface descriptions for "+device.Host)
 	}
 
-	l.parseDescriptions(device, r.Information.Interfaces, ifDescReg)
+	l.parseDescriptions(device, r.Interfaces, ifDescReg)
 
 	return nil
 }

--- a/pkg/interfacelabels/rpc.go
+++ b/pkg/interfacelabels/rpc.go
@@ -2,10 +2,13 @@
 
 package interfacelabels
 
+import (
+	"encoding/xml"
+)
+
 type result struct {
-	Information struct {
-		Interfaces []phyInterface `xml:"physical-interface"`
-	} `xml:"interface-information"`
+	XMLName    xml.Name       `xml:"interface-information"`
+	Interfaces []phyInterface `xml:"physical-interface"`
 }
 
 type phyInterface struct {

--- a/pkg/rpc/error.go
+++ b/pkg/rpc/error.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+
+package rpc
+
+type RpcReplyXmlParserError struct {
+	RawResponse []byte
+	Err         error
+}
+
+func (e *RpcReplyXmlParserError) Error() string {
+	return "Failed to decode RPC reply XML: " + e.Err.Error()
+}
+
+func (e *RpcReplyXmlParserError) Unwrap() error { return e.Err }

--- a/pkg/rpc/rpc.go
+++ b/pkg/rpc/rpc.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+package rpc
+
+import (
+	"encoding/xml"
+)
+
+type rpcReply struct {
+	XMLName xml.Name `xml:"rpc-reply"`
+	Body    []byte   `xml:",innerxml"`
+}


### PR DESCRIPTION
This makes it easier to implement alternative transports, such as netconf, which may already unpack `<rpc-reply>` on transport level before handing the contained response to the RPC client.

With https://github.com/nemith/netconf, we never see the `<rpc-reply>` element in the first place, only its contents are passed on.

This moves the unpacking logic to a central point and separates this change from the netconf implementation, which should result in smaller diffs to review.

Can you please tell me if you consider this a reasonable change?
If you do, I'll go ahead and convert the remaining places as well.