### PR TITLE
Interface Queues: Add forwarding_class label

### DIFF
--- a/pkg/features/interfacequeue/collector.go
+++ b/pkg/features/interfacequeue/collector.go
@@ -53,6 +53,7 @@ func (c *interfaceQueueCollector) init() {
 	l := []string{"target", "name", "description"}
 	l = append(l, c.labels.LabelNames()...)
 	l = append(l, "queue_number")
+	l = append(l, "forwarding_class")
 
 	c.queuedPackets = prometheus.NewDesc(prefix+"queued_packets_count", "Number of queued packets", l, nil)
 	c.queuedBytes = prometheus.NewDesc(prefix+"queued_bytes_count", "Number of bytes of queued packets", l, nil)
@@ -125,6 +126,7 @@ func (c *interfaceQueueCollector) collectForInterface(iface physicalInterface, d
 
 func (c *interfaceQueueCollector) collectForQueue(queue queue, ch chan<- prometheus.Metric, labelValues []string) {
 	l := append(labelValues, queue.Number)
+	l = append(l, queue.ForwaringClassName)
 
 	ch <- prometheus.MustNewConstMetric(c.queuedPackets, prometheus.CounterValue, float64(queue.QueuedPackets), l...)
 	ch <- prometheus.MustNewConstMetric(c.queuedBytes, prometheus.CounterValue, float64(queue.QueuedBytes), l...)

--- a/pkg/features/interfacequeue/rpc.go
+++ b/pkg/features/interfacequeue/rpc.go
@@ -18,6 +18,7 @@ type physicalInterface struct {
 
 type queue struct {
 	Number               string `xml:"queue-number"`
+	ForwaringClassName   string `xml:"forwarding-class-name"`
 	QueuedPackets        uint64 `xml:"queue-counters-queued-packets"`
 	QueuedBytes          uint64 `xml:"queue-counters-queued-bytes"`
 	TransferedPackets    uint64 `xml:"queue-counters-trans-packets"`


### PR DESCRIPTION
Until now interface queues are only identified by their number. This PR adds the forwarding class name too which is way more significant to an operator that just a queue number.