### PR TITLE
Fix license expiration metric

### DIFF
--- a/pkg/features/system/rpc.go
+++ b/pkg/features/system/rpc.go
@@ -82,6 +82,7 @@ type licenseInformation struct {
 			Used int `xml:"used-licensed"`
 			Needed int `xml:"needed"`
 			ValidityType string `xml:"validity-type"`
+			EndDate string `xml:"end-date"`
 		} `xml:"feature-summary"`
 	} `xml:"license-usage-summary"`
 }


### PR DESCRIPTION
XML View of `show system license usage` in junos uses a separate 'end-date' field for license expiration, instead of validity-type used in this exporter. This difference caused incorrect expiration date collection (they are all -Inf), which this PR now corrects.