### PR TITLE
BGP: Implement dynamic labels from descriptions

### DIFF
--- a/collectors_test.go
+++ b/collectors_test.go
@@ -40,7 +40,7 @@ func TestCollectorsRegistered(t *testing.T) {
 
 	cols := collectorsForDevices([]*connector.Device{{
 		Host: "::1",
-	}}, c, "", interfacelabels.NewDynamicLabels())
+	}}, c, "", interfacelabels.NewDynamicLabelManager())
 
 	assert.Equal(t, 20, len(cols.collectors), "collector count")
 }
@@ -88,7 +88,7 @@ func TestCollectorsForDevices(t *testing.T) {
 	d2 := &connector.Device{
 		Host: "2001:678:1e0::2",
 	}
-	cols := collectorsForDevices([]*connector.Device{d1, d2}, c, "", interfacelabels.NewDynamicLabels())
+	cols := collectorsForDevices([]*connector.Device{d1, d2}, c, "", interfacelabels.NewDynamicLabelManager())
 
 	assert.Equal(t, 20, len(cols.collectorsForDevice(d1)), "device 1 collector count")
 

--- a/devices.go
+++ b/devices.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -56,10 +57,15 @@ func deviceFromDeviceConfig(device *config.DeviceConfig, hostname string, cfg *c
 	}
 
 	// check whether there is a device specific regex otherwise fallback to global regex
-	if len(device.IfDescReg) == 0 {
+	if len(device.IfDescRegStr) == 0 {
 		device.IfDescReg = cfg.IfDescReg
 	} else {
-		regexp.MustCompile(device.IfDescReg)
+		re, err := regexp.Compile(device.IfDescRegStr)
+		if err != nil {
+			return nil, fmt.Errorf("unable to compile device description regex for %q: %q: %w", hostname, device.IfDescRegStr, err)
+		}
+
+		device.IfDescReg = re
 	}
 
 	return &connector.Device{

--- a/junos_collector.go
+++ b/junos_collector.go
@@ -40,7 +40,7 @@ type junosCollector struct {
 }
 
 func newJunosCollector(ctx context.Context, devices []*connector.Device, logicalSystem string) *junosCollector {
-	l := interfacelabels.NewDynamicLabels()
+	l := interfacelabels.NewDynamicLabelManager()
 
 	clients := make(map[*connector.Device]*rpc.Client)
 
@@ -78,22 +78,13 @@ func newJunosCollector(ctx context.Context, devices []*connector.Device, logical
 func deviceInterfaceRegex(host string) *regexp.Regexp {
 	dc := cfg.FindDeviceConfig(host)
 
-	if len(dc.IfDescReg) > 0 {
-		regex, err := regexp.Compile(dc.IfDescReg)
+	if len(dc.IfDescRegStr) > 0 {
+		regex, err := regexp.Compile(dc.IfDescRegStr)
 		if err == nil {
 			return regex
 		}
 
-		log.Errorf("device specific dynamic label regex %s invalid: %v", dc.IfDescReg, err)
-	}
-
-	if len(cfg.IfDescReg) > 0 {
-		regex, err := regexp.Compile(cfg.IfDescReg)
-		if err == nil {
-			return regex
-		}
-
-		log.Errorf("global dynamic label regex (%s) invalid: %v", cfg.IfDescReg, err)
+		log.Errorf("device specific dynamic label regex %s invalid: %v", dc.IfDescRegStr, err)
 	}
 
 	return interfacelabels.DefaultInterfaceDescRegex()

--- a/main.go
+++ b/main.go
@@ -212,7 +212,7 @@ func loadConfigFromFlags() *config.Config {
 	c := config.New()
 	c.Targets = strings.Split(*sshHosts, ",")
 	c.LSEnabled = *lsEnabled
-	c.IfDescReg = *interfaceDescriptionRegex
+	c.IfDescReStr = *interfaceDescriptionRegex
 
 	f := &c.Features
 	f.Alarm = *alarmEnabled

--- a/pkg/features/interfacediagnostics/collector.go
+++ b/pkg/features/interfacediagnostics/collector.go
@@ -17,7 +17,7 @@ import (
 const prefix = "junos_interface_diagnostics_"
 
 type interfaceDiagnosticsCollector struct {
-	labels                                 *interfacelabels.DynamicLabels
+	labels                                 *interfacelabels.DynamicLabelManager
 	laserBiasCurrentDesc                   *prometheus.Desc
 	laserBiasCurrentHighAlarmThresholdDesc *prometheus.Desc
 	laserBiasCurrentLowAlarmThresholdDesc  *prometheus.Desc
@@ -67,7 +67,7 @@ type interfaceDiagnosticsCollector struct {
 }
 
 // NewCollector creates a new collector
-func NewCollector(labels *interfacelabels.DynamicLabels) collector.RPCCollector {
+func NewCollector(labels *interfacelabels.DynamicLabelManager) collector.RPCCollector {
 	c := &interfaceDiagnosticsCollector{
 		labels: labels,
 	}

--- a/pkg/features/interfacequeue/collector.go
+++ b/pkg/features/interfacequeue/collector.go
@@ -12,7 +12,7 @@ import (
 const prefix = "junos_interface_queues_"
 
 // NewCollector creates an queue collector instance
-func NewCollector(labels *interfacelabels.DynamicLabels) collector.RPCCollector {
+func NewCollector(labels *interfacelabels.DynamicLabelManager) collector.RPCCollector {
 	c := &interfaceQueueCollector{
 		labels: labels,
 	}
@@ -22,7 +22,7 @@ func NewCollector(labels *interfacelabels.DynamicLabels) collector.RPCCollector 
 }
 
 type interfaceQueueCollector struct {
-	labels               *interfacelabels.DynamicLabels
+	labels               *interfacelabels.DynamicLabelManager
 	queuedPackets        *prometheus.Desc
 	queuedBytes          *prometheus.Desc
 	transferedPackets    *prometheus.Desc

--- a/pkg/features/interfaces/collector.go
+++ b/pkg/features/interfaces/collector.go
@@ -16,7 +16,7 @@ const prefix = "junos_interface_"
 
 // Collector collects interface metrics
 type interfaceCollector struct {
-	labels                      *interfacelabels.DynamicLabels
+	labels                      *interfacelabels.DynamicLabelManager
 	receiveBytesDesc            *prometheus.Desc
 	receivePacketsDesc          *prometheus.Desc
 	receiveErrorsDesc           *prometheus.Desc
@@ -57,7 +57,7 @@ type interfaceCollector struct {
 }
 
 // NewCollector creates a new collector
-func NewCollector(labels *interfacelabels.DynamicLabels) collector.RPCCollector {
+func NewCollector(labels *interfacelabels.DynamicLabelManager) collector.RPCCollector {
 	c := &interfaceCollector{
 		labels: labels,
 	}

--- a/pkg/interfacelabels/dynamic_labels_test.go
+++ b/pkg/interfacelabels/dynamic_labels_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestParseDescriptions(t *testing.T) {
 	t.Run("Test default", func(t *testing.T) {
-		l := NewDynamicLabels()
+		l := NewDynamicLabelManager()
 		regex := DefaultInterfaceDescRegex()
 
 		if1 := interfaceDescription{
@@ -45,7 +45,7 @@ func TestParseDescriptions(t *testing.T) {
 	})
 
 	t.Run("Test custom regex", func(t *testing.T) {
-		l := NewDynamicLabels()
+		l := NewDynamicLabelManager()
 		regex := regexp.MustCompile(`[[\s]([^=\[\]]+)(=[^,\]]+)?[,\]]`)
 
 		if1 := interfaceDescription{


### PR DESCRIPTION
Implementing support for dynamic labels from descriptions for BGP related metrics.
This implementation does not use any state. Unlike the implementation of dynamic labels for interface descriptions.
Shall I adjust the implementation for interface metrics too?