### PR TITLE
Update Helm Chart patch series

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -1,6 +1,10 @@
 # Helm chart for helm v3
 
 ## How to use
+
+### Authentication
+
+#### SSH key authentication
 Add your ssh-keyfile and config.yml to values.yml
 
 > sshkey is the base64 encoded id_rsa you want to use for authentication  
@@ -8,7 +12,47 @@ Add your ssh-keyfile and config.yml to values.yml
 
 `sshkey: QWRkIHlvdXIgb3duIGlkX3JzYSBoZXJl`
 
+#### Password authentication
+To use password authentication the following values.yaml configuration could
+be used with a `junos-exporter-ssh` secret object storing SSH secrets:
+
+``` yaml
+extraArgs:
+- "-ssh.targets=$(JUNOS_EXPORTER_SSH_TARGETS)"
+- "-ssh.user=$(JUNOS_EXPORTER_SSH_USER)"
+- "-ssh.password=$(JUNOS_EXPORTER_SSH_PASSWORD)"
+
+extraEnv:
+- name: JUNOS_EXPORTER_SSH_TARGETS
+  valueFrom:
+    secretKeyRef:
+      name: junos-exporter-ssh
+      key: targets
+- name: JUNOS_EXPORTER_SSH_USER
+  valueFrom:
+    secretKeyRef:
+      name: junos-exporter-ssh
+      key: username
+- name: JUNOS_EXPORTER_SSH_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: junos-exporter-ssh
+      key: password
+```
+
+``` yaml
+apiVersion: v1
+kind: Secret
+type: Opaque
+data:
+  password: BASE64_ENCODED_SSH_PASSWORD
+  targets: BASE64_ENCODED_SSH_TARGETS
+  username: BASE64_ENCODED_SSH_USERNAME
+```
+
+### Devices configuration
 Add your devices to the devices in configyml in values.yml
 
+### Installation
 > cd helm  
 > helm install junosexporter ./junosexporter 

--- a/helm/junosexporter/Chart.yaml
+++ b/helm/junosexporter/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helm/junosexporter/Chart.yaml
+++ b/helm/junosexporter/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: junos_exporter
+name: junos-exporter
 description: junos_exporter deployment for prometheus-operator
 
 # A chart can be either an 'application' or a 'library' chart.

--- a/helm/junosexporter/Chart.yaml
+++ b/helm/junosexporter/Chart.yaml
@@ -18,7 +18,7 @@ version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v0.9.5.7
+appVersion: v0.12.2
 
 # dependencies:
 # - name: prometheus-operator

--- a/helm/junosexporter/templates/configmap.yaml
+++ b/helm/junosexporter/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.configyml }}
 apiVersion: v1
 kind: ConfigMap
 data:
@@ -7,4 +8,4 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "junos_exporter.labels" . | nindent 4 }}
-      
+{{- end }}

--- a/helm/junosexporter/templates/configmap.yaml
+++ b/helm/junosexporter/templates/configmap.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: ConfigMap
 data:
-  config.yml: {{ toYaml .Values.configyml | indent 2 }}
+  config.yml: |
+    {{- toYaml .Values.configyml | nindent 4 }}
 metadata:
   name: {{ .Release.Name }}-configmap
   namespace: {{ .Values.namespace }}

--- a/helm/junosexporter/templates/configmap.yaml
+++ b/helm/junosexporter/templates/configmap.yaml
@@ -6,7 +6,6 @@ data:
     {{- toYaml .Values.configyml | nindent 4 }}
 metadata:
   name: {{ .Release.Name }}-configmap
-  namespace: {{ .Values.namespace }}
   labels:
     {{- include "junos_exporter.labels" . | nindent 4 }}
 {{- end }}

--- a/helm/junosexporter/templates/deployment.yaml
+++ b/helm/junosexporter/templates/deployment.yaml
@@ -11,6 +11,13 @@ spec:
       {{- include "junos_exporter.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- if .Values.rollOutJunosExporterPods }}
+      annotations:
+        {{- if .Values.rollOutJunosExporterPods }}
+        # ensure pods roll when configmap updates
+        junos-exporter.github.io/junos-exporter-configmap-checksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
+        {{- end }}
+      {{- end }}
       labels:
         {{- include "junos_exporter.selectorLabels" . | nindent 8 }}
     spec:

--- a/helm/junosexporter/templates/deployment.yaml
+++ b/helm/junosexporter/templates/deployment.yaml
@@ -64,6 +64,19 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if or .Values.configyml .Values.sshkey }}
+      volumes:
+        {{- if .Values.configyml }}
+        - name: {{ .Release.Name }}-configmap
+          configMap:
+            name: {{ .Release.Name }}-configmap
+        {{- end }}
+        {{- if .Values.sshkey }}
+        - name: {{ .Release.Name }}-sshkey
+          secret:
+            secretName: {{ .Release.Name }}-sshkey
+        {{- end }}
+      {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/junosexporter/templates/deployment.yaml
+++ b/helm/junosexporter/templates/deployment.yaml
@@ -42,17 +42,23 @@ spec:
           - name: SSH_KEYFILE
             value: "/ssh/ssh-keyfile"
           {{- end }}
+          {{- if .Values.configyml }}
           - name: CONFIG_FILE
             value: "/config/config.yml"
+          {{- end }}
           {{- with .Values.extraEnv }}
           {{- toYaml . | trim | nindent 10 }}
           {{- end }}
+          {{- if or .Values.configyml .Values.sshkey }}
           volumeMounts:
+          {{- if .Values.configyml }}
           - mountPath: /config
             name: {{ .Release.Name }}-configmap
+          {{- end }}
           {{- if .Values.sshkey }}
           - mountPath: /ssh
             name: {{ .Release.Name }}-sshkey
+          {{- end }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/junosexporter/templates/deployment.yaml
+++ b/helm/junosexporter/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+          - /app/junos_exporter
           {{- if .Values.extraArgs }}
           args:
           {{- with .Values.extraArgs }}

--- a/helm/junosexporter/templates/deployment.yaml
+++ b/helm/junosexporter/templates/deployment.yaml
@@ -32,15 +32,19 @@ spec:
               containerPort: 9326
               protocol: TCP
           env:
+          {{- if .Values.sshkey }}
           - name: SSH_KEYFILE
             value: "/ssh/ssh-keyfile"
+          {{- end }}
           - name: CONFIG_FILE
             value: "/config/config.yml"
           volumeMounts:
           - mountPath: /config
             name: {{ .Release.Name }}-configmap
+          {{- if .Values.sshkey }}
           - mountPath: /ssh
             name: {{ .Release.Name }}-sshkey
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
     {{- with .Values.nodeSelector }}

--- a/helm/junosexporter/templates/deployment.yaml
+++ b/helm/junosexporter/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
           {{- end }}
           - name: CONFIG_FILE
             value: "/config/config.yml"
+          {{- with .Values.extraEnv }}
+          {{- toYaml . | trim | nindent 10 }}
+          {{- end }}
           volumeMounts:
           - mountPath: /config
             name: {{ .Release.Name }}-configmap

--- a/helm/junosexporter/templates/deployment.yaml
+++ b/helm/junosexporter/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
           - /app/junos_exporter
           {{- if .Values.extraArgs }}
           args:
+          {{- if .Values.configyml }}
+          - -config.file=/config/config.yml
+          {{- end }}
           {{- with .Values.extraArgs }}
           {{- toYaml . | trim | nindent 10 }}
           {{- end }}
@@ -50,10 +53,6 @@ spec:
           {{- if .Values.sshkey }}
           - name: SSH_KEYFILE
             value: "/ssh/ssh-keyfile"
-          {{- end }}
-          {{- if .Values.configyml }}
-          - name: CONFIG_FILE
-            value: "/config/config.yml"
           {{- end }}
           {{- with .Values.extraEnv }}
           {{- toYaml . | trim | nindent 10 }}

--- a/helm/junosexporter/templates/deployment.yaml
+++ b/helm/junosexporter/templates/deployment.yaml
@@ -27,6 +27,12 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.extraArgs }}
+          args:
+          {{- with .Values.extraArgs }}
+          {{- toYaml . | trim | nindent 10 }}
+          {{- end }}
+          {{- end }}
           ports:
             - name: metrics
               containerPort: 9326

--- a/helm/junosexporter/templates/secret.yaml
+++ b/helm/junosexporter/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.sshkey }}
 apiVersion: v1
 kind: Secret
 data:
@@ -8,3 +9,4 @@ metadata:
   labels:
     {{- include "junos_exporter.labels" . | nindent 4 }}
 type: Opaque
+{{- end }}

--- a/helm/junosexporter/templates/servicemonitor.yaml
+++ b/helm/junosexporter/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}-serviceMonitor
+  name: {{ .Release.Name }}-servicemonitor
   namespace: {{ .Values.namespace }}
   release: {{ .Values.prometheusOperator }}
   labels:

--- a/helm/junosexporter/templates/servicemonitor.yaml
+++ b/helm/junosexporter/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.prometheusOperator .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -14,3 +15,4 @@ spec:
   jobLabel: {{ default "jobLabel" .Values.serviceMonitor.jobLabel }}
   selector:
     {{- include "junos_exporter.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/junosexporter/values.yaml
+++ b/helm/junosexporter/values.yaml
@@ -21,6 +21,9 @@ fullnameOverride: ""
 # generate sshkey with `cat $HOME/.ssh/id_rsa | base64 -w0 && echo`
 # sshkey: "QWRkIHlvdXIgb3duIGlkX3JzYSBoZXJl"
 
+# Additional junos_exporter container environment variables.
+extraEnv: []
+
 # configyml is the configfile for the exporter
 configyml: |-
     devices:

--- a/helm/junosexporter/values.yaml
+++ b/helm/junosexporter/values.yaml
@@ -19,7 +19,7 @@ fullnameOverride: ""
 
 # sshkey is the base64 encoded id_rsa you want to use for authentication
 # generate sshkey with `cat $HOME/.ssh/id_rsa | base64 -w0 && echo`
-sshkey: QWRkIHlvdXIgb3duIGlkX3JzYSBoZXJl
+# sshkey: "QWRkIHlvdXIgb3duIGlkX3JzYSBoZXJl"
 
 # configyml is the configfile for the exporter
 configyml: |-

--- a/helm/junosexporter/values.yaml
+++ b/helm/junosexporter/values.yaml
@@ -28,7 +28,7 @@ extraEnv: []
 extraArgs: []
 
 # configyml is the configfile for the exporter
-# configyml: |-
+# configyml:
 #     devices:
 #       - host: srx.example.com
 #         username: junos_exporter

--- a/helm/junosexporter/values.yaml
+++ b/helm/junosexporter/values.yaml
@@ -48,6 +48,7 @@ extraArgs: []
 #serviceMonitor.scapeTimeout needs to be high since junos_exporter uses ssh
 #serviceMonitor.interval needs to be higher than scrapeTimeout
 serviceMonitor:
+  enabled: true
   scrapeTimeout: 60s
   interval: 120s
   jobLabel: jobLabel

--- a/helm/junosexporter/values.yaml
+++ b/helm/junosexporter/values.yaml
@@ -28,22 +28,22 @@ extraEnv: []
 extraArgs: []
 
 # configyml is the configfile for the exporter
-configyml: |-
-    devices:
-      - host: srx.example.com
-        username: junos_exporter
-        keyfile: /config/ssh-keyfile
-
-    features:
-      bgp: false
-      ospf: false
-      isis: false
-      l2circuit: false
-      environment: true
-      routes: true
-      routing_engine: true
-      interface_diagnostic: true
-      power: true
+# configyml: |-
+#     devices:
+#       - host: srx.example.com
+#         username: junos_exporter
+#         keyfile: /config/ssh-keyfile
+#
+#     features:
+#       bgp: false
+#       ospf: false
+#       isis: false
+#       l2circuit: false
+#       environment: true
+#       routes: true
+#       routing_engine: true
+#       interface_diagnostic: true
+#       power: true
 
 #serviceMonitor.scapeTimeout needs to be high since junos_exporter uses ssh
 #serviceMonitor.interval needs to be higher than scrapeTimeout

--- a/helm/junosexporter/values.yaml
+++ b/helm/junosexporter/values.yaml
@@ -90,3 +90,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Roll out junos-exporter pods automatically when configmap is updated.
+rollOutJunosExporterPods: false

--- a/helm/junosexporter/values.yaml
+++ b/helm/junosexporter/values.yaml
@@ -4,8 +4,6 @@
 
 replicaCount: 1
 
-namespace: monitoring
-
 # prometheusOperator is the relase label for prometheus-operator to look at the servicemonitor
 prometheusOperator: prometheus-operator
 

--- a/helm/junosexporter/values.yaml
+++ b/helm/junosexporter/values.yaml
@@ -24,6 +24,9 @@ fullnameOverride: ""
 # Additional junos_exporter container environment variables.
 extraEnv: []
 
+# Additional junos_exporter container arguments.
+extraArgs: []
+
 # configyml is the configfile for the exporter
 configyml: |-
     devices:


### PR DESCRIPTION
Hi.

Following patch series allows to configure the chart more precise and fixes several issues, updates container image to new version.

values.yaml used for monitoring Juniper EX4550 with applied patches:
``` yaml
extraArgs:
- "-debug=true"
- "-ssh.targets=$(JUNOS_EXPORTER_SSH_TARGETS)"
- "-ssh.user=$(JUNOS_EXPORTER_SSH_USER)"
- "-ssh.password=$(JUNOS_EXPORTER_SSH_PASSWORD)"

extraEnv:
- name: JUNOS_EXPORTER_SSH_TARGETS
  valueFrom:
    secretKeyRef:
      name: junos-exporter-ssh
      key: targets
- name: JUNOS_EXPORTER_SSH_USER
  valueFrom:
    secretKeyRef:
      name: junos-exporter-ssh
      key: username
- name: JUNOS_EXPORTER_SSH_PASSWORD
  valueFrom:
    secretKeyRef:
      name: junos-exporter-ssh
      key: password

resources:
  limits:
    cpu: 1
    memory: 1Gi
  requests:
    cpu: 10m
    memory: 128Mi

serviceMonitor:
  enabled: true
  scrapeTimeout: "300s"
  interval: "600s"
```

Regards,
Oleg.