### PR TITLE
Extract local AS from peer xml

### DIFF
--- a/pkg/features/bgp/helper.go
+++ b/pkg/features/bgp/helper.go
@@ -45,5 +45,13 @@ func localASNForPeer(p peer) string {
 		return strconv.FormatInt(p.OptionInformation.LocalAs, 10)
 	}
 
-	return strconv.FormatInt(p.OptionInformation.LocalSystemAs, 10)
+	if p.OptionInformation.LocalSystemAs > 0 {
+		return strconv.FormatInt(p.OptionInformation.LocalSystemAs, 10)
+	}
+
+	if p.LocalASN > 0 {
+		return strconv.FormatInt(p.LocalASN, 10)
+	}
+
+	return "unknown"
 }

--- a/pkg/features/bgp/rpc.go
+++ b/pkg/features/bgp/rpc.go
@@ -12,6 +12,7 @@ type peer struct {
 	CFGRTI            string            `xml:"peer-cfg-rti"`
 	IP                string            `xml:"peer-address"`
 	ASN               string            `xml:"peer-as"`
+	LocalASN          int64             `xml:"local-as"`
 	State             string            `xml:"peer-state"`
 	Group             string            `xml:"peer-group"`
 	GroupIndex        int64             `xml:"peer-group-index"`


### PR DESCRIPTION
When running this against an MX204 the `local_as` in `bgp_session_info` stays `0` - looks like the local ASN is on the _peer_ level instead in this case:

```xml
<rpc-reply xmlns:junos="http://xml.juniper.net/junos/23.4R1-S1.5/junos">
    <bgp-information xmlns="http://xml.juniper.net/junos/23.4R0/junos-routing">
        <bgp-peer junos:style="detail">
            <peer-address>129.143.109.0+179</peer-address>
            <peer-as>553</peer-as>
            <local-address>129.143.109.1+63080</local-address>
            <local-as>215185</local-as>
```