### PR TITLE
Add UFD (Uplink Failure Detection) collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ features:
   system: false
   system_statistics: true
   twamp: false
+  ufd: false
   vpws: false
   vrrp: false
 ```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The following metrics are supported by now:
 * VRRP (state per interface)
 * Subscribers Information (show subscribers client-type dhcp detail)
 * PoE (show poe interface)
+* UFD (uplink-failure-detection group state)
 
 ## Feature specific mappings
 Some collected time series behave like enums - Integer values represent a certain state/meaning.

--- a/collectors.go
+++ b/collectors.go
@@ -52,6 +52,7 @@ import (
 	"github.com/czerwonk/junos_exporter/pkg/features/system"
 	"github.com/czerwonk/junos_exporter/pkg/features/systemstatistics"
 	"github.com/czerwonk/junos_exporter/pkg/features/twamp"
+	"github.com/czerwonk/junos_exporter/pkg/features/ufd"
 	"github.com/czerwonk/junos_exporter/pkg/features/virtualchassis"
 	"github.com/czerwonk/junos_exporter/pkg/features/vpws"
 	"github.com/czerwonk/junos_exporter/pkg/features/vrrp"
@@ -144,6 +145,7 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device, descRe *
 	c.addCollectorIfEnabledForDevice(device, "krt", f.KRT, krt.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "twamp", f.TWAMP, twamp.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "system_statistics", f.SystemStatistics, systemstatistics.NewCollector)
+	c.addCollectorIfEnabledForDevice(device, "ufd", f.UFD, ufd.NewCollector)
 
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,6 +109,7 @@ type FeatureConfig struct {
 	KRT                 bool `yaml:"krt,omitempty"`
 	TWAMP               bool `yaml:"twamp,omitempty"`
 	SystemStatistics    bool `yaml:"system_statistics,omitempty"`
+	UFD                 bool `yaml:"ufd,omitempty"`
 }
 
 // New creates a new config
@@ -201,6 +202,7 @@ func setDefaultValues(c *Config) {
 	f.System = false
 	f.SystemStatistics = true
 	f.TWAMP = false
+	f.UFD = false
 	f.VirtualChassis = false
 	f.VPWS = false
 	f.VRRP = false

--- a/main.go
+++ b/main.go
@@ -100,6 +100,7 @@ var (
 	krtEnabled                  = flag.Bool("krt.enabled", false, "Scrape KRT queue metrics")
 	twampEnabled                = flag.Bool("twamp.enabled", false, "Scrape TWAMP metrics")
 	systemstatisticsEnabled     = flag.Bool("systemstatistics.enabled", true, "Scrape system statistics metrics")
+	ufdEnabled                  = flag.Bool("ufd.enabled", false, "Scrape UFD (uplink-failure-detection) metrics")
 	cfg                         *config.Config
 	devices                     []*connector.Device
 	connManager                 *connector.SSHConnectionManager
@@ -283,6 +284,7 @@ func loadConfigFromFlags() *config.Config {
 	f.System = *systemEnabled
 	f.SystemStatistics = *systemstatisticsEnabled
 	f.TWAMP = *twampEnabled
+	f.UFD = *ufdEnabled
 	f.VirtualChassis = *virtualChassisEnabled
 	f.VPWS = *vpwsEnabled
 	f.VRRP = *vrrpEnabled

--- a/pkg/features/ufd/collector.go
+++ b/pkg/features/ufd/collector.go
@@ -83,8 +83,7 @@ func (c *ufdCollector) Collect(client collector.Client, ch chan<- prometheus.Met
 		return err
 	}
 
-	for _, gi := range res.Information.GroupInfos {
-		g := gi.Group
+	for _, g := range res.Groups {
 		groupLabels := append(labelValues, g.Name)
 
 		active := 0.0

--- a/pkg/features/ufd/collector.go
+++ b/pkg/features/ufd/collector.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+
+package ufd
+
+import (
+	"strings"
+
+	"github.com/czerwonk/junos_exporter/pkg/collector"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix = "junos_ufd_"
+
+var (
+	groupFailureActive *prometheus.Desc
+	groupDebounce      *prometheus.Desc
+	groupUplinkCount   *prometheus.Desc
+	groupDownlinkCount *prometheus.Desc
+	uplinkActive       *prometheus.Desc
+	downlinkActive     *prometheus.Desc
+)
+
+func init() {
+	groupLabels := []string{"target", "group"}
+	groupLabelsWithAction := []string{"target", "group", "failure_action"}
+	ifaceLabels := []string{"target", "group", "interface"}
+
+	groupFailureActive = prometheus.NewDesc(
+		prefix+"group_failure_active",
+		"1 if the UFD group's failure-action is currently engaged (i.e. not 'Inactive'), 0 otherwise",
+		groupLabelsWithAction, nil,
+	)
+	groupDebounce = prometheus.NewDesc(
+		prefix+"group_debounce_seconds",
+		"UFD group debounce interval in seconds",
+		groupLabels, nil,
+	)
+	groupUplinkCount = prometheus.NewDesc(
+		prefix+"group_uplink_count",
+		"Number of uplinks in the UFD group's link-to-monitor list",
+		groupLabels, nil,
+	)
+	groupDownlinkCount = prometheus.NewDesc(
+		prefix+"group_downlink_count",
+		"Number of downlinks in the UFD group's link-to-disable list",
+		groupLabels, nil,
+	)
+	uplinkActive = prometheus.NewDesc(
+		prefix+"uplink_active",
+		"1 if the monitored uplink is currently marked active by UFD (asterisk in show output), 0 otherwise",
+		ifaceLabels, nil,
+	)
+	downlinkActive = prometheus.NewDesc(
+		prefix+"downlink_active",
+		"1 if the downlink is currently marked active (asterisk in show output, i.e. not disabled by UFD), 0 otherwise",
+		ifaceLabels, nil,
+	)
+}
+
+type ufdCollector struct{}
+
+// Name returns the name of the collector
+func (*ufdCollector) Name() string { return "ufd" }
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector { return &ufdCollector{} }
+
+// Describe describes the metrics
+func (*ufdCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- groupFailureActive
+	ch <- groupDebounce
+	ch <- groupUplinkCount
+	ch <- groupDownlinkCount
+	ch <- uplinkActive
+	ch <- downlinkActive
+}
+
+// Collect collects metrics from JunOS
+func (c *ufdCollector) Collect(client collector.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var res = result{}
+	err := client.RunCommandAndParse("show uplink-failure-detection", &res)
+	if err != nil {
+		return err
+	}
+
+	for _, gi := range res.Information.GroupInfos {
+		g := gi.Group
+		groupLabels := append(labelValues, g.Name)
+
+		active := 0.0
+		if g.FailureAction != "" && !strings.EqualFold(strings.TrimSpace(g.FailureAction), "Inactive") {
+			active = 1.0
+		}
+		ch <- prometheus.MustNewConstMetric(
+			groupFailureActive, prometheus.GaugeValue, active,
+			append(groupLabels, strings.TrimSpace(g.FailureAction))...,
+		)
+
+		ch <- prometheus.MustNewConstMetric(groupDebounce, prometheus.GaugeValue, g.DebounceInterval, groupLabels...)
+		ch <- prometheus.MustNewConstMetric(groupUplinkCount, prometheus.GaugeValue, float64(len(g.Uplinks)), groupLabels...)
+		ch <- prometheus.MustNewConstMetric(groupDownlinkCount, prometheus.GaugeValue, float64(len(g.Downlinks)), groupLabels...)
+
+		for _, raw := range g.Uplinks {
+			name, marked := splitMark(raw)
+			ifaceLabels := append(append([]string{}, groupLabels...), name)
+			ch <- prometheus.MustNewConstMetric(uplinkActive, prometheus.GaugeValue, marked, ifaceLabels...)
+		}
+
+		for _, raw := range g.Downlinks {
+			name, marked := splitMark(raw)
+			ifaceLabels := append(append([]string{}, groupLabels...), name)
+			ch <- prometheus.MustNewConstMetric(downlinkActive, prometheus.GaugeValue, marked, ifaceLabels...)
+		}
+	}
+
+	return nil
+}
+
+// splitMark separates the trailing "*" marker from the interface name and
+// returns the clean name plus 1.0 if the marker was present, 0.0 otherwise.
+func splitMark(s string) (string, float64) {
+	s = strings.TrimSpace(s)
+	if strings.HasSuffix(s, "*") {
+		return strings.TrimSuffix(s, "*"), 1.0
+	}
+	return s, 0.0
+}

--- a/pkg/features/ufd/collector.go
+++ b/pkg/features/ufd/collector.go
@@ -3,6 +3,7 @@
 package ufd
 
 import (
+	"encoding/xml"
 	"strings"
 
 	"github.com/czerwonk/junos_exporter/pkg/collector"
@@ -77,13 +78,17 @@ func (*ufdCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect collects metrics from JunOS
 func (c *ufdCollector) Collect(client collector.Client, ch chan<- prometheus.Metric, labelValues []string) error {
-	var res = result{}
-	err := client.RunCommandAndParse("show uplink-failure-detection", &res)
+	var groups []ufdGroup
+	err := client.RunCommandAndParseWithParser("show uplink-failure-detection", func(b []byte) error {
+		var perr error
+		groups, perr = parseGroups(b)
+		return perr
+	})
 	if err != nil {
 		return err
 	}
 
-	for _, g := range res.Groups {
+	for _, g := range groups {
 		groupLabels := append(labelValues, g.Name)
 
 		active := 0.0
@@ -113,6 +118,31 @@ func (c *ufdCollector) Collect(client collector.Client, ch chan<- prometheus.Met
 	}
 
 	return nil
+}
+
+// parseGroups handles both response shapes documented in the QFX YANG: the
+// direct <uplink-failure-detection-information> body and the multi-RE / VC
+// wrapper. Same dispatch pattern as the alarm collector. When multiple REs
+// report groups, they are merged - the re-name is not exposed as a label
+// today (matches the alarm collector's behaviour).
+func parseGroups(b []byte) ([]ufdGroup, error) {
+	if strings.Contains(string(b), "<multi-routing-engine-results") {
+		var m multiEngineResult
+		if err := xml.Unmarshal(b, &m); err != nil {
+			return nil, err
+		}
+		var groups []ufdGroup
+		for _, re := range m.Engines.Items {
+			groups = append(groups, re.Groups...)
+		}
+		return groups, nil
+	}
+
+	var s singleEngineResult
+	if err := xml.Unmarshal(b, &s); err != nil {
+		return nil, err
+	}
+	return s.Groups, nil
 }
 
 // splitMark separates the trailing "*" marker from the interface name and

--- a/pkg/features/ufd/rpc.go
+++ b/pkg/features/ufd/rpc.go
@@ -2,12 +2,43 @@
 
 package ufd
 
-// Junos puts every <ufd-group> as a sibling inside a single
-// <ufd-group-information> wrapper, regardless of how many groups exist.
-// The published YANG model nominally describes ufd-group-information as a
-// list, but real-world emission flattens to one wrapper with many children;
-// the xpath below covers both shapes.
-type result struct {
+import "encoding/xml"
+
+// Junos emits the UFD response in two shapes. On a single-RE non-VC device:
+//
+//   <rpc-reply>
+//     <uplink-failure-detection-information>...</...>
+//   </rpc-reply>
+//
+// On a multi-RE chassis or Virtual Chassis the body is wrapped:
+//
+//   <rpc-reply>
+//     <multi-routing-engine-results>
+//       <multi-routing-engine-item>
+//         <re-name>fpc0</re-name>
+//         <uplink-failure-detection-information>...</...>
+//       </multi-routing-engine-item>
+//       ...
+//     </multi-routing-engine-results>
+//   </rpc-reply>
+//
+// The QFX YANG declares the body as anyxml so the device chooses which case at
+// runtime; both shapes must be handled. Same pattern as the alarm collector.
+
+type singleEngineResult struct {
+	XMLName xml.Name   `xml:"rpc-reply"`
+	Groups  []ufdGroup `xml:"uplink-failure-detection-information>ufd-group-information>ufd-group"`
+}
+
+type multiEngineResult struct {
+	XMLName xml.Name `xml:"rpc-reply"`
+	Engines struct {
+		Items []routingEngine `xml:"multi-routing-engine-item"`
+	} `xml:"multi-routing-engine-results"`
+}
+
+type routingEngine struct {
+	Name   string     `xml:"re-name"`
 	Groups []ufdGroup `xml:"uplink-failure-detection-information>ufd-group-information>ufd-group"`
 }
 
@@ -19,6 +50,6 @@ type ufdGroup struct {
 	Downlinks        []string `xml:"link-to-disable-list>downlink-interface"`
 	// DebounceTimeLeft appears only while a failure is being debounced.
 	// Not yet exposed as a metric — need a debouncing-state sample to
-	// validate the shape (the only triggered sample so far had no entry).
+	// validate the shape.
 	DebounceTimeLeft []string `xml:"link-to-disable-list>debounce-time-left"`
 }

--- a/pkg/features/ufd/rpc.go
+++ b/pkg/features/ufd/rpc.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+package ufd
+
+type result struct {
+	Information struct {
+		GroupInfos []groupInfo `xml:"ufd-group-information"`
+	} `xml:"uplink-failure-detection-information"`
+}
+
+type groupInfo struct {
+	Group ufdGroup `xml:"ufd-group"`
+}
+
+type ufdGroup struct {
+	Name             string   `xml:"ufd-group-name"`
+	FailureAction    string   `xml:"failure-action"`
+	DebounceInterval float64  `xml:"debounce-interval"`
+	Uplinks          []string `xml:"link-to-monitor-list>uplink-interface"`
+	Downlinks        []string `xml:"link-to-disable-list>downlink-interface"`
+	// DebounceTimeLeft appears only while a failure is being debounced.
+	// YANG: 'debounce-time-left' under link-to-disable-list. Not yet exposed
+	// as a metric (need a triggered-state sample to validate the shape).
+	DebounceTimeLeft []string `xml:"link-to-disable-list>debounce-time-left"`
+}

--- a/pkg/features/ufd/rpc.go
+++ b/pkg/features/ufd/rpc.go
@@ -2,14 +2,13 @@
 
 package ufd
 
+// Junos puts every <ufd-group> as a sibling inside a single
+// <ufd-group-information> wrapper, regardless of how many groups exist.
+// The published YANG model nominally describes ufd-group-information as a
+// list, but real-world emission flattens to one wrapper with many children;
+// the xpath below covers both shapes.
 type result struct {
-	Information struct {
-		GroupInfos []groupInfo `xml:"ufd-group-information"`
-	} `xml:"uplink-failure-detection-information"`
-}
-
-type groupInfo struct {
-	Group ufdGroup `xml:"ufd-group"`
+	Groups []ufdGroup `xml:"uplink-failure-detection-information>ufd-group-information>ufd-group"`
 }
 
 type ufdGroup struct {
@@ -19,7 +18,7 @@ type ufdGroup struct {
 	Uplinks          []string `xml:"link-to-monitor-list>uplink-interface"`
 	Downlinks        []string `xml:"link-to-disable-list>downlink-interface"`
 	// DebounceTimeLeft appears only while a failure is being debounced.
-	// YANG: 'debounce-time-left' under link-to-disable-list. Not yet exposed
-	// as a metric (need a triggered-state sample to validate the shape).
+	// Not yet exposed as a metric — need a debouncing-state sample to
+	// validate the shape (the only triggered sample so far had no entry).
 	DebounceTimeLeft []string `xml:"link-to-disable-list>debounce-time-left"`
 }

--- a/pkg/features/ufd/rpc_test.go
+++ b/pkg/features/ufd/rpc_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+
+package ufd
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+// Synthetic healthy-state sample modelled on real EX-series output:
+// single group, one uplink (currently marked active with "*"),
+// two downlinks (one marked, one not), failure-action Inactive.
+const healthySample = `<rpc-reply>
+  <uplink-failure-detection-information>
+    <ufd-group-information>
+      <ufd-group>
+        <ufd-group-name>uplink-group-1</ufd-group-name>
+        <link-to-monitor-list>
+          <uplink-interface>et-0/0/55*</uplink-interface>
+        </link-to-monitor-list>
+        <link-to-disable-list>
+          <downlink-interface>xe-0/0/46*</downlink-interface>
+          <downlink-interface>xe-0/0/47</downlink-interface>
+        </link-to-disable-list>
+        <failure-action>Inactive</failure-action>
+        <debounce-interval>60</debounce-interval>
+      </ufd-group>
+    </ufd-group-information>
+  </uplink-failure-detection-information>
+</rpc-reply>`
+
+func TestParseUFDHealthy(t *testing.T) {
+	var r result
+	if err := xml.Unmarshal([]byte(healthySample), &r); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if len(r.Information.GroupInfos) != 1 {
+		t.Fatalf("expected 1 group-info, got %d", len(r.Information.GroupInfos))
+	}
+
+	g := r.Information.GroupInfos[0].Group
+	if g.Name != "uplink-group-1" {
+		t.Errorf("group name: got %q", g.Name)
+	}
+	if g.FailureAction != "Inactive" {
+		t.Errorf("failure-action: got %q", g.FailureAction)
+	}
+	if g.DebounceInterval != 60 {
+		t.Errorf("debounce-interval: got %v", g.DebounceInterval)
+	}
+	if len(g.Uplinks) != 1 || g.Uplinks[0] != "et-0/0/55*" {
+		t.Errorf("uplinks: got %#v", g.Uplinks)
+	}
+	if len(g.Downlinks) != 2 || g.Downlinks[0] != "xe-0/0/46*" || g.Downlinks[1] != "xe-0/0/47" {
+		t.Errorf("downlinks: got %#v", g.Downlinks)
+	}
+}
+
+func TestSplitMark(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantName string
+		wantMark float64
+	}{
+		{"et-0/0/55*", "et-0/0/55", 1.0},
+		{"xe-0/0/47", "xe-0/0/47", 0.0},
+		{"  et-0/0/1*  ", "et-0/0/1", 1.0},
+		{"", "", 0.0},
+	}
+	for _, c := range cases {
+		name, mark := splitMark(c.in)
+		if name != c.wantName || mark != c.wantMark {
+			t.Errorf("splitMark(%q) = (%q, %v); want (%q, %v)", c.in, name, mark, c.wantName, c.wantMark)
+		}
+	}
+}

--- a/pkg/features/ufd/rpc_test.go
+++ b/pkg/features/ufd/rpc_test.go
@@ -3,7 +3,6 @@
 package ufd
 
 import (
-	"encoding/xml"
 	"testing"
 )
 
@@ -32,8 +31,8 @@ const healthySample = `<rpc-reply>
 
 // Synthetic multi-group sample modelled on real older-Junos output:
 // two <ufd-group> siblings inside ONE <ufd-group-information> wrapper,
-// no debounce-interval element (older Junos / not configured),
-// second group in failure-action Active (uplinks lost their "*" marker).
+// no debounce-interval element, second group in failure-action Active
+// (uplinks lost their "*" marker).
 const multiGroupSample = `<rpc-reply>
   <uplink-failure-detection-information>
     <ufd-group-information>
@@ -63,17 +62,60 @@ const multiGroupSample = `<rpc-reply>
   </uplink-failure-detection-information>
 </rpc-reply>`
 
+// Synthetic multi-RE / Virtual Chassis sample. The QFX UFD YANG declares
+// the response can be wrapped in <multi-routing-engine-results> with a
+// <multi-routing-engine-item> per RE / VC member. Each RE reports its own
+// UFD groups; we merge them.
+const multiEngineSample = `<rpc-reply>
+  <multi-routing-engine-results>
+    <multi-routing-engine-item>
+      <re-name>fpc0</re-name>
+      <uplink-failure-detection-information>
+        <ufd-group-information>
+          <ufd-group>
+            <ufd-group-name>vc-group-1</ufd-group-name>
+            <link-to-monitor-list>
+              <uplink-interface>et-0/0/55*</uplink-interface>
+            </link-to-monitor-list>
+            <link-to-disable-list>
+              <downlink-interface>xe-0/0/46*</downlink-interface>
+            </link-to-disable-list>
+            <failure-action>Inactive</failure-action>
+          </ufd-group>
+        </ufd-group-information>
+      </uplink-failure-detection-information>
+    </multi-routing-engine-item>
+    <multi-routing-engine-item>
+      <re-name>fpc1</re-name>
+      <uplink-failure-detection-information>
+        <ufd-group-information>
+          <ufd-group>
+            <ufd-group-name>vc-group-2</ufd-group-name>
+            <link-to-monitor-list>
+              <uplink-interface>et-1/0/55*</uplink-interface>
+            </link-to-monitor-list>
+            <link-to-disable-list>
+              <downlink-interface>xe-1/0/46*</downlink-interface>
+            </link-to-disable-list>
+            <failure-action>Inactive</failure-action>
+          </ufd-group>
+        </ufd-group-information>
+      </uplink-failure-detection-information>
+    </multi-routing-engine-item>
+  </multi-routing-engine-results>
+</rpc-reply>`
+
 func TestParseUFDHealthy(t *testing.T) {
-	var r result
-	if err := xml.Unmarshal([]byte(healthySample), &r); err != nil {
-		t.Fatalf("unmarshal failed: %v", err)
+	groups, err := parseGroups([]byte(healthySample))
+	if err != nil {
+		t.Fatalf("parseGroups failed: %v", err)
 	}
 
-	if len(r.Groups) != 1 {
-		t.Fatalf("expected 1 group, got %d", len(r.Groups))
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
 	}
 
-	g := r.Groups[0]
+	g := groups[0]
 	if g.Name != "uplink-group-1" {
 		t.Errorf("group name: got %q", g.Name)
 	}
@@ -92,41 +134,58 @@ func TestParseUFDHealthy(t *testing.T) {
 }
 
 func TestParseUFDMultiGroup(t *testing.T) {
-	var r result
-	if err := xml.Unmarshal([]byte(multiGroupSample), &r); err != nil {
-		t.Fatalf("unmarshal failed: %v", err)
+	groups, err := parseGroups([]byte(multiGroupSample))
+	if err != nil {
+		t.Fatalf("parseGroups failed: %v", err)
 	}
 
-	if len(r.Groups) != 2 {
-		t.Fatalf("expected 2 groups, got %d", len(r.Groups))
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
 	}
 
-	// First group: healthy, single uplink, two downlinks
-	if r.Groups[0].Name != "group-a" {
-		t.Errorf("group 0 name: got %q", r.Groups[0].Name)
+	if groups[0].Name != "group-a" {
+		t.Errorf("group 0 name: got %q", groups[0].Name)
 	}
-	if r.Groups[0].FailureAction != "Inactive" {
-		t.Errorf("group 0 failure-action: got %q", r.Groups[0].FailureAction)
+	if groups[0].FailureAction != "Inactive" {
+		t.Errorf("group 0 failure-action: got %q", groups[0].FailureAction)
 	}
-	if r.Groups[0].DebounceInterval != 0 {
-		t.Errorf("group 0 debounce default: got %v want 0", r.Groups[0].DebounceInterval)
-	}
-	if len(r.Groups[0].Uplinks) != 1 {
-		t.Errorf("group 0 uplinks: got %#v", r.Groups[0].Uplinks)
+	if groups[0].DebounceInterval != 0 {
+		t.Errorf("group 0 debounce default: got %v want 0", groups[0].DebounceInterval)
 	}
 
-	// Second group: triggered failure, multiple uplinks (no "*"), single downlink
-	if r.Groups[1].Name != "group-b" {
-		t.Errorf("group 1 name: got %q", r.Groups[1].Name)
+	if groups[1].Name != "group-b" {
+		t.Errorf("group 1 name: got %q", groups[1].Name)
 	}
-	if r.Groups[1].FailureAction != "Active" {
-		t.Errorf("group 1 failure-action: got %q want Active", r.Groups[1].FailureAction)
+	if groups[1].FailureAction != "Active" {
+		t.Errorf("group 1 failure-action: got %q want Active", groups[1].FailureAction)
 	}
-	if len(r.Groups[1].Uplinks) != 2 {
-		t.Errorf("group 1 uplinks: got %#v", r.Groups[1].Uplinks)
+	if len(groups[1].Uplinks) != 2 {
+		t.Errorf("group 1 uplinks: got %#v", groups[1].Uplinks)
 	}
-	if len(r.Groups[1].Downlinks) != 1 {
-		t.Errorf("group 1 downlinks: got %#v", r.Groups[1].Downlinks)
+}
+
+func TestParseUFDMultiEngine(t *testing.T) {
+	groups, err := parseGroups([]byte(multiEngineSample))
+	if err != nil {
+		t.Fatalf("parseGroups failed: %v", err)
+	}
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 merged groups (one per RE), got %d", len(groups))
+	}
+
+	names := []string{groups[0].Name, groups[1].Name}
+	wantNames := map[string]bool{"vc-group-1": false, "vc-group-2": false}
+	for _, n := range names {
+		if _, ok := wantNames[n]; !ok {
+			t.Errorf("unexpected group name %q", n)
+		}
+		wantNames[n] = true
+	}
+	for n, seen := range wantNames {
+		if !seen {
+			t.Errorf("expected to see group %q but didn't", n)
+		}
 	}
 }
 

--- a/pkg/features/ufd/rpc_test.go
+++ b/pkg/features/ufd/rpc_test.go
@@ -9,7 +9,8 @@ import (
 
 // Synthetic healthy-state sample modelled on real EX-series output:
 // single group, one uplink (currently marked active with "*"),
-// two downlinks (one marked, one not), failure-action Inactive.
+// two downlinks (one marked, one not), failure-action Inactive,
+// explicit debounce-interval.
 const healthySample = `<rpc-reply>
   <uplink-failure-detection-information>
     <ufd-group-information>
@@ -29,17 +30,50 @@ const healthySample = `<rpc-reply>
   </uplink-failure-detection-information>
 </rpc-reply>`
 
+// Synthetic multi-group sample modelled on real older-Junos output:
+// two <ufd-group> siblings inside ONE <ufd-group-information> wrapper,
+// no debounce-interval element (older Junos / not configured),
+// second group in failure-action Active (uplinks lost their "*" marker).
+const multiGroupSample = `<rpc-reply>
+  <uplink-failure-detection-information>
+    <ufd-group-information>
+      <ufd-group>
+        <ufd-group-name>group-a</ufd-group-name>
+        <link-to-monitor-list>
+          <uplink-interface>ae22*</uplink-interface>
+        </link-to-monitor-list>
+        <link-to-disable-list>
+          <downlink-interface>xe-0/0/20*</downlink-interface>
+          <downlink-interface>xe-0/0/21</downlink-interface>
+        </link-to-disable-list>
+        <failure-action>Inactive</failure-action>
+      </ufd-group>
+      <ufd-group>
+        <ufd-group-name>group-b</ufd-group-name>
+        <link-to-monitor-list>
+          <uplink-interface>et-0/0/25</uplink-interface>
+          <uplink-interface>et-0/0/26</uplink-interface>
+        </link-to-monitor-list>
+        <link-to-disable-list>
+          <downlink-interface>et-0/0/27</downlink-interface>
+        </link-to-disable-list>
+        <failure-action>Active</failure-action>
+      </ufd-group>
+    </ufd-group-information>
+  </uplink-failure-detection-information>
+</rpc-reply>`
+
 func TestParseUFDHealthy(t *testing.T) {
 	var r result
 	if err := xml.Unmarshal([]byte(healthySample), &r); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}
 
-	if len(r.Information.GroupInfos) != 1 {
-		t.Fatalf("expected 1 group-info, got %d", len(r.Information.GroupInfos))
+	if len(r.Groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(r.Groups))
 	}
 
-	g := r.Information.GroupInfos[0].Group
+	g := r.Groups[0]
 	if g.Name != "uplink-group-1" {
 		t.Errorf("group name: got %q", g.Name)
 	}
@@ -57,6 +91,45 @@ func TestParseUFDHealthy(t *testing.T) {
 	}
 }
 
+func TestParseUFDMultiGroup(t *testing.T) {
+	var r result
+	if err := xml.Unmarshal([]byte(multiGroupSample), &r); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if len(r.Groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(r.Groups))
+	}
+
+	// First group: healthy, single uplink, two downlinks
+	if r.Groups[0].Name != "group-a" {
+		t.Errorf("group 0 name: got %q", r.Groups[0].Name)
+	}
+	if r.Groups[0].FailureAction != "Inactive" {
+		t.Errorf("group 0 failure-action: got %q", r.Groups[0].FailureAction)
+	}
+	if r.Groups[0].DebounceInterval != 0 {
+		t.Errorf("group 0 debounce default: got %v want 0", r.Groups[0].DebounceInterval)
+	}
+	if len(r.Groups[0].Uplinks) != 1 {
+		t.Errorf("group 0 uplinks: got %#v", r.Groups[0].Uplinks)
+	}
+
+	// Second group: triggered failure, multiple uplinks (no "*"), single downlink
+	if r.Groups[1].Name != "group-b" {
+		t.Errorf("group 1 name: got %q", r.Groups[1].Name)
+	}
+	if r.Groups[1].FailureAction != "Active" {
+		t.Errorf("group 1 failure-action: got %q want Active", r.Groups[1].FailureAction)
+	}
+	if len(r.Groups[1].Uplinks) != 2 {
+		t.Errorf("group 1 uplinks: got %#v", r.Groups[1].Uplinks)
+	}
+	if len(r.Groups[1].Downlinks) != 1 {
+		t.Errorf("group 1 downlinks: got %#v", r.Groups[1].Downlinks)
+	}
+}
+
 func TestSplitMark(t *testing.T) {
 	cases := []struct {
 		in       string
@@ -65,6 +138,7 @@ func TestSplitMark(t *testing.T) {
 	}{
 		{"et-0/0/55*", "et-0/0/55", 1.0},
 		{"xe-0/0/47", "xe-0/0/47", 0.0},
+		{"ae22*", "ae22", 1.0},
 		{"  et-0/0/1*  ", "et-0/0/1", 1.0},
 		{"", "", 0.0},
 	}


### PR DESCRIPTION
Adds a new collector that exposes Junos Uplink Failure Detection state by calling `show uplink-failure-detection` (`<get-uplink-failure-detection-information>`).

  UFD pairs a set of monitored uplink interfaces with a set of downlinks that should be administratively disabled when all monitored uplinks fail. It is commonly deployed on
   access switches where downstream devices depend on northbound reachability. The collector lets you alert on:

  - A UFD group whose `failure-action` is currently engaged (uplinks down, downlinks being disabled).
  - Monitored uplinks losing their active marker.
  - Newly added groups whose downlink count diverges from expectation.

  ### Metrics

  | Metric | Type | Labels | Description |
  |---|---|---|---|
  | `junos_ufd_group_failure_active` | gauge | `target`, `group`, `failure_action` | `1` if `failure-action` is anything other than `Inactive`, `0` otherwise |
  | `junos_ufd_group_debounce_seconds` | gauge | `target`, `group` | Configured `debounce-interval` (`0` when the device does not emit the element) |
  | `junos_ufd_group_uplink_count` | gauge | `target`, `group` | Number of uplinks in the link-to-monitor list |
  | `junos_ufd_group_downlink_count` | gauge | `target`, `group` | Number of downlinks in the link-to-disable list |
  | `junos_ufd_uplink_active` | gauge | `target`, `group`, `interface` | `1` if the uplink is currently marked active in show output (trailing `*`), `0` otherwise |
  | `junos_ufd_downlink_active` | gauge | `target`, `group`, `interface` | `1` if the downlink is currently marked active (not disabled by UFD) |

  ### Wiring

  - New feature flag `-ufd.enabled` (default `false`, matching the conservative defaults of other newer collectors).
  - New YAML key `features: { ufd: true }`.
  - Registered in `collectors.go`.
  - README features example updated.

  ### Response-shape handling

  The Junos YANG (`junos-qfx-rpc-uplink-failure-detection@2019-01-01`) declares the operational output as `anyxml` with two cases:

  1. **Direct body** — `<uplink-failure-detection-information>` at the root of `<rpc-reply>`.
  2. **Multi-RE / Virtual Chassis wrapper** — the body is nested under `<multi-routing-engine-results>` / `<multi-routing-engine-item>`, one item per RE or VC member.

  The parser dispatches between the two shapes using the same substring-check pattern as the existing `alarm` collector. When the multi-RE wrapper is present, groups from
  every RE/VC member are merged. The `re-name` is intentionally **not** exposed as a label, matching the `alarm` collector's behaviour (can be added in a follow-up if there
  is demand).

  Junos also emits multiple `<ufd-group>` entries as siblings inside a single `<ufd-group-information>` wrapper rather than as separate wrapper occurrences, so the xpath
  descends through `uplink-failure-detection-information>ufd-group-information>ufd-group` and lets `xml.Unmarshal` collect every group at that path.

  ### Marker semantics

  Interface entries in both `link-to-monitor-list` and `link-to-disable-list` are emitted with an optional trailing `*` denoting "currently active". Observed semantics:

  - **Uplinks** — `*` present in healthy state; lost when the uplink goes down (the trigger for UFD).
  - **Downlinks** — `*` present when not currently disabled by UFD; lost when the failure action engages and the downlink is administratively shut.

  The collector strips the marker from the `interface` label so downstream queries are clean, and exposes the marker presence as the metric value.

  ### Tests

  `pkg/features/ufd/rpc_test.go` includes three response-shape fixtures plus a `splitMark` unit test:

  1. Single-group healthy state with explicit `debounce-interval`.
  2. Multi-group state, one in `failure-action Active` (uplinks lost their `*`), no `debounce-interval` element.
  3. Multi-RE wrapper with one group per RE.

  ```
  === RUN   TestParseUFDHealthy
  --- PASS
  === RUN   TestParseUFDMultiGroup
  --- PASS
  === RUN   TestParseUFDMultiEngine
  --- PASS
  === RUN   TestSplitMark
  --- PASS
  ```

  ### Verified against

  - An EX-series device on Junos 24.x (single group, healthy).
  - An EX-series device on Junos 21.4 (two groups, one in `failure-action Active`).
  - YANG model cross-referenced from [`Juniper/yang`](https://github.com/Juniper/yang) (`junos-ex-rpc-uplink-failure-detection@2023-01-01` and
  `junos-qfx-rpc-uplink-failure-detection@2019-01-01`).

  The multi-RE response handling is exercised by the test fixture but has not yet been validated against a live Virtual Chassis. The dispatch pattern mirrors the `alarm`
  collector, which handles this path in production.

  ### Out of scope (potential follow-ups)

  - Exposing `debounce-time-left` as a metric — the element only appears during the active debounce window; no triggered-state sample captured yet.
  - Adding the `re-name` label for multi-RE / VC visibility (matches `alarm` collector limitation).
  - A `get-uplink-failure-detection-group-information` per-group fetch — useful only if scrape size becomes a concern; the default RPC already returns all groups.