### PR TITLE
Fix alarms on multi-RE systems

### DIFF
--- a/pkg/features/alarm/collector.go
+++ b/pkg/features/alarm/collector.go
@@ -3,7 +3,9 @@
 package alarm
 
 import (
+	"encoding/xml"
 	"regexp"
+	"strings"
 
 	"github.com/czerwonk/junos_exporter/pkg/collector"
 	"github.com/prometheus/client_golang/prometheus"
@@ -19,7 +21,7 @@ var (
 
 func init() {
 	l := []string{"target"}
-	alarmsYellowCount = prometheus.NewDesc(prefix+"yellow_count", "Number of yollow alarms (not silenced)", l, nil)
+	alarmsYellowCount = prometheus.NewDesc(prefix+"yellow_count", "Number of yellow alarms (not silenced)", l, nil)
 	alarmsRedCount = prometheus.NewDesc(prefix+"red_count", "Number of red alarms (not silenced)", l, nil)
 	l = append(l, "class", "type", "description")
 	alarmDetails = prometheus.NewDesc(prefix+"set", "Alarm active with the details provided in labels", l, nil)
@@ -83,30 +85,34 @@ func (c *alarmCollector) alarmCounter(client collector.Client) (*alarmCounter, *
 
 	messages := make(map[string]interface{})
 	for _, cmd := range cmds {
-		var a = result{}
-		err := client.RunCommandAndParse(cmd, &a)
+		var a = multiEngineResult{}
+		err := client.RunCommandAndParseWithParser(cmd, func(b []byte) error {
+			return parseXML(b, &a)
+		})
 		if err != nil {
 			return nil, nil, err
 		}
 
-		for _, d := range a.Information.Details {
-			if _, found := messages[d.Description]; found {
-				continue
+		for _, engine := range a.Information.RoutingEngines {
+			for _, d := range engine.AlarmInfo.Details {
+				if _, found := messages[d.Description]; found {
+					continue
+				}
+
+				alarms = append(alarms, d)
+
+				if c.shouldFilterAlarm(&d) {
+					continue
+				}
+
+				if d.Class == "Major" {
+					red++
+				} else if d.Class == "Minor" {
+					yellow++
+				}
+
+				messages[d.Description] = nil
 			}
-
-			alarms = append(alarms, d)
-
-			if c.shouldFilterAlarm(&d) {
-				continue
-			}
-
-			if d.Class == "Major" {
-				red++
-			} else if d.Class == "Minor" {
-				yellow++
-			}
-
-			messages[d.Description] = nil
 		}
 	}
 
@@ -119,4 +125,26 @@ func (c *alarmCollector) shouldFilterAlarm(a *details) bool {
 	}
 
 	return c.filter.MatchString(a.Description) || c.filter.MatchString(a.Type)
+}
+
+func parseXML(b []byte, res *multiEngineResult) error {
+	if strings.Contains(string(b), "<multi-routing-engine-results") {
+		return xml.Unmarshal(b, res)
+	}
+
+	se := singleEngineResult{}
+
+	err := xml.Unmarshal(b, &se)
+	if err != nil {
+		return err
+	}
+
+	res.Information.RoutingEngines = []routingEngine{
+		{
+			Name:        "N/A",
+			AlarmInfo: se.Information,
+		},
+	}
+
+	return nil
 }

--- a/pkg/features/alarm/rpc.go
+++ b/pkg/features/alarm/rpc.go
@@ -2,10 +2,30 @@
 
 package alarm
 
-type result struct {
+import (
+	"encoding/xml"
+)
+
+type singleEngineResult struct {
+	XMLName xml.Name `xml:"rpc-reply"`
+	Information alarmInformation `xml:"alarm-information"`
+}
+
+type multiEngineResult struct {
+	XMLName xml.Name `xml:"rpc-reply"`
 	Information struct {
-		Details []details `xml:"alarm-detail"`
-	} `xml:"alarm-information"`
+		RoutingEngines []routingEngine `xml:"multi-routing-engine-item"`
+	} `xml:"multi-routing-engine-results"`
+}
+
+type routingEngine struct {
+	Name    string    `xml:"re-name"`
+	AlarmInfo alarmInformation `xml:"alarm-information"`
+}
+
+type alarmInformation struct {
+	XMLName xml.Name `xml:"alarm-information"`
+	Details []details `xml:"alarm-detail"`
 }
 
 type details struct {

--- a/pkg/features/alarm/rpc_test.go
+++ b/pkg/features/alarm/rpc_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+
+package alarm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test multi routing engine
+func TestParseOutputMultiRESystemAlarms(t *testing.T) {
+	body := `<rpc-reply xmlns:junos="http://xml.juniper.net/junos/ZZZ/junos">
+    <multi-routing-engine-results>
+
+        <multi-routing-engine-item>
+
+            <re-name>node0</re-name>
+
+            <alarm-information xmlns="http://xml.juniper.net/junos/ZZZ/junos-alarm">
+                <alarm-summary>
+                    <active-alarm-count>2</active-alarm-count>
+                </alarm-summary>
+                <alarm-detail>
+                    <alarm-time junos:seconds="1684172206">2023-05-15 17:36:46 UTC</alarm-time>
+                    <alarm-class>Minor</alarm-class>
+                    <alarm-description>Autorecovery information needs to be saved</alarm-description>
+                    <alarm-short-description>autorecovery-save-r</alarm-short-description>
+                    <alarm-type>Autorecovery</alarm-type>
+                </alarm-detail>
+                <alarm-detail>
+                    <alarm-time junos:seconds="1684172206">2023-05-15 17:36:46 UTC</alarm-time>
+                    <alarm-class>Minor</alarm-class>
+                    <alarm-description>Rescue configuration is not set</alarm-description>
+                    <alarm-short-description>no-rescue</alarm-short-description>
+                    <alarm-type>Configuration</alarm-type>
+                </alarm-detail>
+            </alarm-information>
+        </multi-routing-engine-item>
+
+        <multi-routing-engine-item>
+
+            <re-name>node1</re-name>
+
+            <alarm-information xmlns="http://xml.juniper.net/junos/ZZZ/junos-alarm">
+                <alarm-summary>
+                    <active-alarm-count>2</active-alarm-count>
+                </alarm-summary>
+                <alarm-detail>
+                    <alarm-time junos:seconds="1685967777">2023-06-05 12:22:57 UTC</alarm-time>
+                    <alarm-class>Minor</alarm-class>
+                    <alarm-description>Autorecovery information needs to be saved</alarm-description>
+                    <alarm-short-description>autorecovery-save-r</alarm-short-description>
+                    <alarm-type>Autorecovery</alarm-type>
+                </alarm-detail>
+                <alarm-detail>
+                    <alarm-time junos:seconds="1685967777">2023-06-05 12:22:57 UTC</alarm-time>
+                    <alarm-class>Minor</alarm-class>
+                    <alarm-description>Rescue configuration is not set</alarm-description>
+                    <alarm-short-description>no-rescue</alarm-short-description>
+                    <alarm-type>Configuration</alarm-type>
+                </alarm-detail>
+            </alarm-information>
+        </multi-routing-engine-item>
+
+    </multi-routing-engine-results>
+    <cli>
+        <banner>{primary:node0}</banner>
+    </cli>
+</rpc-reply>`
+
+	rpc := multiEngineResult{}
+	err := parseXML([]byte(body), &rpc)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "node0", rpc.Information.RoutingEngines[0].Name, "re-name")
+	assert.Equal(t, "Autorecovery", rpc.Information.RoutingEngines[0].AlarmInfo.Details[0].Type, "alarm-type")
+	assert.Equal(t, "Minor", rpc.Information.RoutingEngines[0].AlarmInfo.Details[0].Class, "alarm-class")
+	assert.Equal(t, "Autorecovery information needs to be saved", rpc.Information.RoutingEngines[0].AlarmInfo.Details[0].Description, "alarm-description")
+
+	assert.Equal(t, "node1", rpc.Information.RoutingEngines[1].Name, "re-name")
+	assert.Equal(t, "Configuration", rpc.Information.RoutingEngines[1].AlarmInfo.Details[1].Type, "alarm-type")
+	assert.Equal(t, "Minor", rpc.Information.RoutingEngines[1].AlarmInfo.Details[1].Class, "alarm-class")
+	assert.Equal(t, "Rescue configuration is not set", rpc.Information.RoutingEngines[1].AlarmInfo.Details[1].Description, "alarm-description")
+}
+
+// Test no multi routing engine
+func TestParseOutputSingleRESystemAlarms(t *testing.T) {
+	body := `<rpc-reply xmlns:junos="http://xml.juniper.net/junos/ZZZ/junos">
+    <alarm-information xmlns="http://xml.juniper.net/junos/ZZZ/junos-alarm">
+        <alarm-summary>
+            <active-alarm-count>2</active-alarm-count>
+        </alarm-summary>
+        <alarm-detail>
+            <alarm-time junos:seconds="1635533090">
+                2021-10-29 18:44:50 UTC
+            </alarm-time>
+            <alarm-class>Minor</alarm-class>
+            <alarm-description>Autorecovery information needs to be saved</alarm-description>
+            <alarm-short-description>autorecovery-save-r</alarm-short-description>
+            <alarm-type>Autorecovery</alarm-type>
+        </alarm-detail>
+        <alarm-detail>
+            <alarm-time junos:seconds="1635533089">
+                2021-10-29 18:44:49 UTC
+            </alarm-time>
+            <alarm-class>Minor</alarm-class>
+            <alarm-description>Rescue configuration is not set</alarm-description>
+            <alarm-short-description>no-rescue</alarm-short-description>
+            <alarm-type>Configuration</alarm-type>
+        </alarm-detail>
+    </alarm-information>
+    <cli>
+        <banner></banner>
+    </cli>
+</rpc-reply>`
+
+	rpc := multiEngineResult{}
+	err := parseXML([]byte(body), &rpc)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "N/A", rpc.Information.RoutingEngines[0].Name, "re-name")
+	assert.Equal(t, "Autorecovery", rpc.Information.RoutingEngines[0].AlarmInfo.Details[0].Type, "alarm-type")
+	assert.Equal(t, "Minor", rpc.Information.RoutingEngines[0].AlarmInfo.Details[0].Class, "alarm-class")
+	assert.Equal(t, "Autorecovery information needs to be saved", rpc.Information.RoutingEngines[0].AlarmInfo.Details[0].Description, "alarm-description")
+}


### PR DESCRIPTION
This implements handling of multi-RE alarm responses, fixing #216.
It also introduces a few test cases to ensure multi-RE systems are being handled properly in the future.

Apparently GitHub doesn't like "fixing", here you go: fixes #216

This has been tested against SRX 300 series firewalls in single node and chassis cluster modes.