### PR TITLE
Enhance show interface extensive

### DIFF
--- a/collectors.go
+++ b/collectors.go
@@ -34,6 +34,7 @@ import (
 	"github.com/czerwonk/junos_exporter/pkg/features/mplslsp"
 	"github.com/czerwonk/junos_exporter/pkg/features/nat"
 	"github.com/czerwonk/junos_exporter/pkg/features/nat2"
+	"github.com/czerwonk/junos_exporter/pkg/features/ntp"
 	"github.com/czerwonk/junos_exporter/pkg/features/ospf"
 	"github.com/czerwonk/junos_exporter/pkg/features/power"
 	"github.com/czerwonk/junos_exporter/pkg/features/route"
@@ -82,6 +83,9 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device, descRe *
 	c.addCollectorIfEnabledForDevice(device, "accounting", f.Accounting, accounting.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "alarm", f.Alarm, func() collector.RPCCollector {
 		return alarm.NewCollector(*alarmFilter)
+	})
+	c.addCollectorIfEnabledForDevice(device, "ntp", f.NTP, func() collector.RPCCollector {
+		return ntp.NewCollector()
 	})
 	c.addCollectorIfEnabledForDevice(device, "bfd", f.BFD, bfd.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "bgp", f.BGP, func() collector.RPCCollector {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,7 +152,7 @@ func setDefaultValues(c *Config) {
 	c.LSEnabled = false
 	f := &c.Features
 	f.Alarm = true
-	f.NTP = true
+	f.NTP = false
 	f.BGP = true
 	f.Environment = true
 	f.Interfaces = true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,7 @@ type DeviceConfig struct {
 // FeatureConfig is the list of collectors enabled or disabled
 type FeatureConfig struct {
 	Alarm               bool `yaml:"alarm,omitempty"`
+	NTP                 bool `yaml:"ntp,omitempty"`
 	Environment         bool `yaml:"environment,omitempty"`
 	BFD                 bool `yaml:"bfd,omitempty"`
 	BGP                 bool `yaml:"bgp,omitempty"`
@@ -151,6 +152,7 @@ func setDefaultValues(c *Config) {
 	c.LSEnabled = false
 	f := &c.Features
 	f.Alarm = true
+	f.NTP = true
 	f.BGP = true
 	f.Environment = true
 	f.Interfaces = true

--- a/main.go
+++ b/main.go
@@ -41,7 +41,8 @@ var (
 	sshKeepAliveTimeout         = flag.Duration("ssh.keep-alive-timeout", 15*time.Second, "Duration to wait for keep alive message response")
 	sshExpireTimeout            = flag.Duration("ssh.expire-timeout", 15*time.Minute, "Duration after an connection is terminated when it is not used")
 	debug                       = flag.Bool("debug", false, "Show verbose debug output in log")
-	alarmEnabled                = flag.Bool("alarm.enabled", true, "Scrape Alarm metrics")
+	alarmEnabled                = flag.Bool("alarm.enabled", false, "Scrape Alarm metrics")
+	ntpEnabled                  = flag.Bool("ntp.enabled", false, "Scrape NTP metrics")
 	bgpEnabled                  = flag.Bool("bgp.enabled", true, "Scrape BGP metrics")
 	ospfEnabled                 = flag.Bool("ospf.enabled", true, "Scrape OSPFv3 metrics")
 	isisEnabled                 = flag.Bool("isis.enabled", false, "Scrape ISIS metrics")
@@ -229,6 +230,7 @@ func loadConfigFromFlags() *config.Config {
 
 	f := &c.Features
 	f.Alarm = *alarmEnabled
+	f.NTP = *ntpEnabled
 	f.BGP = *bgpEnabled
 	f.Environment = *environmentEnabled
 	f.Firewall = *firewallEnabled

--- a/pkg/features/interfaces/collector.go
+++ b/pkg/features/interfaces/collector.go
@@ -16,45 +16,52 @@ import (
 const prefix = "junos_interface_"
 
 type description struct {
-	receiveBytesDesc            *prometheus.Desc
-	receivePacketsDesc          *prometheus.Desc
-	receiveErrorsDesc           *prometheus.Desc
-	receiveDropsDesc            *prometheus.Desc
-	interfaceSpeedDesc          *prometheus.Desc
-	interfaceBPDUErrorDesc      *prometheus.Desc
-	transmitBytesDesc           *prometheus.Desc
-	transmitPacketsDesc         *prometheus.Desc
-	transmitErrorsDesc          *prometheus.Desc
-	transmitDropsDesc           *prometheus.Desc
-	ipv6receiveBytesDesc        *prometheus.Desc
-	ipv6receivePacketsDesc      *prometheus.Desc
-	ipv6transmitBytesDesc       *prometheus.Desc
-	ipv6transmitPacketsDesc     *prometheus.Desc
-	adminStatusDesc             *prometheus.Desc
-	operStatusDesc              *prometheus.Desc
-	errorStatusDesc             *prometheus.Desc
-	lastFlappedDesc             *prometheus.Desc
-	receiveUnicastsDesc         *prometheus.Desc
-	receiveBroadcastsDesc       *prometheus.Desc
-	receiveMulticastsDesc       *prometheus.Desc
-	receiveCRCErrorsDesc        *prometheus.Desc
-	transmitUnicastsDesc        *prometheus.Desc
-	transmitBroadcastsDesc      *prometheus.Desc
-	transmitMulticastsDesc      *prometheus.Desc
-	transmitCRCErrorsDesc       *prometheus.Desc
-	fecCcwCountDesc             *prometheus.Desc
-	fecNccwCountDesc            *prometheus.Desc
-	fecCcwErrorRateDesc         *prometheus.Desc
-	fecNccwErrorRateDesc        *prometheus.Desc
-	receiveOversizedFramesDesc  *prometheus.Desc
-	receiveJabberFramesDesc     *prometheus.Desc
-	receiveFragmentFramesDesc   *prometheus.Desc
-	receiveVlanTaggedFramesDesc *prometheus.Desc
-	receiveCodeViolationsDesc   *prometheus.Desc
-	receiveTotalErrorsDesc      *prometheus.Desc
-	transmitTotalErrorsDesc     *prometheus.Desc
-	mtuDesc                     *prometheus.Desc
-	fecModeDesc                 *prometheus.Desc
+	receiveBytesDesc               *prometheus.Desc
+	receivePacketsDesc             *prometheus.Desc
+	receiveErrorsDesc              *prometheus.Desc
+	receiveDropsDesc               *prometheus.Desc
+	interfaceSpeedDesc             *prometheus.Desc
+	interfaceBPDUErrorDesc         *prometheus.Desc
+	transmitBytesDesc              *prometheus.Desc
+	transmitPacketsDesc            *prometheus.Desc
+	transmitErrorsDesc             *prometheus.Desc
+	transmitCarrierTransitionsDesc *prometheus.Desc
+	transmitDropsDesc              *prometheus.Desc
+	transmitCollisions             *prometheus.Desc
+	transmitAgedPackets            *prometheus.Desc
+	transmitFIFOErrors             *prometheus.Desc
+	transmitCRCErrors              *prometheus.Desc
+	transmitMTUErrors              *prometheus.Desc
+	transmitResourceErrors         *prometheus.Desc
+	ipv6receiveBytesDesc           *prometheus.Desc
+	ipv6receivePacketsDesc         *prometheus.Desc
+	ipv6transmitBytesDesc          *prometheus.Desc
+	ipv6transmitPacketsDesc        *prometheus.Desc
+	adminStatusDesc                *prometheus.Desc
+	operStatusDesc                 *prometheus.Desc
+	errorStatusDesc                *prometheus.Desc
+	lastFlappedDesc                *prometheus.Desc
+	receiveUnicastsDesc            *prometheus.Desc
+	receiveBroadcastsDesc          *prometheus.Desc
+	receiveMulticastsDesc          *prometheus.Desc
+	receiveCRCErrorsDesc           *prometheus.Desc
+	transmitUnicastsDesc           *prometheus.Desc
+	transmitBroadcastsDesc         *prometheus.Desc
+	transmitMulticastsDesc         *prometheus.Desc
+	transmitCRCErrorsDesc          *prometheus.Desc
+	fecCcwCountDesc                *prometheus.Desc
+	fecNccwCountDesc               *prometheus.Desc
+	fecCcwErrorRateDesc            *prometheus.Desc
+	fecNccwErrorRateDesc           *prometheus.Desc
+	receiveOversizedFramesDesc     *prometheus.Desc
+	receiveJabberFramesDesc        *prometheus.Desc
+	receiveFragmentFramesDesc      *prometheus.Desc
+	receiveVlanTaggedFramesDesc    *prometheus.Desc
+	receiveCodeViolationsDesc      *prometheus.Desc
+	receiveTotalErrorsDesc         *prometheus.Desc
+	transmitTotalErrorsDesc        *prometheus.Desc
+	mtuDesc                        *prometheus.Desc
+	fecModeDesc                    *prometheus.Desc
 }
 
 func newDescriptions(dynLabels dynamiclabels.Labels) *description {
@@ -71,6 +78,13 @@ func newDescriptions(dynLabels dynamiclabels.Labels) *description {
 	d.transmitBytesDesc = prometheus.NewDesc(prefix+"transmit_bytes", "Transmitted data in bytes", l, nil)
 	d.transmitPacketsDesc = prometheus.NewDesc(prefix+"transmit_packets_total", "Transmitted packets", l, nil)
 	d.transmitErrorsDesc = prometheus.NewDesc(prefix+"transmit_errors", "Number of errors caused by outgoing packets", l, nil)
+	d.transmitCarrierTransitionsDesc = prometheus.NewDesc(prefix+"transmit_carrier_transitions", "Number of carrier transitions of outgoing link", l, nil)
+	d.transmitCollisions = prometheus.NewDesc(prefix+"transmit_collisions", "Number of outgoing packet collisions", l, nil)
+	d.transmitAgedPackets = prometheus.NewDesc(prefix+"transmit_aged_packets", "Number of outgoing aged packets ", l, nil)
+	d.transmitFIFOErrors = prometheus.NewDesc(prefix+"transmit_fifo_erros", "Number of outgoing packets with FIFO errors", l, nil)
+	d.transmitCRCErrors = prometheus.NewDesc(prefix+"transmit_crc_errors", "Number of outgoing packets with CRC errors ", l, nil)
+	d.transmitMTUErrors = prometheus.NewDesc(prefix+"transmit_mtu_errors", "Number of outgoing packets with MTU errors ", l, nil)
+	d.transmitResourceErrors = prometheus.NewDesc(prefix+"transmit_resource_errors", "Number of coutgoing packets with resource errors", l, nil)
 	d.transmitDropsDesc = prometheus.NewDesc(prefix+"transmit_drops", "Number of dropped outgoing packets", l, nil)
 	d.ipv6receiveBytesDesc = prometheus.NewDesc(prefix+"IPv6_receive_bytes_total", "Received IPv6 data in bytes", l, nil)
 	d.ipv6receivePacketsDesc = prometheus.NewDesc(prefix+"IPv6_receive_packets_total", "Received IPv6 packets", l, nil)
@@ -134,6 +148,13 @@ func (*interfaceCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- d.interfaceBPDUErrorDesc
 	ch <- d.transmitBytesDesc
 	ch <- d.transmitPacketsDesc
+	ch <- d.transmitCarrierTransitionsDesc
+	ch <- d.transmitCollisions
+	ch <- d.transmitAgedPackets
+	ch <- d.transmitFIFOErrors
+	ch <- d.transmitCRCErrors
+	ch <- d.transmitMTUErrors
+	ch <- d.transmitResourceErrors
 	ch <- d.transmitDropsDesc
 	ch <- d.transmitErrorsDesc
 	ch <- d.ipv6receiveBytesDesc
@@ -204,6 +225,7 @@ func (c *interfaceCollector) interfaceStats(client collector.Client) ([]*interfa
 			ReceivePackets:          float64(phy.Stats.InputPackets),
 			Speed:                   phy.Speed,
 			BPDUError:               phy.BPDUError == "detected",
+			CarrierTransitions:      float64(phy.OutputErrors.CarrierTransitions),
 			TransmitDrops:           float64(phy.OutputErrors.Drops),
 			TransmitErrors:          float64(phy.OutputErrors.Errors),
 			TransmitBytes:           float64(phy.Stats.OutputBytes),
@@ -340,6 +362,13 @@ func (c *interfaceCollector) collectForInterface(s *interfaceStats, ch chan<- pr
 		ch <- prometheus.MustNewConstMetric(d.operStatusDesc, prometheus.GaugeValue, float64(operUp), lv...)
 		ch <- prometheus.MustNewConstMetric(d.errorStatusDesc, prometheus.GaugeValue, float64(err), lv...)
 		ch <- prometheus.MustNewConstMetric(d.transmitErrorsDesc, prometheus.CounterValue, s.TransmitErrors, lv...)
+		ch <- prometheus.MustNewConstMetric(d.transmitCarrierTransitionsDesc, prometheus.CounterValue, s.CarrierTransitions, lv...)
+		ch <- prometheus.MustNewConstMetric(d.transmitCollisions, prometheus.CounterValue, s.Collisions, lv...)
+		ch <- prometheus.MustNewConstMetric(d.transmitAgedPackets, prometheus.CounterValue, s.AgedPackets, lv...)
+		ch <- prometheus.MustNewConstMetric(d.transmitFIFOErrors, prometheus.CounterValue, s.FIFOErrors, lv...)
+		ch <- prometheus.MustNewConstMetric(d.transmitCRCErrors, prometheus.CounterValue, s.CRCErrors, lv...)
+		ch <- prometheus.MustNewConstMetric(d.transmitMTUErrors, prometheus.CounterValue, s.MTUErrors, lv...)
+		ch <- prometheus.MustNewConstMetric(d.transmitResourceErrors, prometheus.CounterValue, s.ResourceErrors, lv...)
 		ch <- prometheus.MustNewConstMetric(d.transmitDropsDesc, prometheus.CounterValue, s.TransmitDrops, lv...)
 		ch <- prometheus.MustNewConstMetric(d.receiveErrorsDesc, prometheus.CounterValue, s.ReceiveErrors, lv...)
 		ch <- prometheus.MustNewConstMetric(d.receiveDropsDesc, prometheus.CounterValue, s.ReceiveDrops, lv...)

--- a/pkg/features/interfaces/interface_stats.go
+++ b/pkg/features/interfaces/interface_stats.go
@@ -19,7 +19,14 @@ type interfaceStats struct {
 	TransmitBytes           float64
 	TransmitPackets         float64
 	TransmitErrors          float64
+	CarrierTransitions      float64
 	TransmitDrops           float64
+	Collisions              float64
+	AgedPackets             float64
+	FIFOErrors              float64
+	CRCErrors               float64
+	MTUErrors               float64
+	ResourceErrors          float64
 	IPv6ReceiveBytes        float64
 	IPv6ReceivePackets      float64
 	IPv6TransmitBytes       float64

--- a/pkg/features/interfaces/rpc.go
+++ b/pkg/features/interfaces/rpc.go
@@ -23,8 +23,15 @@ type phyInterface struct {
 		Errors uint64 `xml:"input-errors"`
 	} `xml:"input-error-list"`
 	OutputErrors struct {
-		Drops  uint64 `xml:"output-drops"`
-		Errors uint64 `xml:"output-errors"`
+		CarrierTransitions uint64 `xml:"output-carrier-transitions"`
+		Errors             uint64 `xml:"output-errors"`
+		Drops              uint64 `xml:"output-drops"`
+		Collisions         uint64 `xml:"output-collisions"`
+		AgedPackets        uint64 `xml:"output-aged-packets"`
+		FIFOErrors         uint64 `xml:"output-fifo-errors"`
+		CRCErrors          uint64 `xml:"output-crc-errors"`
+		MTUErrors          uint64 `xml:"output-mtu-errors"`
+		ResourceErrors     uint64 `xml:"output-resource-errors"`
 	} `xml:"output-error-list"`
 	InterfaceFlapped struct {
 		Seconds uint64 `xml:"seconds,attr"`

--- a/pkg/features/ntp/collector.go
+++ b/pkg/features/ntp/collector.go
@@ -22,8 +22,6 @@ var (
 	ntpLeapDesc      *prometheus.Desc
 	ntpPrecisionDesc *prometheus.Desc
 	ntpPollDesc      *prometheus.Desc
-
-// ntpServerDesc     *prometheus.Desc
 )
 
 func init() {
@@ -36,7 +34,6 @@ func init() {
 	ntpLeapDesc = prometheus.NewDesc(prefix+"leap", "Leap indicator (00=ok, 01: last minute with 61 seconds, 10: last minute with 59 seconds, 11: not syncronized)", l, nil)
 	ntpPrecisionDesc = prometheus.NewDesc(prefix+"precision", "Clock precision (should be -20 to -22)", l, nil)
 	ntpPollDesc = prometheus.NewDesc(prefix+"poll_interval", "Poll interval in seconds", l, nil)
-	// ntpServerDesc = prometheus.NewDesc(prefix+"server_info", "NTP server info", append(l, "refid"), nil)
 }
 
 type ntpCollector struct{}
@@ -58,7 +55,6 @@ func (c *ntpCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- ntpLeapDesc
 	ch <- ntpPrecisionDesc
 	ch <- ntpPollDesc
-	// ch <- ntpServerDesc
 }
 
 func (c *ntpCollector) Collect(client collector.Client, ch chan<- prometheus.Metric, labelValues []string) error {
@@ -109,13 +105,6 @@ func (c *ntpCollector) Collect(client collector.Client, ch chan<- prometheus.Met
 	exportMetric(ch, ntpLeapDesc, parseLeap(result.Leap), labels)
 	exportMetric(ch, ntpPrecisionDesc, result.Precision, labels)
 	exportMetric(ch, ntpPollDesc, result.PollInterval, labels)
-
-	//	ch <- prometheus.MustNewConstMetric(
-	//		ntpServerDesc,
-	//		prometheus.GaugeValue,
-	//		1,
-	//		append(labels, result.RefID)...,
-	//	)
 
 	return nil
 }

--- a/pkg/features/ntp/collector.go
+++ b/pkg/features/ntp/collector.go
@@ -1,0 +1,159 @@
+package ntp
+
+import (
+	"log"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/czerwonk/junos_exporter/pkg/collector"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix = "junos_ntp_"
+
+var (
+	ntpStratumDesc   *prometheus.Desc
+	ntpOffsetDesc    *prometheus.Desc
+	ntpSysJitterDesc *prometheus.Desc
+	ntpClkJitterDesc *prometheus.Desc
+	ntpRootDelayDesc *prometheus.Desc
+	ntpLeapDesc      *prometheus.Desc
+	ntpPrecisionDesc *prometheus.Desc
+	ntpPollDesc      *prometheus.Desc
+
+// ntpServerDesc     *prometheus.Desc
+)
+
+func init() {
+	l := []string{"target", "server"}
+	ntpStratumDesc = prometheus.NewDesc(prefix+"stratum", "NTP stratum level (0: reference clock, 1-15: hops to refernce clock, 16: not syncronized)", l, nil)
+	ntpOffsetDesc = prometheus.NewDesc(prefix+"offset", "Time offset in msec", l, nil)
+	ntpSysJitterDesc = prometheus.NewDesc(prefix+"system_jitter", "System jitter in msec", l, nil)
+	ntpClkJitterDesc = prometheus.NewDesc(prefix+"clock_jitter", "Clock jitter in msec", l, nil)
+	ntpRootDelayDesc = prometheus.NewDesc(prefix+"root_delay", "Root delay in msec", l, nil)
+	ntpLeapDesc = prometheus.NewDesc(prefix+"leap", "Leap indicator (00=ok, 01: last minute with 61 seconds, 10: last minute with 59 seconds, 11: not syncronized)", l, nil)
+	ntpPrecisionDesc = prometheus.NewDesc(prefix+"precision", "Clock precision (should be -20 to -22)", l, nil)
+	ntpPollDesc = prometheus.NewDesc(prefix+"poll_interval", "Poll interval in seconds", l, nil)
+	// ntpServerDesc = prometheus.NewDesc(prefix+"server_info", "NTP server info", append(l, "refid"), nil)
+}
+
+type ntpCollector struct{}
+
+func NewCollector() collector.RPCCollector {
+	return &ntpCollector{}
+}
+
+func (c *ntpCollector) Name() string {
+	return "ntp"
+}
+
+func (c *ntpCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- ntpStratumDesc
+	ch <- ntpOffsetDesc
+	ch <- ntpSysJitterDesc
+	ch <- ntpClkJitterDesc
+	ch <- ntpRootDelayDesc
+	ch <- ntpLeapDesc
+	ch <- ntpPrecisionDesc
+	ch <- ntpPollDesc
+	// ch <- ntpServerDesc
+}
+
+func (c *ntpCollector) Collect(client collector.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var reply rpcReply
+
+	err := client.RunCommandAndParse("show ntp status | display xml", &reply)
+	if err != nil {
+		return errors.Wrap(err, "failed to execute NTP command")
+	}
+
+	// Hier wird das parseResult direkt aus den Metriken erzeugt
+	metrics := parseNTPOutput(reply.Output.Text)
+	if len(metrics) == 0 {
+		return errors.New("no NTP metrics parsed")
+	}
+
+	tc := mustParseFloat(metrics["tc"])
+	if tc == 0 {
+		tc = 10
+	}
+
+	// Konvertierung der Metriken in parseResult
+	result := &parseResult{
+		AssocID:      metrics["associd"],
+		Stratum:      mustParseFloat(metrics["stratum"]),
+		RefID:        metrics["refid"],
+		Offset:       mustParseFloat(metrics["offset"]),
+		SysJitter:    mustParseFloat(metrics["sys_jitter"]),
+		ClkJitter:    mustParseFloat(metrics["clk_jitter"]),
+		RootDelay:    mustParseFloat(metrics["rootdelay"]),
+		Leap:         metrics["leap"],
+		Precision:    mustParseFloat(metrics["precision"]),
+		PollInterval: math.Pow(2, tc), // 2^10 = 1024
+	}
+
+	server := result.RefID
+	if server == "" {
+		server = "unknown"
+	}
+
+	labels := append(labelValues, server)
+
+	exportMetric(ch, ntpStratumDesc, result.Stratum, labels)
+	exportMetric(ch, ntpOffsetDesc, result.Offset, labels)
+	exportMetric(ch, ntpSysJitterDesc, result.SysJitter, labels)
+	exportMetric(ch, ntpClkJitterDesc, result.ClkJitter, labels)
+	exportMetric(ch, ntpRootDelayDesc, result.RootDelay, labels)
+	exportMetric(ch, ntpLeapDesc, parseLeap(result.Leap), labels)
+	exportMetric(ch, ntpPrecisionDesc, result.Precision, labels)
+	exportMetric(ch, ntpPollDesc, result.PollInterval, labels)
+
+	//	ch <- prometheus.MustNewConstMetric(
+	//		ntpServerDesc,
+	//		prometheus.GaugeValue,
+	//		1,
+	//		append(labels, result.RefID)...,
+	//	)
+
+	return nil
+}
+
+func exportMetric(ch chan<- prometheus.Metric, desc *prometheus.Desc, value float64, labels []string) {
+	ch <- prometheus.MustNewConstMetric(
+		desc,
+		prometheus.GaugeValue,
+		value,
+		labels...,
+	)
+}
+
+func parseLeap(leap string) float64 {
+	leap = strings.TrimSpace(leap)
+	switch leap {
+	case "00":
+		return 0
+	case "01":
+		return 1
+	case "10":
+		return 2
+	case "11":
+		return 3
+	default:
+		return -1
+	}
+}
+
+func mustParseFloat(s string) float64 {
+	s = strings.Trim(s, "+,\" ") // Kommas entfernen
+	if s == "" || s == "-" {
+		return 0
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		log.Printf("Parse error for '%s': %v", s, err)
+		return 0
+	}
+	return f
+}

--- a/pkg/features/ntp/rpc.go
+++ b/pkg/features/ntp/rpc.go
@@ -1,0 +1,41 @@
+// In rpc.go NUR folgendes belassen:
+package ntp
+
+import (
+	"encoding/xml"
+	"regexp"
+        "strings"
+)
+
+type rpcReply struct {
+	XMLName xml.Name `xml:"rpc-reply"`
+	Output  struct {
+		Text string `xml:",chardata"`
+	} `xml:"output"`
+}
+
+type parseResult struct {
+	AssocID      string
+	Stratum      float64
+	RefID        string
+	Offset       float64
+	SysJitter    float64
+	ClkJitter    float64
+	RootDelay    float64
+	Leap         string
+	Precision    float64
+	PollInterval float64
+}
+
+func parseNTPOutput(output string) map[string]string {
+	re := regexp.MustCompile(`(\w+)=("[^"]+"|\S+)`)
+	matches := re.FindAllStringSubmatch(output, -1)
+
+	metrics := make(map[string]string)
+	for _, m := range matches {
+		key := m[1]
+                value := strings.Trim(m[2], "\", ")
+		metrics[key] = value
+	}
+	return metrics
+}


### PR DESCRIPTION
I enhanced the metrics by adding "output errors" displayed in "show interfaces extensive" which are not yet included. 
Please have look down at the bold text:
 show interfaces ge-0/0/15 extensive
Physical interface: ge-0/0/15, Enabled, Physical link is Up
  Interface index: 665, SNMP ifIndex: 545, Generation: 156
  Description: 49_6151_BORLAB_TOPO-01_5C2C - Uplink to DCN-Switch
  Link-level type: Ethernet, MTU: 1514, LAN-PHY mode, Link-mode: Full-duplex, Speed: 1000mbps, Duplex: Full-Duplex, BPDU Error: None, Loop Detect PDU Error: None,
  Ethernet-Switching Error: None, MAC-REWRITE Error: None, Loopback: Disabled, Source filtering: Disabled, Flow control: Disabled, Auto-negotiation: Enabled,
  Remote fault: Online, Media type: Copper, IEEE 802.3az Energy Efficient Ethernet: Disabled, Auto-MDIX: Enabled
  Device flags   : Present Running
  Interface flags: SNMP-Traps Internal: 0x4000
  Link flags     : None
  CoS queues     : 12 supported, 12 maximum usable queues
  Hold-times     : Up 2000 ms, Down 0 ms
  Current address: 9c:5a:80:c4:26:92, Hardware address: 9c:5a:80:c4:26:92
  Last flapped   : 2026-03-06 14:31:48 UTC (5w2d 18:55 ago)
  Statistics last cleared: Never
  Traffic statistics:
   Input  bytes  :          13415613059                 2840 bps
   Output bytes  :          13356423942                 3664 bps
   Input  packets:             37416959                    4 pps
   Output packets:             36763815                    4 pps
   IPv6 transit statistics:
   Input  bytes  :                    0
   Output bytes  :                    0
   Input  packets:                    0
   Output packets:                    0
  Input errors:
    Errors: 0, Drops: 0, Framing errors: 0, Runts: 0, Policed discards: 0, L3 incompletes: 0, L2 channel errors: 0, L2 mismatch timeouts: 0, FIFO errors: 0, Resource errors: 0
  **Output errors:**
    **Carrier transitions: 5**, Errors: 0, Drops: 0, **Collisions: 0, Aged packets: 0, FIFO errors: 0, HS link CRC errors: 0, MTU errors: 0, Resource errors: 0**
  Egress queues: 12 supported, 8 in use
  Queue counters:       Queued packets  Transmitted packets      Dropped packets
    0                         10666698             10666698                    0
    1                                0                    0                    0
    2                                0                    0                    0
    3                         26097115             26097115                    0
    8                                0                    0                    0
    9                                0                    0                    0
    10                               0                    0                    0
    11                               0                    0                    0
  Queue number:         Mapped forwarding classes
    0                   best-effort
    1                   expedited-forwarding
    2                   assured-forwarding
    3                   network-control
    8                   mcast-be
    9                   mcast-ef
    10                  mcast-af
    11                  mcast-nc
  Active alarms  : None
  Active defects : None
  PCS statistics                      Seconds
    Bit errors                             0
    Errored blocks                         0
  Ethernet FEC statistics              Errors
    FEC Corrected Errors                    0
    FEC Uncorrected Errors                  0
    FEC Corrected Errors Rate               0
    FEC Uncorrected Errors Rate             0
  MAC statistics:                      Receive         Transmit
    Total octets                   13415613059      13356423942
    Total packets                     37416959         36763815
    Unicast packets                   37158761         36510941
    Broadcast packets                    53539            48162
    Multicast packets                   204659           204712
    CRC/Align errors                         0                0
    FIFO errors                              0                0
    MAC control frames                       0                0
    MAC pause frames                         0                0
    Oversized frames                         0
    Jabber frames                            0
    Fragment frames                          0
    VLAN tagged frames                       0
    Code violations                          0
  PRBS Mode : Disabled
  Autonegotiation information:
    Negotiation status: Complete
    Link partner:
        Link mode: Full-duplex, Flow control: None, Remote fault: OK, Link partner Speed: 1000 Mbps
    Local resolution:
        Flow control: None, Flow control tx: None, Flow control rx: None, Remote fault: Link OK, Local link Speed: 1000 Mbps, Link mode: Full-duplex
  Packet Forwarding Engine configuration:
    Destination slot: 0 (0x00)
  CoS information:
    Direction : Output
    CoS transmit queue               Bandwidth               Buffer Priority   Limit
                              %            bps     %           usec
    0 best-effort            75      750000000    75              0      low    none
    3 network-control         5       50000000     5              0      low    none
    8 mcast-be               15      150000000    15              0      low    none
    11 mcast-nc               5       50000000     5              0      low    none
  Interface transmit statistics: Disabled
  MACSec statistics:
    Output
        Secure Channel Transmitted
        Protected Packets               : 0
        Encrypted Packets               : 0
        Protected Bytes                 : 0
        Encrypted Bytes                 : 0
     Input
        Secure Channel Received
        Accepted Packets                : 0
        Validated Bytes                 : 0
        Decrypted Bytes                 : 0

  Logical interface ge-0/0/15.0 (Index 580) (SNMP ifIndex 547) (HW Token 2047) (Generation 165)
    Flags: Up SNMP-Traps 0x4004000 Encapsulation: ENET2
    Traffic statistics:
     Input  bytes  :          13415612702
     Output bytes  :          11379664115
     Input  packets:             37416967
     Output packets:              9717722
    Local statistics:
     Input  bytes  :            165732783
     Output bytes  :            184098688
     Input  packets:              1166605
     Output packets:              1170652
    Transit statistics:
     Input  bytes  :          13249879919                 2496 bps
     Output bytes  :          11195565427                    0 bps
     Input  packets:             36250362                    4 pps
     Output packets:              8547070                    0 pps
    Protocol inet, MTU: 1500
    Max nh cache: 75000, New hold nh limit: 75000, Curr nh cnt: 3, Curr new hold cnt: 0, NH drop cnt: 0
    Generation: 194, Route table: 7
      Flags: Sendbcast-pkt-to-re, Is-Primary
      Addresses, Flags: Is-Default Is-Preferred Is-Primary
        Destination: 10.100.121.0/29, Local: 10.100.121.4, Broadcast: 10.100.121.7, Generation: 150

New metrics are:
junos_interface_transmit_carrier_transitions{description="49_6151_BORLAB_TOPO-01_5C2C - Uplink to DCN-Switch",mac="9c:5a:80:c4:26:92",name="ge-0/0/15",target="10.100.190.232"} 0
junos_interface_transmit_collisions{description="49_6151_BORLAB_TOPO-01_5C2C - Uplink to DCN-Switch",mac="9c:5a:80:c4:26:92",name="ge-0/0/15",target="10.100.190.232"} 0
junos_interface_transmit_crc_errors{description="49_6151_BORLAB_TOPO-01_5C2C - Uplink to DCN-Switch",mac="9c:5a:80:c4:26:92",name="ge-0/0/15",target="10.100.190.232"} 0
junos_interface_transmit_fifo_erros{description="49_6151_BORLAB_TOPO-01_5C2C - Uplink to DCN-Switch",mac="9c:5a:80:c4:26:92",name="ge-0/0/15",target="10.100.190.232"} 0
junos_interface_transmit_mtu_errors{description="49_6151_BORLAB_TOPO-01_5C2C - Uplink to DCN-Switch",mac="9c:5a:80:c4:26:92",name="ge-0/0/15",target="10.100.190.232"} 0
junos_interface_transmit_resource_errors{description="49_6151_BORLAB_TOPO-01_5C2C - Uplink to DCN-Switch",mac="9c:5a:80:c4:26:92",name="ge-0/0/15",target="10.100.190.232"} 0
