### PR TITLE
Added PoE interface metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following metrics are supported by now:
 * LDP (number of neighbors, sessions and session states)
 * VRRP (state per interface)
 * Subscribers Information (show subscribers client-type dhcp detail)
+* PoE (show poe interface)
 
 ## Feature specific mappings
 Some collected time series behave like enums - Integer values represent a certain state/meaning.

--- a/collectors.go
+++ b/collectors.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"github.com/czerwonk/junos_exporter/pkg/features/poe"
 	"regexp"
 
 	"github.com/czerwonk/junos_exporter/internal/config"
@@ -119,6 +120,7 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device, descRe *
 	c.addCollectorIfEnabledForDevice(device, "mpls_lsp", f.MPLSLSP, mplslsp.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "subscriber", f.Subscriber, subscriber.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "macsec", f.MACSec, macsec.NewCollector)
+	c.addCollectorIfEnabledForDevice(device, "poe", f.Poe, poe.NewCollector)
 }
 
 func (c *collectors) addCollectorIfEnabledForDevice(device *connector.Device, key string, enabled bool, newCollector func() collector.RPCCollector) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,7 @@ type FeatureConfig struct {
 	License             bool `yaml:"license,omitempty"`
 	Subscriber          bool `yaml:"subscriber,omitempty"`
 	MACSec              bool `yaml:"macsec,omitempty"`
+	Poe                 bool `yaml:"poe,omitempty"`
 }
 
 // New creates a new config
@@ -176,6 +177,7 @@ func setDefaultValues(c *Config) {
 	f.BFD = false
 	f.License = false
 	f.MACSec = true
+	f.Poe = false
 }
 
 // FeaturesForDevice gets the feature set configured for a device

--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ var (
 	tracingCollectorEndpoint    = flag.String("tracing.collector.grpc-endpoint", "", "Sets the tracing provider (stdout or collector)")
 	subscriberEnabled           = flag.Bool("subscriber.enabled", false, "Scrape subscribers detail")
 	macsecEnabled               = flag.Bool("macsec.enabled", true, "Scrape MACSec metrics")
+	poeEnabled                  = flag.Bool("poe.enabled", true, "Scrape PoE metrics")
 	cfg                         *config.Config
 	devices                     []*connector.Device
 	connManager                 *connector.SSHConnectionManager
@@ -251,6 +252,7 @@ func loadConfigFromFlags() *config.Config {
 	f.License = *licenseEnabled
 	f.Subscriber = *subscriberEnabled
 	f.MACSec = *macsecEnabled
+	f.Poe = *poeEnabled
 	return c
 }
 

--- a/pkg/features/poe/collector.go
+++ b/pkg/features/poe/collector.go
@@ -1,0 +1,95 @@
+package poe
+
+import (
+	"github.com/czerwonk/junos_exporter/pkg/collector"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"strconv"
+	"strings"
+)
+
+const prefix string = "junos_poe_"
+
+var (
+	poeEnabledDesc    *prometheus.Desc
+	poeStatusDesc     *prometheus.Desc
+	poePowerLimitDesc *prometheus.Desc
+	poePowerDesc      *prometheus.Desc
+	poeClassDesc      *prometheus.Desc
+)
+
+// Initialize metrics descriptions
+func init() {
+	labels := []string{"interface"}
+	poeEnabledDesc = prometheus.NewDesc(prefix+"enabled", "Information about interface status", labels, nil)
+	poeStatusDesc = prometheus.NewDesc(prefix+"status", "Information about interface PoE status", labels, nil)
+	poePowerLimitDesc = prometheus.NewDesc(prefix+"power_limit", "Information about interface PoE power limit", labels, nil)
+	poePowerDesc = prometheus.NewDesc(prefix+"power", "Information about interface PoE power usage", labels, nil)
+	poeClassDesc = prometheus.NewDesc(prefix+"class", "Information about interface PoE class", labels, nil)
+}
+
+type poeCollector struct{}
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector {
+	return &poeCollector{}
+}
+
+// Name returns the name of the collector
+func (p poeCollector) Name() string {
+	return "poe"
+}
+
+// Describe describes the metrics
+func (p poeCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- poeEnabledDesc
+	ch <- poeStatusDesc
+	ch <- poePowerLimitDesc
+	ch <- poePowerDesc
+	ch <- poeClassDesc
+}
+
+func (p poeCollector) Collect(client collector.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var result poeInterfaceResult
+	err := client.RunCommandAndParse("show poe interface", &result)
+	if err != nil {
+		return errors.Wrap(err, "failed to run command 'show poe interface'")
+	}
+	for _, i := range result.Poe.InterfaceInformation {
+		p.CollectForInterface(i, ch, labelValues)
+	}
+	return nil
+}
+
+func (p *poeCollector) CollectForInterface(iface InterfaceInformation, ch chan<- prometheus.Metric, labelValues []string) {
+	lv := append(labelValues, []string{iface.Name}...)
+
+	enabled := 0
+	if iface.Enabled == "Enabled" {
+		enabled = 1
+	}
+	status := 0
+	if iface.Status == "ON" {
+		status = 1
+	}
+	powerLimit := parsePower(iface.PowerLimit)
+	powerUsage := parsePower(iface.Power)
+
+	class := -1.0
+	if iface.Class != "not-applicable" {
+		pClass, _ := strconv.ParseFloat(iface.Class, 64)
+		class = pClass
+	}
+
+	ch <- prometheus.MustNewConstMetric(poeEnabledDesc, prometheus.GaugeValue, float64(enabled), lv...)
+	ch <- prometheus.MustNewConstMetric(poeStatusDesc, prometheus.GaugeValue, float64(status), lv...)
+	ch <- prometheus.MustNewConstMetric(poePowerLimitDesc, prometheus.GaugeValue, powerLimit, lv...)
+	ch <- prometheus.MustNewConstMetric(poePowerDesc, prometheus.GaugeValue, powerUsage, lv...)
+	ch <- prometheus.MustNewConstMetric(poeClassDesc, prometheus.GaugeValue, class, lv...)
+}
+
+func parsePower(s string) float64 {
+	powerWithoutSuffix := strings.ReplaceAll(s, "W", "")
+	parsedPower, _ := strconv.ParseFloat(powerWithoutSuffix, 64)
+	return parsedPower
+}

--- a/pkg/features/poe/collector.go
+++ b/pkg/features/poe/collector.go
@@ -20,7 +20,7 @@ var (
 
 // Initialize metrics descriptions
 func init() {
-	labels := []string{"interface"}
+	labels := []string{"target", "interface"}
 	poeEnabledDesc = prometheus.NewDesc(prefix+"enabled", "Information about interface status", labels, nil)
 	poeStatusDesc = prometheus.NewDesc(prefix+"status", "Information about interface PoE status", labels, nil)
 	poePowerLimitDesc = prometheus.NewDesc(prefix+"power_limit", "Information about interface PoE power limit", labels, nil)

--- a/pkg/features/poe/rpc.go
+++ b/pkg/features/poe/rpc.go
@@ -1,0 +1,25 @@
+package poe
+
+import "encoding/xml"
+
+// structure for poe interface result
+type poeInterfaceResult struct {
+	XMLName xml.Name `xml:"rpc-reply"`
+	Poe     struct {
+		InterfaceInformation []InterfaceInformation `xml:"interface-information"`
+	} `xml:"poe"`
+}
+
+// InterfaceInformation structure for poe information from interface
+type InterfaceInformation struct {
+	Name                    string `xml:"interface-name"`
+	Enabled                 string `xml:"interface-enabled"`
+	Status                  string `xml:"interface-status"`
+	PowerLimit              string `xml:"interface-power-limit"`
+	LldpNegotiationPower    string `xml:"interface-lldp-negotiation-power"`
+	Priority                string `xml:"interface-priority"`
+	LldpNegotiationPriority string `xml:"interface-lldp-negotiation-priority"`
+	Power                   string `xml:"interface-power"`
+	Asterisk                string `xml:"interface-asterisk"`
+	Class                   string `xml:"interface-class"`
+}

--- a/pkg/features/poe/rpc_test.go
+++ b/pkg/features/poe/rpc_test.go
@@ -1,0 +1,63 @@
+package poe
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseXML(t *testing.T) {
+	resultData := `
+<rpc-reply xmlns:junos="http://xml.juniper.net/junos/15.1R7/junos">
+    <poe>
+        <interface-information>
+            <interface-name>ge-0/0/0</interface-name>
+            <interface-enabled>Enabled</interface-enabled>
+            <interface-status>ON</interface-status>
+            <interface-power-limit>30.0W</interface-power-limit>
+            <interface-lldp-negotiation-power>  </interface-lldp-negotiation-power>
+            <interface-priority>Low</interface-priority>
+            <interface-lldp-negotiation-priority>  </interface-lldp-negotiation-priority>
+            <interface-power>5.3W</interface-power>
+            <interface-asterisk> </interface-asterisk>
+            <interface-class>4</interface-class>
+        </interface-information>
+        <interface-information>
+            <interface-name>ge-0/0/23</interface-name>
+            <interface-enabled>Enabled</interface-enabled>
+            <interface-status>OFF</interface-status>
+            <interface-power-limit>15.4W</interface-power-limit>
+            <interface-lldp-negotiation-power>  </interface-lldp-negotiation-power>
+            <interface-priority>Low</interface-priority>
+            <interface-lldp-negotiation-priority>  </interface-lldp-negotiation-priority>
+            <interface-power>0.0W</interface-power>
+            <interface-asterisk> </interface-asterisk>
+            <interface-class>not-applicable</interface-class>
+        </interface-information>
+    </poe>
+    <cli>
+        <banner>{master:0}</banner>
+    </cli>
+</rpc-reply>
+`
+
+	var result poeInterfaceResult
+
+	err := xml.Unmarshal([]byte(resultData), &result)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "ge-0/0/0", result.Poe.InterfaceInformation[0].Name)
+	assert.Equal(t, "Enabled", result.Poe.InterfaceInformation[0].Enabled)
+	assert.Equal(t, "ON", result.Poe.InterfaceInformation[0].Status)
+	assert.Equal(t, "30.0W", result.Poe.InterfaceInformation[0].PowerLimit)
+	assert.Equal(t, "5.3W", result.Poe.InterfaceInformation[0].Power)
+	assert.Equal(t, "4", result.Poe.InterfaceInformation[0].Class)
+
+	assert.Equal(t, "ge-0/0/23", result.Poe.InterfaceInformation[1].Name)
+	assert.Equal(t, "Enabled", result.Poe.InterfaceInformation[1].Enabled)
+	assert.Equal(t, "OFF", result.Poe.InterfaceInformation[1].Status)
+	assert.Equal(t, "15.4W", result.Poe.InterfaceInformation[1].PowerLimit)
+	assert.Equal(t, "0.0W", result.Poe.InterfaceInformation[1].Power)
+	assert.Equal(t, "not-applicable", result.Poe.InterfaceInformation[1].Class)
+}


### PR DESCRIPTION
The following command is used
`show poe interface`

PoE power is parsed without the `W` suffix.
I've written a test to ensure the XML parsing is working as expected.
I've also tested the metrics using an EX3300-24P with firmware version 15.1R7-S9.