### PR TITLE
Fix wrong path to executable

### DIFF
--- a/.packaging/prometheus-junos-exporter.service
+++ b/.packaging/prometheus-junos-exporter.service
@@ -7,7 +7,7 @@ Restart=on-failure
 DynamicUser=yes
 User=prometheus
 EnvironmentFile=/etc/default/prometheus-junos-exporter
-ExecStart=/usr/local/bin/junos_exporter $ARGS
+ExecStart=/usr/bin/junos_exporter $ARGS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The correct executable path in the systemd unit definition does not contain 'local'.