### PR TITLE
Add Description L2Circuit Metrics

### DIFF
--- a/pkg/features/l2circuit/collector.go
+++ b/pkg/features/l2circuit/collector.go
@@ -104,11 +104,9 @@ func (c *l2circuitCollector) collectForConnection(client collector.Client, ch ch
 	idInt := re.FindStringSubmatch(idStr)
 	id := idInt[len(idInt)-1]
 
-	// Ajout de la description dans les labels
 	l := append(labelValues, id, conn.LocalInterface.Description)
 	state := l2circuitMap[conn.StatusString]
 
-	// Envoie des métriques avec la description incluse
 	ch <- prometheus.MustNewConstMetric(l2circuitConnectionsDesc, prometheus.GaugeValue, float64(connCount), l...)
 	ch <- prometheus.MustNewConstMetric(l2circuitConnectionStateDesc, prometheus.GaugeValue, float64(state), l...)
 }

--- a/pkg/features/l2circuit/rpc.go
+++ b/pkg/features/l2circuit/rpc.go
@@ -19,4 +19,9 @@ type connection struct {
 	ID           string `xml:"connection-id"`
 	Type         string `xml:"connection-type"`
 	StatusString string `xml:"connection-status"`
+    LocalInterface localInterface  `xml:"local-interface"`
+}
+type localInterface struct {
+	Name        string `xml:"interface-name"`
+	Description string `xml:"interface-description"`
 }


### PR DESCRIPTION
This simply adds the description of your L2Circuit to the metrics.
Example:
junos_l2circuit_connection_status{address=“1.1.1.1”, **description=“L2 Description”**, instance=“router1.junos.net”, job=“junos”, target=“router1.junos.net”, vcid=“33333333”}