### PR TITLE
scrape more transceiver data

### DIFF
--- a/pkg/features/interfacediagnostics/collector.go
+++ b/pkg/features/interfacediagnostics/collector.go
@@ -302,6 +302,11 @@ func transceiverInfoFromRPCResult(chassisHardware chassisHardware) []*chassisSub
 				j := strings.Split(subModule.Name, " ")[1]
 				k := strings.Split(subSubModule.Name, " ")[1]
 
+				name := strings.Split(subSubModule.Name, " ")[0]
+				if name != "Xcvr" {
+					continue
+				}
+
 				id := i + "/" + j + "/" + k
 				transceiver := &chassisSubSubModule{
 					Name:         id,

--- a/pkg/features/interfacediagnostics/collector.go
+++ b/pkg/features/interfacediagnostics/collector.go
@@ -132,7 +132,7 @@ func (c *interfaceDiagnosticsCollector) init() {
 	c.laserRxOpticalPowerHighWarnThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_rx_high_warn_threshold_dbm", "Laser rx power high warn threshold_dbm in dBm", l, nil)
 	c.laserRxOpticalPowerLowWarnThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_rx_low_warn_threshold_dbm", "Laser rx power low warn threshold_dbm in dBm", l, nil)
 
-	transceiver_labels := []string{"target", "name", "version", "part_number", "serial_number", "description"}
+	transceiver_labels := []string{"target", "name", "version", "part_number", "serial_number", "description", "speed"}
 	c.transceiverDesc = prometheus.NewDesc("junos_interface_transceiver", "Transceiver Info", transceiver_labels, nil)
 }
 
@@ -195,7 +195,6 @@ func (c *interfaceDiagnosticsCollector) Collect(client collector.Client, ch chan
 		if err != nil {
 			return err
 		}
-
 		diagnostics = append(diagnostics, diagnosticsSatellite...)
 	}
 
@@ -265,22 +264,44 @@ func (c *interfaceDiagnosticsCollector) Collect(client collector.Client, ch chan
 		}
 	}
 
+	ifMediaDict, err := c.interfaceInformation(client)
+	if err != nil {
+		return err
+	}
+
 	transceiverInfo, err := c.chassisHardwareInfos(client)
 	if err != nil {
 		return err
 	}
 
-	for _, t := range transceiverInfo {
+	interfaceDictList := make(map[string]*interfaceStatsAggregate)
 
+	for _, t := range transceiverInfo {
 		if diag, hit := diagnostics_dict[t.Name]; hit {
 			t.Name = diag.Name
-			continue
-		}
-		if t.Description == "SFP-T" {
+		} else if t.Description == "SFP-T" {
 			t.Name = "ge-" + t.Name
+		} else {
+			t.Name = "slot-" + t.Name
+			transceiver_labels := append(labelValues, t.Name, t.Version, t.PartNumber, t.SerialNumber, t.Description, "")
+			ch <- prometheus.MustNewConstMetric(c.transceiverDesc, prometheus.GaugeValue, 0, transceiver_labels...)
 			continue
 		}
-		t.Name = "slot-" + t.Name
+
+		s := interfaceStatsAggregate{
+			ChassisHardwareInfo: t,
+			InterfacesMediaInfo: (ifMediaDict[t.Name]),
+		}
+
+		interfaceDictList[t.Name] = &s
+		transceiver_labels := append(labelValues, t.Name, t.Version, t.PartNumber, t.SerialNumber, t.Description, s.InterfacesMediaInfo.Speed)
+
+		if s.InterfacesMediaInfo.AdminStatus == "up" && s.InterfacesMediaInfo.OperStatus == "up" {
+			ch <- prometheus.MustNewConstMetric(c.transceiverDesc, prometheus.GaugeValue, 1, transceiver_labels...)
+		} else {
+			ch <- prometheus.MustNewConstMetric(c.transceiverDesc, prometheus.GaugeValue, 0, transceiver_labels...)
+		}
+
 	}
 
 	return nil
@@ -306,23 +327,46 @@ func (c *interfaceDiagnosticsCollector) chassisHardwareInfos(client *rpc.Client)
 	return transceiverInfoFromRPCResult(x), nil
 }
 
+func (c *interfaceDiagnosticsCollector) interfaceInformation(client *rpc.Client) (map[string]*physicalInterface, error) {
+	var x = interfacesMediaStruct{}
+	err := client.RunCommandAndParse("show interfaces media", &x)
+	if err != nil {
+		return nil, err
+	}
+
+	return interfaceMediaInfoFromRPCResult(&x.InterfaceInformation.PhysicalInterface), nil
+}
+
+func interfaceMediaInfoFromRPCResult(interfaceMediaList *[]physicalInterface) map[string]*physicalInterface {
+
+	interfaceMediaDict := make(map[string]*physicalInterface)
+
+	for _, i := range *interfaceMediaList {
+		iface := i
+		interfaceMediaDict[iface.Name] = &iface
+	}
+
+	return interfaceMediaDict
+}
+
 func transceiverInfoFromRPCResult(chassisHardware chassisHardware) []*chassisSubSubModule {
 	transceiverList := make([]*chassisSubSubModule, 0)
 
 	var chassisModules = chassisHardware.ChassisInventory.Chassis.ChassisModule
 	for _, module := range chassisModules {
+		if strings.Split(module.Name, " ")[0] != "FPC" {
+			continue
+		}
 		for _, subModule := range module.ChassisSubModule {
+			if strings.Split(subModule.Name, " ")[0] != "PIC" {
+				continue
+			}
 			for _, subSubModule := range subModule.ChassisSubSubModule {
-				i := strings.Split(module.Name, " ")[1]
-				j := strings.Split(subModule.Name, " ")[1]
-				k := strings.Split(subSubModule.Name, " ")[1]
+				fpc := strings.Split(module.Name, " ")[1]
+				pic := strings.Split(subModule.Name, " ")[1]
+				port := strings.Split(subSubModule.Name, " ")[1]
 
-				name := strings.Split(subSubModule.Name, " ")[0]
-				if name != "Xcvr" {
-					continue
-				}
-
-				id := i + "/" + j + "/" + k
+				id := fpc + "/" + pic + "/" + port
 				transceiver := &chassisSubSubModule{
 					Name:         id,
 					Version:      subSubModule.Version,

--- a/pkg/features/interfacediagnostics/collector.go
+++ b/pkg/features/interfacediagnostics/collector.go
@@ -4,6 +4,7 @@ package interfacediagnostics
 
 import (
 	"encoding/xml"
+	"fmt"
 	"log"
 	"math"
 	"net/rpc"
@@ -132,7 +133,7 @@ func (c *interfaceDiagnosticsCollector) init() {
 	c.laserRxOpticalPowerHighWarnThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_rx_high_warn_threshold_dbm", "Laser rx power high warn threshold_dbm in dBm", l, nil)
 	c.laserRxOpticalPowerLowWarnThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_rx_low_warn_threshold_dbm", "Laser rx power low warn threshold_dbm in dBm", l, nil)
 
-	transceiver_labels := []string{"target", "name", "version", "part_number", "serial_number", "description", "speed"}
+	transceiver_labels := []string{"target", "name", "serial_number", "description", "speed", "fiber_type", "vendor_name", "vendor_part_number", "wavelength"}
 	c.transceiverDesc = prometheus.NewDesc("junos_interface_transceiver", "Transceiver Info", transceiver_labels, nil)
 }
 
@@ -264,46 +265,10 @@ func (c *interfaceDiagnosticsCollector) Collect(client collector.Client, ch chan
 		}
 	}
 
-	ifMediaDict, err := c.interfaceInformation(client)
+	err = createTransceiverMetrics(c, client, diagnostics_dict, ch, labelValues)
 	if err != nil {
 		return err
 	}
-
-	transceiverInfo, err := c.chassisHardwareInfos(client)
-	if err != nil {
-		return err
-	}
-
-	interfaceDictList := make(map[string]*interfaceStatsAggregate)
-
-	for _, t := range transceiverInfo {
-		if diag, hit := diagnostics_dict[t.Name]; hit {
-			t.Name = diag.Name
-		} else if t.Description == "SFP-T" {
-			t.Name = "ge-" + t.Name
-		} else {
-			t.Name = "slot-" + t.Name
-			transceiver_labels := append(labelValues, t.Name, t.Version, t.PartNumber, t.SerialNumber, t.Description, "")
-			ch <- prometheus.MustNewConstMetric(c.transceiverDesc, prometheus.GaugeValue, 0, transceiver_labels...)
-			continue
-		}
-
-		s := interfaceStatsAggregate{
-			ChassisHardwareInfo: t,
-			InterfacesMediaInfo: (ifMediaDict[t.Name]),
-		}
-
-		interfaceDictList[t.Name] = &s
-		transceiver_labels := append(labelValues, t.Name, t.Version, t.PartNumber, t.SerialNumber, t.Description, s.InterfacesMediaInfo.Speed)
-
-		if s.InterfacesMediaInfo.AdminStatus == "up" && s.InterfacesMediaInfo.OperStatus == "up" {
-			ch <- prometheus.MustNewConstMetric(c.transceiverDesc, prometheus.GaugeValue, 1, transceiver_labels...)
-		} else {
-			ch <- prometheus.MustNewConstMetric(c.transceiverDesc, prometheus.GaugeValue, 0, transceiver_labels...)
-		}
-
-	}
-
 	return nil
 }
 
@@ -317,14 +282,14 @@ func (c *interfaceDiagnosticsCollector) interfaceDiagnostics(client collector.Cl
 	return interfaceDiagnosticsFromRPCResult(x), nil
 }
 
-func (c *interfaceDiagnosticsCollector) chassisHardwareInfos(client *rpc.Client) ([]*chassisSubSubModule, error) {
+func (c *interfaceDiagnosticsCollector) chassisHardwareInfos(client *rpc.Client) ([]*transceiverInformation, error) {
 	var x = chassisHardware{}
 	err := client.RunCommandAndParse("show chassis hardware", &x)
 	if err != nil {
 		return nil, err
 	}
 
-	return transceiverInfoFromRPCResult(x), nil
+	return transceiverInfoFromRPCResult(client, x)
 }
 
 func (c *interfaceDiagnosticsCollector) interfaceInformation(client *rpc.Client) (map[string]*physicalInterface, error) {
@@ -349,8 +314,8 @@ func interfaceMediaInfoFromRPCResult(interfaceMediaList *[]physicalInterface) ma
 	return interfaceMediaDict
 }
 
-func transceiverInfoFromRPCResult(chassisHardware chassisHardware) []*chassisSubSubModule {
-	transceiverList := make([]*chassisSubSubModule, 0)
+func transceiverInfoFromRPCResult(client *rpc.Client, chassisHardware chassisHardware) ([]*transceiverInformation, error) {
+	transceiverList := make([]*transceiverInformation, 0)
 
 	var chassisModules = chassisHardware.ChassisInventory.Chassis.ChassisModule
 	for _, module := range chassisModules {
@@ -361,24 +326,72 @@ func transceiverInfoFromRPCResult(chassisHardware chassisHardware) []*chassisSub
 			if strings.Split(subModule.Name, " ")[0] != "PIC" {
 				continue
 			}
-			for _, subSubModule := range subModule.ChassisSubSubModule {
-				fpc := strings.Split(module.Name, " ")[1]
-				pic := strings.Split(subModule.Name, " ")[1]
-				port := strings.Split(subSubModule.Name, " ")[1]
+			fpc := strings.Split(module.Name, " ")[1]
+			pic := strings.Split(subModule.Name, " ")[1]
 
-				id := fpc + "/" + pic + "/" + port
-				transceiver := &chassisSubSubModule{
-					Name:         id,
-					Version:      subSubModule.Version,
-					PartNumber:   subSubModule.PartNumber,
-					SerialNumber: subSubModule.SerialNumber,
-					Description:  subSubModule.Description,
+			picPortsInformation, err := getPicPortsFromRPCResult(client, fpc, pic)
+			if err != nil {
+				return nil, err
+			}
+
+			for port, subSubModule := range subModule.ChassisSubSubModule {
+				port_name := strings.Split(subSubModule.Name, " ")[1]
+
+				id := fpc + "/" + pic + "/" + port_name
+				transceiver := transceiverInformation{
+					Name:                id,
+					ChassisHardwareInfo: &subSubModule,
+					PicPort:             &picPortsInformation[port],
 				}
-				transceiverList = append(transceiverList, transceiver)
+				transceiverList = append(transceiverList, &transceiver)
 			}
 		}
 	}
-	return transceiverList
+	return transceiverList, nil
+}
+
+func getPicPortsFromRPCResult(client *rpc.Client, fpc string, pic string) ([]picPort, error) {
+	var x = fPCInformationStruct{}
+	command := fmt.Sprintf("show chassis pic fpc-slot %s pic-slot %s", fpc, pic)
+	err := client.RunCommandAndParse(command, &x)
+	if err != nil {
+		return nil, err
+	}
+
+	return x.FPCInformation.FPC.PicDetail.PicPortInfoList, nil
+}
+
+func createTransceiverMetrics(c *interfaceDiagnosticsCollector, client *rpc.Client, diagnostics_dict map[string]*interfaceDiagnostics, ch chan<- prometheus.Metric, labelValues []string) error {
+
+	ifMediaDict, err := c.interfaceInformation(client)
+	if err != nil {
+		return err
+	}
+
+	transceiverInfo, err := c.chassisHardwareInfos(client)
+	if err != nil {
+		return err
+	}
+
+	for _, t := range transceiverInfo {
+		chassisInfo := t.ChassisHardwareInfo
+		port_speed := "0"
+
+		if diag, hit := diagnostics_dict[t.Name]; hit {
+			t.Name = diag.Name
+			port_speed = ifMediaDict[t.Name].Speed
+		} else if t.ChassisHardwareInfo.Description == "SFP-T" {
+			t.Name = "ge-" + t.Name
+			port_speed = ifMediaDict[t.Name].Speed
+		} else {
+			t.Name = "slot-" + t.Name
+		}
+
+		transceiver_labels := append(labelValues, t.Name, chassisInfo.SerialNumber, chassisInfo.Description, port_speed, t.PicPort.FiberMode, strings.TrimSpace(t.PicPort.SFPVendorName), strings.TrimSpace(t.PicPort.SFPVendorPno), t.PicPort.Wavelength)
+
+		ch <- prometheus.MustNewConstMetric(c.transceiverDesc, prometheus.GaugeValue, 1, transceiver_labels...)
+	}
+	return nil
 }
 
 func (c *interfaceDiagnosticsCollector) interfaceDiagnosticsSatellite(client *rpc.Client) ([]*interfaceDiagnostics, error) {

--- a/pkg/features/interfacediagnostics/collector.go
+++ b/pkg/features/interfacediagnostics/collector.go
@@ -289,8 +289,8 @@ func interfaceMediaInfoFromRPCResult(interfaceMediaList *[]physicalInterface) ma
 	for _, i := range *interfaceMediaList {
 		if strings.HasPrefix(i.Name, "xe") || strings.HasPrefix(i.Name, "ge") || strings.HasPrefix(i.Name, "et") {
 			iface := i
-			afterThirdIndex := iface.Name[3:]
-			interfaceMediaDict[afterThirdIndex] = &iface
+			slotIndex := iface.Name[3:]
+			interfaceMediaDict[slotIndex] = &iface
 		}
 	}
 	return interfaceMediaDict

--- a/pkg/features/interfacediagnostics/collector.go
+++ b/pkg/features/interfacediagnostics/collector.go
@@ -132,7 +132,7 @@ func (c *interfaceDiagnosticsCollector) init() {
 	c.laserRxOpticalPowerHighWarnThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_rx_high_warn_threshold_dbm", "Laser rx power high warn threshold_dbm in dBm", l, nil)
 	c.laserRxOpticalPowerLowWarnThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_rx_low_warn_threshold_dbm", "Laser rx power low warn threshold_dbm in dBm", l, nil)
 
-	transceiver_labels := []string{"target", "slot", "version", "part_number", "serial_number", "description"}
+	transceiver_labels := []string{"target", "name", "version", "part_number", "serial_number", "description"}
 	c.transceiverDesc = prometheus.NewDesc("junos_interface_transceiver", "Transceiver Info", transceiver_labels, nil)
 }
 
@@ -189,15 +189,6 @@ func (c *interfaceDiagnosticsCollector) Collect(client collector.Client, ch chan
 		return err
 	}
 
-	transceiverInfo, err := c.chassisHardwareInfos(client)
-	if err != nil {
-		return err
-	}
-	for _, t := range transceiverInfo {
-		transceiver_labels := append(labelValues, t.Name, t.Version, t.PartNumber, t.SerialNumber, t.Description)
-		ch <- prometheus.MustNewConstMetric(c.transceiverDesc, prometheus.GaugeValue, 1, transceiver_labels...)
-	}
-
 	// add satellite details if feature is enabled
 	if client.IsSatelliteEnabled() {
 		diagnosticsSatellite, err := c.interfaceDiagnosticsSatellite(client)
@@ -208,7 +199,13 @@ func (c *interfaceDiagnosticsCollector) Collect(client collector.Client, ch chan
 		diagnostics = append(diagnostics, diagnosticsSatellite...)
 	}
 
+	diagnostics_dict := make(map[string]*interfaceDiagnostics)
+
 	for _, d := range diagnostics {
+
+		index := strings.Split(d.Name, "-")[1]
+		diagnostics_dict[index] = d
+
 		l := append(labelValues, d.Name)
 		l = append(l, c.labels.ValuesForInterface(client.Device(), d.Name)...)
 
@@ -266,6 +263,24 @@ func (c *interfaceDiagnosticsCollector) Collect(client collector.Client, ch chan
 			ch <- prometheus.MustNewConstMetric(c.laserRxOpticalPowerHighWarnThresholdDbmDesc, prometheus.GaugeValue, d.LaserRxOpticalPowerHighWarnThresholdDbm, l2...)
 			ch <- prometheus.MustNewConstMetric(c.laserRxOpticalPowerLowWarnThresholdDbmDesc, prometheus.GaugeValue, d.LaserRxOpticalPowerLowWarnThresholdDbm, l2...)
 		}
+	}
+
+	transceiverInfo, err := c.chassisHardwareInfos(client)
+	if err != nil {
+		return err
+	}
+
+	for _, t := range transceiverInfo {
+
+		if diag, hit := diagnostics_dict[t.Name]; hit {
+			t.Name = diag.Name
+			continue
+		}
+		if t.Description == "SFP-T" {
+			t.Name = "ge-" + t.Name
+			continue
+		}
+		t.Name = "slot-" + t.Name
 	}
 
 	return nil

--- a/pkg/features/interfacediagnostics/collector.go
+++ b/pkg/features/interfacediagnostics/collector.go
@@ -272,27 +272,7 @@ func (c *interfaceDiagnosticsCollector) Collect(client collector.Client, ch chan
 	return nil
 }
 
-func (c *interfaceDiagnosticsCollector) interfaceDiagnostics(client collector.Client) ([]*interfaceDiagnostics, error) {
-	var x = result{}
-	err := client.RunCommandAndParse("show interfaces diagnostics optics", &x)
-	if err != nil {
-		return nil, err
-	}
-
-	return interfaceDiagnosticsFromRPCResult(x), nil
-}
-
-func (c *interfaceDiagnosticsCollector) chassisHardwareInfos(client *rpc.Client) ([]*transceiverInformation, error) {
-	var x = chassisHardware{}
-	err := client.RunCommandAndParse("show chassis hardware", &x)
-	if err != nil {
-		return nil, err
-	}
-
-	return transceiverInfoFromRPCResult(client, x)
-}
-
-func (c *interfaceDiagnosticsCollector) interfaceInformation(client *rpc.Client) (map[string]*physicalInterface, error) {
+func (c *interfaceDiagnosticsCollector) interfaceMediaInfo(client *rpc.Client) (map[string]*physicalInterface, error) {
 	var x = interfacesMediaStruct{}
 	err := client.RunCommandAndParse("show interfaces media", &x)
 	if err != nil {
@@ -307,14 +287,26 @@ func interfaceMediaInfoFromRPCResult(interfaceMediaList *[]physicalInterface) ma
 	interfaceMediaDict := make(map[string]*physicalInterface)
 
 	for _, i := range *interfaceMediaList {
-		iface := i
-		interfaceMediaDict[iface.Name] = &iface
+		if strings.HasPrefix(i.Name, "xe") || strings.HasPrefix(i.Name, "ge") || strings.HasPrefix(i.Name, "et") {
+			iface := i
+			afterThirdIndex := iface.Name[3:]
+			interfaceMediaDict[afterThirdIndex] = &iface
+		}
 	}
-
 	return interfaceMediaDict
 }
 
-func transceiverInfoFromRPCResult(client *rpc.Client, chassisHardware chassisHardware) ([]*transceiverInformation, error) {
+func (c *interfaceDiagnosticsCollector) chassisHardwareInfos(client *rpc.Client) ([]*transceiverInformation, error) {
+	var x = chassisHardware{}
+	err := client.RunCommandAndParse("show chassis hardware", &x)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.transceiverInfoFromRPCResult(client, x)
+}
+
+func (c *interfaceDiagnosticsCollector) transceiverInfoFromRPCResult(client *rpc.Client, chassisHardware chassisHardware) ([]*transceiverInformation, error) {
 	transceiverList := make([]*transceiverInformation, 0)
 
 	var chassisModules = chassisHardware.ChassisInventory.Chassis.ChassisModule
@@ -329,18 +321,18 @@ func transceiverInfoFromRPCResult(client *rpc.Client, chassisHardware chassisHar
 			fpc := strings.Split(module.Name, " ")[1]
 			pic := strings.Split(subModule.Name, " ")[1]
 
-			picPortsInformation, err := getPicPortsFromRPCResult(client, fpc, pic)
+			picPortsInformation, err := c.getPicPortsFromRPCResult(client, fpc, pic)
 			if err != nil {
 				return nil, err
 			}
 
 			for port, subSubModule := range subModule.ChassisSubSubModule {
 				port_name := strings.Split(subSubModule.Name, " ")[1]
-
+				subSubModule_pointer := subSubModule
 				id := fpc + "/" + pic + "/" + port_name
 				transceiver := transceiverInformation{
 					Name:                id,
-					ChassisHardwareInfo: &subSubModule,
+					ChassisHardwareInfo: &subSubModule_pointer,
 					PicPort:             &picPortsInformation[port],
 				}
 				transceiverList = append(transceiverList, &transceiver)
@@ -350,7 +342,7 @@ func transceiverInfoFromRPCResult(client *rpc.Client, chassisHardware chassisHar
 	return transceiverList, nil
 }
 
-func getPicPortsFromRPCResult(client *rpc.Client, fpc string, pic string) ([]picPort, error) {
+func (c *interfaceDiagnosticsCollector) getPicPortsFromRPCResult(client *rpc.Client, fpc string, pic string) ([]picPort, error) {
 	var x = fPCInformationStruct{}
 	command := fmt.Sprintf("show chassis pic fpc-slot %s pic-slot %s", fpc, pic)
 	err := client.RunCommandAndParse(command, &x)
@@ -363,7 +355,7 @@ func getPicPortsFromRPCResult(client *rpc.Client, fpc string, pic string) ([]pic
 
 func createTransceiverMetrics(c *interfaceDiagnosticsCollector, client *rpc.Client, diagnostics_dict map[string]*interfaceDiagnostics, ch chan<- prometheus.Metric, labelValues []string) error {
 
-	ifMediaDict, err := c.interfaceInformation(client)
+	ifMediaDict, err := c.interfaceMediaInfo(client)
 	if err != nil {
 		return err
 	}
@@ -376,20 +368,21 @@ func createTransceiverMetrics(c *interfaceDiagnosticsCollector, client *rpc.Clie
 	for _, t := range transceiverInfo {
 		chassisInfo := t.ChassisHardwareInfo
 		port_speed := "0"
+		oper_status := 0.0
 
-		if diag, hit := diagnostics_dict[t.Name]; hit {
-			t.Name = diag.Name
-			port_speed = ifMediaDict[t.Name].Speed
-		} else if t.ChassisHardwareInfo.Description == "SFP-T" {
-			t.Name = "ge-" + t.Name
-			port_speed = ifMediaDict[t.Name].Speed
+		if media, hit := ifMediaDict[t.Name]; hit {
+			if media.OperStatus == "up" {
+				oper_status = 1.0
+			}
+			t.Name = media.Name
+			port_speed = media.Speed
 		} else {
 			t.Name = "slot-" + t.Name
 		}
 
 		transceiver_labels := append(labelValues, t.Name, chassisInfo.SerialNumber, chassisInfo.Description, port_speed, t.PicPort.FiberMode, strings.TrimSpace(t.PicPort.SFPVendorName), strings.TrimSpace(t.PicPort.SFPVendorPno), t.PicPort.Wavelength)
 
-		ch <- prometheus.MustNewConstMetric(c.transceiverDesc, prometheus.GaugeValue, 1, transceiver_labels...)
+		ch <- prometheus.MustNewConstMetric(c.transceiverDesc, prometheus.GaugeValue, oper_status, transceiver_labels...)
 	}
 	return nil
 }
@@ -444,6 +437,16 @@ func (c *interfaceDiagnosticsCollector) interfaceDiagnosticsSatellite(client *rp
 		return xml.Unmarshal(tmpByte, &x)
 	})
 
+	if err != nil {
+		return nil, err
+	}
+
+	return interfaceDiagnosticsFromRPCResult(x), nil
+}
+
+func (c *interfaceDiagnosticsCollector) interfaceDiagnostics(client *rpc.Client) ([]*interfaceDiagnostics, error) {
+	var x = result{}
+	err := client.RunCommandAndParse("show interfaces diagnostics optics", &x)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/features/interfacediagnostics/interface_stats.go
+++ b/pkg/features/interfacediagnostics/interface_stats.go
@@ -1,6 +1,7 @@
 package interfacediagnostics
 
-type interfaceStatsAggregate struct {
+type transceiverInformation struct {
+	Name                string
 	ChassisHardwareInfo *chassisSubSubModule
-	InterfacesMediaInfo *physicalInterface
+	PicPort             *picPort
 }

--- a/pkg/features/interfacediagnostics/interface_stats.go
+++ b/pkg/features/interfacediagnostics/interface_stats.go
@@ -1,0 +1,6 @@
+package interfacediagnostics
+
+type interfaceStatsAggregate struct {
+	ChassisHardwareInfo *chassisSubSubModule
+	InterfacesMediaInfo *physicalInterface
+}

--- a/pkg/features/interfacediagnostics/rpc.go
+++ b/pkg/features/interfacediagnostics/rpc.go
@@ -2,6 +2,52 @@
 
 package interfacediagnostics
 
+type interfacesMediaStruct struct {
+	InterfaceInformation struct {
+		PhysicalInterface []physicalInterface `xml:"physical-interface"`
+	} `xml:"interface-information"`
+}
+
+type physicalInterface struct {
+	Name             string `xml:"name"`
+	AdminStatus      string `xml:"admin-status"`
+	OperStatus       string `xml:"oper-status"`
+	LocalIndex       string `xml:"local-index"`
+	SnmpIndex        string `xml:"snmp-index"`
+	IfType           string `xml:"if-type"`
+	LinkLevelType    string `xml:"link-level-type"`
+	Mtu              string `xml:"mtu"`
+	Speed            string `xml:"speed"`
+	LinkType         string `xml:"link-type"`
+	InterfaceFlapped struct {
+		Seconds uint64 `xml:"seconds,attr"`
+		Value   string `xml:",chardata"`
+	} `xml:"interface-flapped"`
+	IfDeviceFlags ifDeviceFlags `xml:"if-device-flags"`
+	Stats         trafficStat   `xml:"traffic-statistics"`
+}
+
+type trafficStat struct {
+	InputBytes    uint64   `xml:"input-bytes"`
+	InputPackets  uint64   `xml:"input-packets"`
+	OutputBytes   uint64   `xml:"output-bytes"`
+	OutputPackets uint64   `xml:"output-packets"`
+	IPv6Traffic   ipv6Stat `xml:"ipv6-transit-statistics"`
+}
+type ipv6Stat struct {
+	InputBytes    uint64 `xml:"input-bytes"`
+	InputPackets  uint64 `xml:"input-packets"`
+	OutputBytes   uint64 `xml:"output-bytes"`
+	OutputPackets uint64 `xml:"output-packets"`
+}
+
+type ifDeviceFlags struct {
+	Present  bool `xml:"ifdf-present"`
+	Running  bool `xml:"ifdf-running"`
+	Loopback bool `xml:"ifdf-loopback"`
+	Down     bool `xml:"ifdf-down"`
+}
+
 type chassisHardware struct {
 	ChassisInventory chassisInventory `xml:"chassis-inventory"`
 }

--- a/pkg/features/interfacediagnostics/rpc.go
+++ b/pkg/features/interfacediagnostics/rpc.go
@@ -2,6 +2,48 @@
 
 package interfacediagnostics
 
+type chassisHardware struct {
+	ChassisInventory chassisInventory `xml:"chassis-inventory"`
+}
+
+type chassisInventory struct {
+	Chassis chassis `xml:"chassis"`
+}
+
+type chassis struct {
+	Name          string          `xml:"name"`
+	SerialNumber  string          `xml:"serial-number"`
+	Description   string          `xml:"description"`
+	ChassisModule []chassisModule `xml:"chassis-module"`
+}
+
+type chassisModule struct {
+	Name             string             `xml:"name"`
+	PartNumber       string             `xml:"part-number"`
+	SerialNumber     string             `xml:"serial-number"`
+	Description      string             `xml:"description"`
+	CleiCode         string             `xml:"clei-code"`
+	ModelNumber      string             `xml:"model-number"`
+	ChassisSubModule []chassisSubModule `xml:"chassis-sub-module"`
+}
+
+type chassisSubModule struct {
+	Name                string                `xml:"name"`
+	PartNumber          string                `xml:"part-number"`
+	SerialNumber        string                `xml:"serial-number"`
+	Description         string                `xml:"description"`
+	CleiCode            string                `xml:"clei-code"`
+	ModelNumber         string                `xml:"model-number"`
+	ChassisSubSubModule []chassisSubSubModule `xml:"chassis-sub-sub-module"`
+}
+type chassisSubSubModule struct {
+	Name         string `xml:"name"`
+	Version      string `xml:"version"`
+	PartNumber   string `xml:"part-number"`
+	SerialNumber string `xml:"serial-number"`
+	Description  string `xml:"description"`
+}
+
 type result struct {
 	Information struct {
 		Diagnostics []phyDiagInterface `xml:"physical-interface"`

--- a/pkg/features/interfacediagnostics/rpc.go
+++ b/pkg/features/interfacediagnostics/rpc.go
@@ -2,6 +2,38 @@
 
 package interfacediagnostics
 
+type fPCInformationStruct struct {
+	FPCInformation fPCInformation `xml:"fpc-information"`
+}
+type fPCInformation struct {
+	FPC fPC `xml:"fpc"`
+}
+
+type fPC struct {
+	PicDetail picDetail `xml:"pic-detail"`
+}
+
+type picDetail struct {
+	Slot            int       `xml:"slot"`
+	PicSlot         int       `xml:"pic-slot"`
+	PicType         string    `xml:"pic-type"`
+	State           string    `xml:"state"`
+	PicVersion      string    `xml:"pic-version"`
+	UpTime          string    `xml:"up-time"`
+	PicPortInfoList []picPort `xml:"port-information>port"`
+}
+
+type picPort struct {
+	PortNumber     int    `xml:"port-number"`
+	CableType      string `xml:"cable-type"`
+	FiberMode      string `xml:"fiber-mode"`
+	SFPVendorName  string `xml:"sfp-vendor-name"`
+	SFPVendorPno   string `xml:"sfp-vendor-pno"`
+	Wavelength     string `xml:"wavelength"`
+	SFPVendorFwVer string `xml:"sfp-vendor-fw-ver"`
+	SFPJnprVer     string `xml:"sfp-jnpr-ver"`
+}
+
 type interfacesMediaStruct struct {
 	InterfaceInformation struct {
 		PhysicalInterface []physicalInterface `xml:"physical-interface"`


### PR DESCRIPTION
this pr scrapes transceiver information and adds a new metric to the interfacediagnostics module.

"show chassis hardware", "show interfaces media" and "show chassis pic fpc-slot x pic-slot y" are all used to create a new metric.

called junos_interface_transceiver.

e.g.: 
`junos_interface_transceiver{description="SFP-T",fiber_type="n/a",name="ge-1/0/33",serial_number="F78K8TE",speed="1000mbps",target="csw01.anx10.par.fr.anexia-it.net",vendor_name="FLEXOPTIX",vendor_part_number="T.C12.02",wavelength="n/a"} 1`