### PR TITLE
fix interface speed 0 error

### DIFF
--- a/pkg/features/interfaces/collector.go
+++ b/pkg/features/interfaces/collector.go
@@ -286,8 +286,8 @@ func (c *interfaceCollector) collectForInterface(s *interfaceStats, device *conn
 		}
 
 		speed := "0"
-		if strings.Contains(s.Speed, "mbps") {
-			speed = strings.Replace(s.Speed, "mbps", "000000", 1)
+		if strings.Contains(strings.ToLower(s.Speed), "mbps") {
+			speed = strings.Replace(strings.ToLower(s.Speed), "mbps", "000000", 1)
 		}
 		if strings.Contains(s.Speed, "Gbps") {
 			speed = strings.Replace(s.Speed, "Gbps", "000000000", 1)
@@ -306,6 +306,9 @@ func (c *interfaceCollector) collectForInterface(s *interfaceStats, device *conn
 		if strings.Contains(s.Speed, "Unlimited") {
 			speed = strings.Replace(s.Speed, "Unlimited", "0", 1)
 		}
+
+		// Trimming all white spaces in the entire string
+		speed = strings.ReplaceAll(speed, " ", "")
 
 		sp64, _ := strconv.ParseFloat(speed, 64)
 


### PR DESCRIPTION
When reading `junos_interface_speed{}` on `1000 Mbps` interfaces, the string `Mbps` doesn't match `mbps` & there is a white space between `1000` and `Mbps` which would result in `10 000000`

Example from a QFX5100

1000 Mbps
```
> show interfaces xe-0/0/47 extensive | display xml | grep speed 
            <speed>1000 Mbps</speed>
                <link-partner-speed>1000 Mbps</link-partner-speed>
```

Since we don't match `mbps`, `speed := "0"` remains true. 

This PR lowers Mbps to mbps before comparing && replaces all whitespaces in the end.