### PR TITLE
Add EVPN-VXLAN coverage (instance / detail / duplicate-MAC / L3 contexts) + separate Type-5 collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ features:
   ddos_protection: false
   dot1x: false
   environment: true
+  evpn: false
   firewall: true
   fpc: false
   interface_diagnostic: true

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The following metrics are supported by now:
 * NAT (all available statistics from services nat)
 * Chassis cluster HA status (SRX)
 * Environment (temperatures, fans and PEM power statistics)
+* EVPN (per-EVI state, neighbor route counts, detail tables for interfaces / IRBs / bridge-domains / ESIs with DF election, duplicate-MAC detection, L3 contexts)
+* EVPN Type-5 / IP-prefix database (per-context per-AFI local + remote prefix counts, accepted/rejected advertisements) — separate flag (`-evpn_ip_prefix.enabled`) because the response scales with prefix count
 * Routing engine statistics
 * Storage (total, available and used blocks, used percentage)
 * Firewall filters (counters and policers) - needs explicit rights beyond read-only
@@ -55,8 +57,6 @@ The following metrics are supported by now:
 * VRRP (state per interface)
 * Subscribers Information (show subscribers client-type dhcp detail)
 * PoE (show poe interface)
-* EVPN (per-EVI state, neighbor route counts, detail tables for interfaces / IRBs / bridge-domains / ESIs with DF election, duplicate-MAC detection, L3 contexts)
-* EVPN Type-5 / IP-prefix database (per-context per-AFI local + remote prefix counts, accepted/rejected advertisements) — separate flag (`-evpn_ip_prefix.enabled`) because the response scales with prefix count
 
 ## Feature specific mappings
 Some collected time series behave like enums - Integer values represent a certain state/meaning.

--- a/README.md
+++ b/README.md
@@ -228,9 +228,26 @@ devices:
     host_pattern: true
     features:
       bgp: false
+  - host: dc-leaf\d+
+    # Example: enable the EVPN collector (instance metrics, detail tables,
+    # duplicate-MAC, L3 contexts) on every DC leaf. Type-5 IP-prefix routes
+    # are gated separately because the response size scales with prefix count.
+    host_pattern: true
+    features:
+      evpn: true
+      evpn_ip_prefix: true
 
 # Optional
 # interface_description_regex: '\[([^=\]]+)(=[^\]]+)?\]'
+#
+# Global feature defaults. Two EVPN-specific knobs are exposed:
+#   - `evpn`:           per-EVI state, neighbor route counts, detail tables
+#                       (interfaces / IRBs / bridge-domains / ESIs with DF
+#                       election), duplicate-MAC detection, L3 contexts.
+#                       Issues 3 RPCs against the device when enabled.
+#   - `evpn_ip_prefix`: EVPN Type-5 (IP-prefix) database. Separated because
+#                       response size scales with prefix count on busy
+#                       fabrics; enable per-device where Type-5 is in use.
 features:
   accounting: false
   alarm: true

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ features:
   dot1x: false
   environment: true
   evpn: false
+  evpn_ip_prefix: false
   firewall: true
   fpc: false
   interface_diagnostic: true

--- a/README.md
+++ b/README.md
@@ -237,17 +237,6 @@ devices:
       evpn: true
       evpn_ip_prefix: true
 
-# Optional
-# interface_description_regex: '\[([^=\]]+)(=[^\]]+)?\]'
-#
-# Global feature defaults. Two EVPN-specific knobs are exposed:
-#   - `evpn`:           per-EVI state, neighbor route counts, detail tables
-#                       (interfaces / IRBs / bridge-domains / ESIs with DF
-#                       election), duplicate-MAC detection, L3 contexts.
-#                       Issues 3 RPCs against the device when enabled.
-#   - `evpn_ip_prefix`: EVPN Type-5 (IP-prefix) database. Separated because
-#                       response size scales with prefix count on busy
-#                       fabrics; enable per-device where Type-5 is in use.
 features:
   accounting: false
   alarm: true

--- a/README.md
+++ b/README.md
@@ -315,6 +315,15 @@ Label name: peer
 Label value: 202739
 ```
 
+### Enriching other collectors via PromQL join
+Dynamic labels are attached only to metrics whose source RPC carries the description text (interfaces, interfacediagnostics, interfacequeue, bgp). Other collectors with an `interface` label — for example EVPN's `junos_evpn_interface_status` or `junos_evpn_esi_designated_forwarder_info` — can pick up the same labels at query time via a vector join on `(target, interface)`:
+```
+junos_evpn_interface_status
+  * on(target, interface) group_left(prod, peer, customer)
+    junos_interfaces_up
+```
+This requires the `interfaces` collector to be enabled (the default).
+
 ### Custom Label RegEx
 
 To override the default behavior a `interface_description_regex` can be supplied. This parameter can be given at a global level or per device. To use per-device regexes the target devices need to be defined in the exporter config. Per-device regex cannot be used in combination with `-config.ignore-targets`.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ The following metrics are supported by now:
 * VRRP (state per interface)
 * Subscribers Information (show subscribers client-type dhcp detail)
 * PoE (show poe interface)
+* EVPN (per-EVI state, neighbor route counts, detail tables for interfaces / IRBs / bridge-domains / ESIs with DF election, duplicate-MAC detection, L3 contexts)
+* EVPN Type-5 / IP-prefix database (per-context per-AFI local + remote prefix counts, accepted/rejected advertisements) — separate flag (`-evpn_ip_prefix.enabled`) because the response scales with prefix count
 
 ## Feature specific mappings
 Some collected time series behave like enums - Integer values represent a certain state/meaning.
@@ -119,6 +121,35 @@ States map to human readable names like this:
 1: "init"
 2: "backup"
 3: "master"
+```
+
+### EVPN
+The EVPN collector exposes both per-EVI scalars and several state metrics. The state metrics all use the same 0/1 mapping:
+
+```
+junos_evpn_interface_status   0: Down   1: Up
+junos_evpn_irb_status         0: Down   1: Up
+junos_evpn_esi_resolved       0: unresolved (or remote-only)   1: resolved (local-bound)
+```
+
+`junos_evpn_esi_designated_forwarder_info` is an info-pattern gauge that is always `1` when emitted; its labels (`designated_forwarder`, `backup_forwarder`, `df_algorithm`, `local_interface`) deliberately churn on DF-election events, so it is split off from `junos_evpn_esi_resolved` to keep state-alert queries stable. Join on `(target, instance, esi)` for Grafana dashboards:
+
+```
+junos_evpn_esi_resolved
+  * on(target, instance, esi)
+  group_left(designated_forwarder, backup_forwarder, local_interface)
+    junos_evpn_esi_designated_forwarder_info
+```
+
+The duplicate-MAC suppression total is always emitted and is the primary alert signal:
+```
+junos_evpn_duplicate_mac_total > 0   # forwarding loop or split-brain
+```
+
+### EVPN Type-5 IP prefix
+`junos_evpn_ip_prefix_advertisement_count` uses a `status` discriminator label (`accepted`, `rejected`, …) so rejected Type-5 routes can be alerted on without separate metric families:
+```
+junos_evpn_ip_prefix_advertisement_count{status="rejected"} > 0
 ```
 
 ### License statistics

--- a/collectors.go
+++ b/collectors.go
@@ -20,6 +20,7 @@ import (
 	"github.com/czerwonk/junos_exporter/pkg/features/dot1x"
 	"github.com/czerwonk/junos_exporter/pkg/features/environment"
 	"github.com/czerwonk/junos_exporter/pkg/features/evpn"
+	"github.com/czerwonk/junos_exporter/pkg/features/evpnipprefix"
 	"github.com/czerwonk/junos_exporter/pkg/features/firewall"
 	"github.com/czerwonk/junos_exporter/pkg/features/fpc"
 	"github.com/czerwonk/junos_exporter/pkg/features/interfacediagnostics"
@@ -100,6 +101,7 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device, descRe *
 	c.addCollectorIfEnabledForDevice(device, "dot1x", f.DOT1X, dot1x.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "env", f.Environment, environment.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "evpn", f.EVPN, evpn.NewCollector)
+	c.addCollectorIfEnabledForDevice(device, "evpn_ip_prefix", f.EVPNIPPrefix, evpnipprefix.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "firewall", f.Firewall, firewall.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "fpc", f.FPC, fpc.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "ifacediag", f.InterfaceDiagnostic, func() collector.RPCCollector {

--- a/collectors.go
+++ b/collectors.go
@@ -19,6 +19,7 @@ import (
 	"github.com/czerwonk/junos_exporter/pkg/features/cluster"
 	"github.com/czerwonk/junos_exporter/pkg/features/dot1x"
 	"github.com/czerwonk/junos_exporter/pkg/features/environment"
+	"github.com/czerwonk/junos_exporter/pkg/features/evpn"
 	"github.com/czerwonk/junos_exporter/pkg/features/firewall"
 	"github.com/czerwonk/junos_exporter/pkg/features/fpc"
 	"github.com/czerwonk/junos_exporter/pkg/features/interfacediagnostics"
@@ -98,6 +99,7 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device, descRe *
 	})
 	c.addCollectorIfEnabledForDevice(device, "dot1x", f.DOT1X, dot1x.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "env", f.Environment, environment.NewCollector)
+	c.addCollectorIfEnabledForDevice(device, "evpn", f.EVPN, evpn.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "firewall", f.Firewall, firewall.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "fpc", f.FPC, fpc.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "ifacediag", f.InterfaceDiagnostic, func() collector.RPCCollector {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,7 @@ type FeatureConfig struct {
 	Alarm               bool `yaml:"alarm,omitempty"`
 	NTP                 bool `yaml:"ntp,omitempty"`
 	Environment         bool `yaml:"environment,omitempty"`
+	EVPN                bool `yaml:"evpn,omitempty"`
 	BFD                 bool `yaml:"bfd,omitempty"`
 	BGP                 bool `yaml:"bgp,omitempty"`
 	DOT1X               bool `yaml:"dot1x,omitempty"`
@@ -165,6 +166,7 @@ func setDefaultValues(c *Config) {
 	f.DDOSProtection = false
 	f.DOT1X = false
 	f.Environment = true
+	f.EVPN = false
 	f.Firewall = true
 	f.FPC = false
 	f.Interfaces = true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,7 @@ type FeatureConfig struct {
 	NTP                 bool `yaml:"ntp,omitempty"`
 	Environment         bool `yaml:"environment,omitempty"`
 	EVPN                bool `yaml:"evpn,omitempty"`
+	EVPNIPPrefix        bool `yaml:"evpn_ip_prefix,omitempty"`
 	BFD                 bool `yaml:"bfd,omitempty"`
 	BGP                 bool `yaml:"bgp,omitempty"`
 	DOT1X               bool `yaml:"dot1x,omitempty"`
@@ -167,6 +168,7 @@ func setDefaultValues(c *Config) {
 	f.DOT1X = false
 	f.Environment = true
 	f.EVPN = false
+	f.EVPNIPPrefix = false
 	f.Firewall = true
 	f.FPC = false
 	f.Interfaces = true

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ var (
 	routingEngineEnabled        = flag.Bool("routingengine.enabled", true, "Scrape Routing Engine metrics")
 	routesEnabled               = flag.Bool("routes.enabled", true, "Scrape routing table metrics")
 	environmentEnabled          = flag.Bool("environment.enabled", true, "Scrape environment metrics")
+	evpnEnabled                 = flag.Bool("evpn.enabled", false, "Scrape EVPN instance metrics")
 	firewallEnabled             = flag.Bool("firewall.enabled", true, "Scrape Firewall count metrics")
 	interfacesEnabled           = flag.Bool("interfaces.enabled", true, "Scrape interface metrics")
 	interfaceDiagnosticsEnabled = flag.Bool("ifdiag.enabled", true, "Scrape optical interface diagnostic metrics")
@@ -247,6 +248,7 @@ func loadConfigFromFlags() *config.Config {
 	f.DDOSProtection = *ddosProtectionEnabled
 	f.DOT1X = *dot1xEnabled
 	f.Environment = *environmentEnabled
+	f.EVPN = *evpnEnabled
 	f.Firewall = *firewallEnabled
 	f.FPC = *fpcEnabled
 	f.Interfaces = *interfacesEnabled

--- a/main.go
+++ b/main.go
@@ -55,7 +55,8 @@ var (
 	routingEngineEnabled        = flag.Bool("routingengine.enabled", true, "Scrape Routing Engine metrics")
 	routesEnabled               = flag.Bool("routes.enabled", true, "Scrape routing table metrics")
 	environmentEnabled          = flag.Bool("environment.enabled", true, "Scrape environment metrics")
-	evpnEnabled                 = flag.Bool("evpn.enabled", false, "Scrape EVPN instance metrics")
+	evpnEnabled                 = flag.Bool("evpn.enabled", false, "Scrape EVPN instance, detail tables (interfaces/IRBs/bridge-domains/ESIs), duplicate-MAC, and L3 context metrics")
+	evpnIPPrefixEnabled         = flag.Bool("evpn_ip_prefix.enabled", false, "Scrape EVPN Type-5 (IP-prefix) database metrics; potentially large on busy fabrics")
 	firewallEnabled             = flag.Bool("firewall.enabled", true, "Scrape Firewall count metrics")
 	interfacesEnabled           = flag.Bool("interfaces.enabled", true, "Scrape interface metrics")
 	interfaceDiagnosticsEnabled = flag.Bool("ifdiag.enabled", true, "Scrape optical interface diagnostic metrics")
@@ -249,6 +250,7 @@ func loadConfigFromFlags() *config.Config {
 	f.DOT1X = *dot1xEnabled
 	f.Environment = *environmentEnabled
 	f.EVPN = *evpnEnabled
+	f.EVPNIPPrefix = *evpnIPPrefixEnabled
 	f.Firewall = *firewallEnabled
 	f.FPC = *fpcEnabled
 	f.Interfaces = *interfacesEnabled

--- a/pkg/features/evpn/collector.go
+++ b/pkg/features/evpn/collector.go
@@ -47,6 +47,7 @@ var (
 	bridgeDomainInterfaceUpCount *prometheus.Desc
 	esiResolved                  *prometheus.Desc
 	esiRemotePECount             *prometheus.Desc
+	esiDesignatedForwarderInfo   *prometheus.Desc
 
 	// ============== Duplicate-MAC descriptors (from show evpn database state duplicate) ==============
 	duplicateMACTotal *prometheus.Desc
@@ -64,8 +65,8 @@ func init() {
 	interfaceLabels := []string{"target", "instance", "interface", "esi", "mode", "etree_role"}
 	irbLabels := []string{"target", "instance", "irb_interface", "vni_id", "l3_context"}
 	bdLabels := []string{"target", "instance", "vlan_id", "domain_id", "irb_interface", "mode", "mac_sync"}
-	esiLabels := []string{"target", "instance", "esi", "status", "local_interface", "designated_forwarder", "backup_forwarder", "df_algorithm"}
 	esiCountLabels := []string{"target", "instance", "esi"}
+	esiDFLabels := []string{"target", "instance", "esi", "designated_forwarder", "backup_forwarder", "df_algorithm", "local_interface"}
 	l3CtxLabels := []string{"target", "context", "type", "advertisement_mode", "router_mac", "encapsulation"}
 	stateLabels := []string{"target"}
 
@@ -128,10 +129,13 @@ func init() {
 	bridgeDomainInterfaceUpCount = prometheus.NewDesc(prefix+"bridge_domain_interface_up_count",
 		"Interfaces currently up in this bridge-domain", bdLabels, nil)
 	esiResolved = prometheus.NewDesc(prefix+"esi_resolved",
-		"EVPN ESI resolution state (0: unresolved, 1: resolved). Labels carry the local-interface bind, DF election state, backup forwarder, and DF election algorithm.",
-		esiLabels, nil)
+		"EVPN ESI resolution state (0: unresolved, 1: resolved). Join with junos_evpn_esi_designated_forwarder_info on (target, instance, esi) for DF/local-interface labels.",
+		esiCountLabels, nil)
 	esiRemotePECount = prometheus.NewDesc(prefix+"esi_remote_pe_count",
 		"Number of remote PEs known for this Ethernet Segment", esiCountLabels, nil)
+	esiDesignatedForwarderInfo = prometheus.NewDesc(prefix+"esi_designated_forwarder_info",
+		"EVPN ESI designated-forwarder election state (gauge=1 info-pattern). Labels churn on DF election events; join with junos_evpn_esi_resolved for clean state queries.",
+		esiDFLabels, nil)
 
 	// Duplicate-MAC: target-level total always emitted, per-instance only when > 0.
 	duplicateMACTotal = prometheus.NewDesc(prefix+"duplicate_mac_total",
@@ -174,7 +178,7 @@ func (*evpnCollector) Describe(ch chan<- *prometheus.Desc) {
 		neighborEthernetSegmentRoutes,
 		interfaceStatus, irbStatus,
 		bridgeDomainInterfaceCount, bridgeDomainInterfaceUpCount,
-		esiResolved, esiRemotePECount,
+		esiResolved, esiRemotePECount, esiDesignatedForwarderInfo,
 		duplicateMACTotal, duplicateMACCount,
 		l3ContextVNI, l3ContextCount,
 	} {
@@ -298,13 +302,26 @@ func (c *evpnCollector) emitInstance(ch chan<- prometheus.Metric, labelValues []
 		ch <- prometheus.MustNewConstMetric(bridgeDomainInterfaceUpCount, prometheus.GaugeValue, bd.InterfacesUp, l...)
 	}
 	for _, esi := range in.ESIs {
-		// ESI is "resolved" if the status text contains "Resolved" (the
-		// other observed value is an empty string for unconfigured remote
-		// segments).
+		// _resolved is a pure-state gauge with stable labels — operators
+		// alert on this directly without worrying about DF-election churn.
 		resolved := 0.0
 		if strings.Contains(strings.ToLower(esi.Status), "resolved") {
 			resolved = 1.0
 		}
+		esiLabels := append(append([]string{}, base...), esi.Value)
+		ch <- prometheus.MustNewConstMetric(esiResolved, prometheus.GaugeValue, resolved, esiLabels...)
+
+		if esi.RemotePEInfo != nil {
+			ch <- prometheus.MustNewConstMetric(esiRemotePECount, prometheus.GaugeValue, esi.RemotePEInfo.Count, esiLabels...)
+		}
+
+		// _designated_forwarder_info is an info-pattern series carrying the
+		// labels that *do* change on DF-election events (DF/backup IPs,
+		// local-interface bind, algorithm). It deliberately churns when those
+		// rotate — operators query `changes(... [window])` on this series to
+		// detect DF instability, and `group_left(...)` it onto _resolved for
+		// dashboards. Emitted only when at least one of the labels is
+		// populated, to avoid noise on remote ESIs with no local state.
 		localIfName, dfAddr, backupAddr, dfAlgo := "", "", "", ""
 		if esi.LocalIntf != nil {
 			localIfName = esi.LocalIntf.Name
@@ -314,14 +331,9 @@ func (c *evpnCollector) emitInstance(ch chan<- prometheus.Metric, labelValues []
 			backupAddr = esi.DFInfo.BackupForwarder
 			dfAlgo = esi.DFInfo.Algorithm
 		}
-		statusLabel := strings.TrimSpace(esi.Status)
-
-		l := append(append([]string{}, base...), esi.Value, statusLabel, localIfName, dfAddr, backupAddr, dfAlgo)
-		ch <- prometheus.MustNewConstMetric(esiResolved, prometheus.GaugeValue, resolved, l...)
-
-		if esi.RemotePEInfo != nil {
-			cl := append(append([]string{}, base...), esi.Value)
-			ch <- prometheus.MustNewConstMetric(esiRemotePECount, prometheus.GaugeValue, esi.RemotePEInfo.Count, cl...)
+		if dfAddr != "" || backupAddr != "" || dfAlgo != "" || localIfName != "" {
+			dfLabels := append(append([]string{}, base...), esi.Value, dfAddr, backupAddr, dfAlgo, localIfName)
+			ch <- prometheus.MustNewConstMetric(esiDesignatedForwarderInfo, prometheus.GaugeValue, 1, dfLabels...)
 		}
 	}
 }

--- a/pkg/features/evpn/collector.go
+++ b/pkg/features/evpn/collector.go
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: MIT
+
+package evpn
+
+import (
+	"encoding/xml"
+	"strings"
+
+	"github.com/czerwonk/junos_exporter/pkg/collector"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix = "junos_evpn_"
+
+var (
+	// Per-instance descriptors.
+	instanceInfo                   *prometheus.Desc
+	instanceNeighborCount          *prometheus.Desc
+	instanceESICount               *prometheus.Desc
+	instanceLocalInterfaces        *prometheus.Desc
+	instanceLocalInterfacesUp      *prometheus.Desc
+	instanceIRBInterfaces          *prometheus.Desc
+	instanceIRBInterfacesUp        *prometheus.Desc
+	instanceProtectInterfaces      *prometheus.Desc
+	instanceBridgeDomains          *prometheus.Desc
+	instanceLocalMACs              *prometheus.Desc
+	instanceRemoteMACs             *prometheus.Desc
+	instanceLocalMACIPs            *prometheus.Desc
+	instanceRemoteMACIPs           *prometheus.Desc
+	instanceLocalDefaultGwMACs     *prometheus.Desc
+	instanceRemoteDefaultGwMACs    *prometheus.Desc
+	instanceDuplicateMACThreshold  *prometheus.Desc
+	instanceDuplicateMACWindow     *prometheus.Desc
+
+	// Per-neighbor descriptors.
+	neighborMACRoutes               *prometheus.Desc
+	neighborMACIPRoutes             *prometheus.Desc
+	neighborAutoDiscoveryRoutes     *prometheus.Desc
+	neighborInclusiveMulticastRoutes *prometheus.Desc
+	neighborEthernetSegmentRoutes   *prometheus.Desc
+)
+
+func init() {
+	instanceLabels := []string{"target", "instance"}
+	infoLabels := []string{"target", "instance", "rd", "encap", "router_id", "source_vtep"}
+	neighborLabels := []string{"target", "instance", "neighbor"}
+
+	instanceInfo = prometheus.NewDesc(
+		prefix+"instance_info",
+		"Per-EVI metadata (always 1). Labels carry route-distinguisher, encapsulation, router-id and source VTEP address.",
+		infoLabels, nil,
+	)
+	instanceNeighborCount = prometheus.NewDesc(
+		prefix+"instance_neighbor_count",
+		"Number of EVPN neighbors (PEs) for this instance",
+		instanceLabels, nil,
+	)
+	instanceESICount = prometheus.NewDesc(
+		prefix+"instance_esi_count",
+		"Number of Ethernet Segment Identifiers known by this instance",
+		instanceLabels, nil,
+	)
+	instanceLocalInterfaces = prometheus.NewDesc(
+		prefix+"instance_local_interfaces",
+		"Number of local interfaces in this EVPN instance",
+		instanceLabels, nil,
+	)
+	instanceLocalInterfacesUp = prometheus.NewDesc(
+		prefix+"instance_local_interfaces_up",
+		"Number of local interfaces currently up in this EVPN instance",
+		instanceLabels, nil,
+	)
+	instanceIRBInterfaces = prometheus.NewDesc(
+		prefix+"instance_irb_interfaces",
+		"Number of IRB interfaces in this EVPN instance",
+		instanceLabels, nil,
+	)
+	instanceIRBInterfacesUp = prometheus.NewDesc(
+		prefix+"instance_irb_interfaces_up",
+		"Number of IRB interfaces currently up in this EVPN instance",
+		instanceLabels, nil,
+	)
+	instanceProtectInterfaces = prometheus.NewDesc(
+		prefix+"instance_protect_interfaces",
+		"Number of protect (backup) interfaces in this EVPN instance",
+		instanceLabels, nil,
+	)
+	instanceBridgeDomains = prometheus.NewDesc(
+		prefix+"instance_bridge_domains",
+		"Number of bridge domains in this EVPN instance",
+		instanceLabels, nil,
+	)
+	instanceLocalMACs = prometheus.NewDesc(
+		prefix+"instance_local_mac_count",
+		"Number of MACs learned locally in this EVPN instance",
+		instanceLabels, nil,
+	)
+	instanceRemoteMACs = prometheus.NewDesc(
+		prefix+"instance_remote_mac_count",
+		"Number of MACs learned from remote PEs in this EVPN instance",
+		instanceLabels, nil,
+	)
+	instanceLocalMACIPs = prometheus.NewDesc(
+		prefix+"instance_local_mac_ip_count",
+		"Number of local MAC+IP bindings in this EVPN instance",
+		instanceLabels, nil,
+	)
+	instanceRemoteMACIPs = prometheus.NewDesc(
+		prefix+"instance_remote_mac_ip_count",
+		"Number of remote MAC+IP bindings in this EVPN instance",
+		instanceLabels, nil,
+	)
+	instanceLocalDefaultGwMACs = prometheus.NewDesc(
+		prefix+"instance_local_default_gateway_mac_count",
+		"Number of local default-gateway MACs in this EVPN instance",
+		instanceLabels, nil,
+	)
+	instanceRemoteDefaultGwMACs = prometheus.NewDesc(
+		prefix+"instance_remote_default_gateway_mac_count",
+		"Number of remote default-gateway MACs in this EVPN instance",
+		instanceLabels, nil,
+	)
+	instanceDuplicateMACThreshold = prometheus.NewDesc(
+		prefix+"instance_duplicate_mac_threshold",
+		"Configured duplicate-MAC detection threshold for this EVPN instance",
+		instanceLabels, nil,
+	)
+	instanceDuplicateMACWindow = prometheus.NewDesc(
+		prefix+"instance_duplicate_mac_window_seconds",
+		"Configured duplicate-MAC detection window in seconds for this EVPN instance",
+		instanceLabels, nil,
+	)
+
+	neighborMACRoutes = prometheus.NewDesc(
+		prefix+"neighbor_mac_routes",
+		"Per-neighbor count of EVPN Type-2 MAC routes (without IP)",
+		neighborLabels, nil,
+	)
+	neighborMACIPRoutes = prometheus.NewDesc(
+		prefix+"neighbor_mac_ip_routes",
+		"Per-neighbor count of EVPN Type-2 MAC+IP routes",
+		neighborLabels, nil,
+	)
+	neighborAutoDiscoveryRoutes = prometheus.NewDesc(
+		prefix+"neighbor_ethernet_autodiscovery_routes",
+		"Per-neighbor count of EVPN Type-1 Ethernet auto-discovery routes",
+		neighborLabels, nil,
+	)
+	neighborInclusiveMulticastRoutes = prometheus.NewDesc(
+		prefix+"neighbor_inclusive_multicast_routes",
+		"Per-neighbor count of EVPN Type-3 inclusive-multicast routes",
+		neighborLabels, nil,
+	)
+	neighborEthernetSegmentRoutes = prometheus.NewDesc(
+		prefix+"neighbor_ethernet_segment_routes",
+		"Per-neighbor count of EVPN Type-4 Ethernet-segment routes",
+		neighborLabels, nil,
+	)
+}
+
+type evpnCollector struct{}
+
+// Name returns the name of the collector.
+func (*evpnCollector) Name() string { return "evpn" }
+
+// NewCollector creates a new collector.
+func NewCollector() collector.RPCCollector { return &evpnCollector{} }
+
+// Describe describes the metrics.
+func (*evpnCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- instanceInfo
+	ch <- instanceNeighborCount
+	ch <- instanceESICount
+	ch <- instanceLocalInterfaces
+	ch <- instanceLocalInterfacesUp
+	ch <- instanceIRBInterfaces
+	ch <- instanceIRBInterfacesUp
+	ch <- instanceProtectInterfaces
+	ch <- instanceBridgeDomains
+	ch <- instanceLocalMACs
+	ch <- instanceRemoteMACs
+	ch <- instanceLocalMACIPs
+	ch <- instanceRemoteMACIPs
+	ch <- instanceLocalDefaultGwMACs
+	ch <- instanceRemoteDefaultGwMACs
+	ch <- instanceDuplicateMACThreshold
+	ch <- instanceDuplicateMACWindow
+
+	ch <- neighborMACRoutes
+	ch <- neighborMACIPRoutes
+	ch <- neighborAutoDiscoveryRoutes
+	ch <- neighborInclusiveMulticastRoutes
+	ch <- neighborEthernetSegmentRoutes
+}
+
+// Collect collects metrics from Junos. The extensive modifier is required:
+// the basic 'show evpn instance' output is too thin (omits route-distinguisher,
+// encapsulation, the per-PE route breakdown, and the full
+// mac-database-status-table, and renames remaining scalars).
+func (c *evpnCollector) Collect(client collector.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var instances []evpnInstance
+	err := client.RunCommandAndParseWithParser("show evpn instance extensive", func(b []byte) error {
+		var perr error
+		instances, perr = parseInstances(b)
+		return perr
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, in := range instances {
+		il := append(labelValues, in.Name)
+
+		ch <- prometheus.MustNewConstMetric(
+			instanceInfo, prometheus.GaugeValue, 1,
+			append(il, in.RouteDistinguisher, strings.TrimSpace(in.EncapType), in.RouterID, in.SourceVTEPAddr)...,
+		)
+
+		ch <- prometheus.MustNewConstMetric(instanceNeighborCount, prometheus.GaugeValue, in.NumNeighbors, il...)
+		ch <- prometheus.MustNewConstMetric(instanceESICount, prometheus.GaugeValue, in.NumESI, il...)
+		ch <- prometheus.MustNewConstMetric(instanceLocalInterfaces, prometheus.GaugeValue, in.LocalInterfaces, il...)
+		ch <- prometheus.MustNewConstMetric(instanceLocalInterfacesUp, prometheus.GaugeValue, in.LocalInterfacesUp, il...)
+		ch <- prometheus.MustNewConstMetric(instanceIRBInterfaces, prometheus.GaugeValue, in.IRBInterfaces, il...)
+		ch <- prometheus.MustNewConstMetric(instanceIRBInterfacesUp, prometheus.GaugeValue, in.IRBInterfacesUp, il...)
+		ch <- prometheus.MustNewConstMetric(instanceProtectInterfaces, prometheus.GaugeValue, in.NumProtectInterfaces, il...)
+		ch <- prometheus.MustNewConstMetric(instanceBridgeDomains, prometheus.GaugeValue, in.NumBridgeDomains, il...)
+		ch <- prometheus.MustNewConstMetric(instanceDuplicateMACThreshold, prometheus.GaugeValue, in.DuplicateMACDetectionThreshold, il...)
+		ch <- prometheus.MustNewConstMetric(instanceDuplicateMACWindow, prometheus.GaugeValue, in.DuplicateMACDetectionWindow, il...)
+
+		if in.MACDatabase != nil {
+			db := in.MACDatabase
+			ch <- prometheus.MustNewConstMetric(instanceLocalMACs, prometheus.GaugeValue, db.LocalMACs, il...)
+			ch <- prometheus.MustNewConstMetric(instanceRemoteMACs, prometheus.GaugeValue, db.RemoteMACs, il...)
+			ch <- prometheus.MustNewConstMetric(instanceLocalMACIPs, prometheus.GaugeValue, db.LocalMACIPs, il...)
+			ch <- prometheus.MustNewConstMetric(instanceRemoteMACIPs, prometheus.GaugeValue, db.RemoteMACIPs, il...)
+			ch <- prometheus.MustNewConstMetric(instanceLocalDefaultGwMACs, prometheus.GaugeValue, db.LocalDefaultGatewayMACs, il...)
+			ch <- prometheus.MustNewConstMetric(instanceRemoteDefaultGwMACs, prometheus.GaugeValue, db.RemoteDefaultGatewayMACs, il...)
+		}
+
+		for _, n := range in.Neighbors {
+			r := n.Routes
+			if r.Address == "" {
+				continue
+			}
+			nl := append(append([]string{}, il...), r.Address)
+			ch <- prometheus.MustNewConstMetric(neighborMACRoutes, prometheus.GaugeValue, r.NumMACRoutes, nl...)
+			ch <- prometheus.MustNewConstMetric(neighborMACIPRoutes, prometheus.GaugeValue, r.NumMACIPRoutes, nl...)
+			ch <- prometheus.MustNewConstMetric(neighborAutoDiscoveryRoutes, prometheus.GaugeValue, r.NumAutoDiscoveryRoutes, nl...)
+			ch <- prometheus.MustNewConstMetric(neighborInclusiveMulticastRoutes, prometheus.GaugeValue, r.NumInclusiveMulticastRoutes, nl...)
+			ch <- prometheus.MustNewConstMetric(neighborEthernetSegmentRoutes, prometheus.GaugeValue, r.NumEthernetSegmentRoutes, nl...)
+		}
+	}
+
+	return nil
+}
+
+// parseInstances handles both single-RE and multi-RE response shapes.
+// Same dispatch pattern as the alarm and ufd collectors. When multiple REs
+// report instances they are merged; re-name is not exposed as a label today
+// (matches alarm/ufd precedent).
+func parseInstances(b []byte) ([]evpnInstance, error) {
+	if strings.Contains(string(b), "<multi-routing-engine-results") {
+		var m multiEngineResult
+		if err := xml.Unmarshal(b, &m); err != nil {
+			return nil, err
+		}
+		var out []evpnInstance
+		for _, re := range m.Engines.Items {
+			out = append(out, re.Instances...)
+		}
+		return out, nil
+	}
+
+	var s singleEngineResult
+	if err := xml.Unmarshal(b, &s); err != nil {
+		return nil, err
+	}
+	return s.Instances, nil
+}

--- a/pkg/features/evpn/collector.go
+++ b/pkg/features/evpn/collector.go
@@ -8,154 +8,145 @@ import (
 
 	"github.com/czerwonk/junos_exporter/pkg/collector"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 )
 
 const prefix = "junos_evpn_"
 
 var (
-	// Per-instance descriptors.
-	instanceInfo                   *prometheus.Desc
-	instanceNeighborCount          *prometheus.Desc
-	instanceESICount               *prometheus.Desc
-	instanceLocalInterfaces        *prometheus.Desc
-	instanceLocalInterfacesUp      *prometheus.Desc
-	instanceIRBInterfaces          *prometheus.Desc
-	instanceIRBInterfacesUp        *prometheus.Desc
-	instanceProtectInterfaces      *prometheus.Desc
-	instanceBridgeDomains          *prometheus.Desc
-	instanceLocalMACs              *prometheus.Desc
-	instanceRemoteMACs             *prometheus.Desc
-	instanceLocalMACIPs            *prometheus.Desc
-	instanceRemoteMACIPs           *prometheus.Desc
-	instanceLocalDefaultGwMACs     *prometheus.Desc
-	instanceRemoteDefaultGwMACs    *prometheus.Desc
-	instanceDuplicateMACThreshold  *prometheus.Desc
-	instanceDuplicateMACWindow     *prometheus.Desc
+	// ============== Per-instance descriptors (from show evpn instance) ==============
+	instanceInfo                  *prometheus.Desc
+	instanceNeighborCount         *prometheus.Desc
+	instanceESICount              *prometheus.Desc
+	instanceLocalInterfaces       *prometheus.Desc
+	instanceLocalInterfacesUp     *prometheus.Desc
+	instanceIRBInterfaces         *prometheus.Desc
+	instanceIRBInterfacesUp       *prometheus.Desc
+	instanceProtectInterfaces     *prometheus.Desc
+	instanceBridgeDomains         *prometheus.Desc
+	instanceLocalMACs             *prometheus.Desc
+	instanceRemoteMACs            *prometheus.Desc
+	instanceLocalMACIPs           *prometheus.Desc
+	instanceRemoteMACIPs          *prometheus.Desc
+	instanceLocalDefaultGwMACs    *prometheus.Desc
+	instanceRemoteDefaultGwMACs   *prometheus.Desc
+	instanceDuplicateMACThreshold *prometheus.Desc
+	instanceDuplicateMACWindow    *prometheus.Desc
 
-	// Per-neighbor descriptors.
-	neighborMACRoutes               *prometheus.Desc
-	neighborMACIPRoutes             *prometheus.Desc
-	neighborAutoDiscoveryRoutes     *prometheus.Desc
+	// ============== Per-neighbor descriptors (from show evpn instance) ==============
+	neighborMACRoutes                *prometheus.Desc
+	neighborMACIPRoutes              *prometheus.Desc
+	neighborAutoDiscoveryRoutes      *prometheus.Desc
 	neighborInclusiveMulticastRoutes *prometheus.Desc
-	neighborEthernetSegmentRoutes   *prometheus.Desc
+	neighborEthernetSegmentRoutes    *prometheus.Desc
+
+	// ============== Detail descriptors (from show evpn instance) ==============
+	interfaceStatus              *prometheus.Desc
+	irbStatus                    *prometheus.Desc
+	bridgeDomainInterfaceCount   *prometheus.Desc
+	bridgeDomainInterfaceUpCount *prometheus.Desc
+	esiResolved                  *prometheus.Desc
+	esiRemotePECount             *prometheus.Desc
+
+	// ============== Duplicate-MAC descriptors (from show evpn database state duplicate) ==============
+	duplicateMACTotal *prometheus.Desc
+	duplicateMACCount *prometheus.Desc
+
+	// ============== L3 context descriptors (from show evpn l3-context) ==============
+	l3ContextVNI   *prometheus.Desc
+	l3ContextCount *prometheus.Desc
 )
 
 func init() {
-	instanceLabels := []string{"target", "instance"}
+	il := []string{"target", "instance"}
 	infoLabels := []string{"target", "instance", "rd", "encap", "router_id", "source_vtep"}
 	neighborLabels := []string{"target", "instance", "neighbor"}
+	interfaceLabels := []string{"target", "instance", "interface", "esi", "mode", "etree_role"}
+	irbLabels := []string{"target", "instance", "irb_interface", "vni_id", "l3_context"}
+	bdLabels := []string{"target", "instance", "vlan_id", "domain_id", "irb_interface", "mode", "mac_sync"}
+	esiLabels := []string{"target", "instance", "esi", "status", "local_interface", "designated_forwarder", "backup_forwarder", "df_algorithm"}
+	esiCountLabels := []string{"target", "instance", "esi"}
+	l3CtxLabels := []string{"target", "context", "type", "advertisement_mode", "router_mac", "encapsulation"}
+	stateLabels := []string{"target"}
 
-	instanceInfo = prometheus.NewDesc(
-		prefix+"instance_info",
+	instanceInfo = prometheus.NewDesc(prefix+"instance_info",
 		"Per-EVI metadata (always 1). Labels carry route-distinguisher, encapsulation, router-id and source VTEP address.",
-		infoLabels, nil,
-	)
-	instanceNeighborCount = prometheus.NewDesc(
-		prefix+"instance_neighbor_count",
-		"Number of EVPN neighbors (PEs) for this instance",
-		instanceLabels, nil,
-	)
-	instanceESICount = prometheus.NewDesc(
-		prefix+"instance_esi_count",
-		"Number of Ethernet Segment Identifiers known by this instance",
-		instanceLabels, nil,
-	)
-	instanceLocalInterfaces = prometheus.NewDesc(
-		prefix+"instance_local_interfaces",
-		"Number of local interfaces in this EVPN instance",
-		instanceLabels, nil,
-	)
-	instanceLocalInterfacesUp = prometheus.NewDesc(
-		prefix+"instance_local_interfaces_up",
-		"Number of local interfaces currently up in this EVPN instance",
-		instanceLabels, nil,
-	)
-	instanceIRBInterfaces = prometheus.NewDesc(
-		prefix+"instance_irb_interfaces",
-		"Number of IRB interfaces in this EVPN instance",
-		instanceLabels, nil,
-	)
-	instanceIRBInterfacesUp = prometheus.NewDesc(
-		prefix+"instance_irb_interfaces_up",
-		"Number of IRB interfaces currently up in this EVPN instance",
-		instanceLabels, nil,
-	)
-	instanceProtectInterfaces = prometheus.NewDesc(
-		prefix+"instance_protect_interfaces",
-		"Number of protect (backup) interfaces in this EVPN instance",
-		instanceLabels, nil,
-	)
-	instanceBridgeDomains = prometheus.NewDesc(
-		prefix+"instance_bridge_domains",
-		"Number of bridge domains in this EVPN instance",
-		instanceLabels, nil,
-	)
-	instanceLocalMACs = prometheus.NewDesc(
-		prefix+"instance_local_mac_count",
-		"Number of MACs learned locally in this EVPN instance",
-		instanceLabels, nil,
-	)
-	instanceRemoteMACs = prometheus.NewDesc(
-		prefix+"instance_remote_mac_count",
-		"Number of MACs learned from remote PEs in this EVPN instance",
-		instanceLabels, nil,
-	)
-	instanceLocalMACIPs = prometheus.NewDesc(
-		prefix+"instance_local_mac_ip_count",
-		"Number of local MAC+IP bindings in this EVPN instance",
-		instanceLabels, nil,
-	)
-	instanceRemoteMACIPs = prometheus.NewDesc(
-		prefix+"instance_remote_mac_ip_count",
-		"Number of remote MAC+IP bindings in this EVPN instance",
-		instanceLabels, nil,
-	)
-	instanceLocalDefaultGwMACs = prometheus.NewDesc(
-		prefix+"instance_local_default_gateway_mac_count",
-		"Number of local default-gateway MACs in this EVPN instance",
-		instanceLabels, nil,
-	)
-	instanceRemoteDefaultGwMACs = prometheus.NewDesc(
-		prefix+"instance_remote_default_gateway_mac_count",
-		"Number of remote default-gateway MACs in this EVPN instance",
-		instanceLabels, nil,
-	)
-	instanceDuplicateMACThreshold = prometheus.NewDesc(
-		prefix+"instance_duplicate_mac_threshold",
-		"Configured duplicate-MAC detection threshold for this EVPN instance",
-		instanceLabels, nil,
-	)
-	instanceDuplicateMACWindow = prometheus.NewDesc(
-		prefix+"instance_duplicate_mac_window_seconds",
-		"Configured duplicate-MAC detection window in seconds for this EVPN instance",
-		instanceLabels, nil,
-	)
+		infoLabels, nil)
+	instanceNeighborCount = prometheus.NewDesc(prefix+"instance_neighbor_count",
+		"Number of EVPN neighbors (PEs) for this instance", il, nil)
+	instanceESICount = prometheus.NewDesc(prefix+"instance_esi_count",
+		"Number of Ethernet Segment Identifiers known by this instance", il, nil)
+	instanceLocalInterfaces = prometheus.NewDesc(prefix+"instance_local_interfaces",
+		"Number of local interfaces in this EVPN instance", il, nil)
+	instanceLocalInterfacesUp = prometheus.NewDesc(prefix+"instance_local_interfaces_up",
+		"Number of local interfaces currently up in this EVPN instance", il, nil)
+	instanceIRBInterfaces = prometheus.NewDesc(prefix+"instance_irb_interfaces",
+		"Number of IRB interfaces in this EVPN instance", il, nil)
+	instanceIRBInterfacesUp = prometheus.NewDesc(prefix+"instance_irb_interfaces_up",
+		"Number of IRB interfaces currently up in this EVPN instance", il, nil)
+	instanceProtectInterfaces = prometheus.NewDesc(prefix+"instance_protect_interfaces",
+		"Number of protect (backup) interfaces in this EVPN instance", il, nil)
+	instanceBridgeDomains = prometheus.NewDesc(prefix+"instance_bridge_domains",
+		"Number of bridge domains in this EVPN instance", il, nil)
+	instanceLocalMACs = prometheus.NewDesc(prefix+"instance_local_mac_count",
+		"Number of MACs learned locally in this EVPN instance", il, nil)
+	instanceRemoteMACs = prometheus.NewDesc(prefix+"instance_remote_mac_count",
+		"Number of MACs learned from remote PEs in this EVPN instance", il, nil)
+	instanceLocalMACIPs = prometheus.NewDesc(prefix+"instance_local_mac_ip_count",
+		"Number of local MAC+IP bindings in this EVPN instance", il, nil)
+	instanceRemoteMACIPs = prometheus.NewDesc(prefix+"instance_remote_mac_ip_count",
+		"Number of remote MAC+IP bindings in this EVPN instance", il, nil)
+	instanceLocalDefaultGwMACs = prometheus.NewDesc(prefix+"instance_local_default_gateway_mac_count",
+		"Number of local default-gateway MACs in this EVPN instance", il, nil)
+	instanceRemoteDefaultGwMACs = prometheus.NewDesc(prefix+"instance_remote_default_gateway_mac_count",
+		"Number of remote default-gateway MACs in this EVPN instance", il, nil)
+	instanceDuplicateMACThreshold = prometheus.NewDesc(prefix+"instance_duplicate_mac_threshold",
+		"Configured duplicate-MAC detection threshold for this EVPN instance", il, nil)
+	instanceDuplicateMACWindow = prometheus.NewDesc(prefix+"instance_duplicate_mac_window_seconds",
+		"Configured duplicate-MAC detection window in seconds for this EVPN instance", il, nil)
 
-	neighborMACRoutes = prometheus.NewDesc(
-		prefix+"neighbor_mac_routes",
-		"Per-neighbor count of EVPN Type-2 MAC routes (without IP)",
-		neighborLabels, nil,
-	)
-	neighborMACIPRoutes = prometheus.NewDesc(
-		prefix+"neighbor_mac_ip_routes",
-		"Per-neighbor count of EVPN Type-2 MAC+IP routes",
-		neighborLabels, nil,
-	)
-	neighborAutoDiscoveryRoutes = prometheus.NewDesc(
-		prefix+"neighbor_ethernet_autodiscovery_routes",
-		"Per-neighbor count of EVPN Type-1 Ethernet auto-discovery routes",
-		neighborLabels, nil,
-	)
-	neighborInclusiveMulticastRoutes = prometheus.NewDesc(
-		prefix+"neighbor_inclusive_multicast_routes",
-		"Per-neighbor count of EVPN Type-3 inclusive-multicast routes",
-		neighborLabels, nil,
-	)
-	neighborEthernetSegmentRoutes = prometheus.NewDesc(
-		prefix+"neighbor_ethernet_segment_routes",
-		"Per-neighbor count of EVPN Type-4 Ethernet-segment routes",
-		neighborLabels, nil,
-	)
+	neighborMACRoutes = prometheus.NewDesc(prefix+"neighbor_mac_routes",
+		"Per-neighbor count of EVPN Type-2 MAC routes (without IP)", neighborLabels, nil)
+	neighborMACIPRoutes = prometheus.NewDesc(prefix+"neighbor_mac_ip_routes",
+		"Per-neighbor count of EVPN Type-2 MAC+IP routes", neighborLabels, nil)
+	neighborAutoDiscoveryRoutes = prometheus.NewDesc(prefix+"neighbor_ethernet_autodiscovery_routes",
+		"Per-neighbor count of EVPN Type-1 Ethernet auto-discovery routes", neighborLabels, nil)
+	neighborInclusiveMulticastRoutes = prometheus.NewDesc(prefix+"neighbor_inclusive_multicast_routes",
+		"Per-neighbor count of EVPN Type-3 inclusive-multicast routes", neighborLabels, nil)
+	neighborEthernetSegmentRoutes = prometheus.NewDesc(prefix+"neighbor_ethernet_segment_routes",
+		"Per-neighbor count of EVPN Type-4 Ethernet-segment routes", neighborLabels, nil)
+
+	// Detail (Phase A): per-interface, per-IRB, per-bridge-domain, per-ESI.
+	interfaceStatus = prometheus.NewDesc(prefix+"interface_status",
+		"EVPN interface status (0: down, 1: up). Labels carry the ESI, mode (single-homed / all-active / active-standby) and E-tree role.",
+		interfaceLabels, nil)
+	irbStatus = prometheus.NewDesc(prefix+"irb_status",
+		"IRB interface status within an EVPN instance (0: down, 1: up). Labels carry the IRB VNI and L3 context.",
+		irbLabels, nil)
+	bridgeDomainInterfaceCount = prometheus.NewDesc(prefix+"bridge_domain_interface_count",
+		"Total interfaces in this bridge-domain", bdLabels, nil)
+	bridgeDomainInterfaceUpCount = prometheus.NewDesc(prefix+"bridge_domain_interface_up_count",
+		"Interfaces currently up in this bridge-domain", bdLabels, nil)
+	esiResolved = prometheus.NewDesc(prefix+"esi_resolved",
+		"EVPN ESI resolution state (0: unresolved, 1: resolved). Labels carry the local-interface bind, DF election state, backup forwarder, and DF election algorithm.",
+		esiLabels, nil)
+	esiRemotePECount = prometheus.NewDesc(prefix+"esi_remote_pe_count",
+		"Number of remote PEs known for this Ethernet Segment", esiCountLabels, nil)
+
+	// Duplicate-MAC: target-level total always emitted, per-instance only when > 0.
+	duplicateMACTotal = prometheus.NewDesc(prefix+"duplicate_mac_total",
+		"Total MAC entries currently suppressed by duplicate-MAC detection across all EVIs on this device. Non-zero indicates a forwarding loop or split-brain.",
+		stateLabels, nil)
+	duplicateMACCount = prometheus.NewDesc(prefix+"duplicate_mac_count",
+		"MAC entries currently suppressed by duplicate-MAC detection in a specific EVPN instance. Emitted only when count > 0.",
+		il, nil)
+
+	// L3 context.
+	l3ContextVNI = prometheus.NewDesc(prefix+"l3_context_vni",
+		"EVPN L3 context (VRF) VNI. Labels carry context type, advertisement mode, router MAC and encapsulation.",
+		l3CtxLabels, nil)
+	l3ContextCount = prometheus.NewDesc(prefix+"l3_context_count",
+		"Number of EVPN L3 contexts configured on this device", []string{"target"}, nil)
 }
 
 type evpnCollector struct{}
@@ -168,96 +159,209 @@ func NewCollector() collector.RPCCollector { return &evpnCollector{} }
 
 // Describe describes the metrics.
 func (*evpnCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- instanceInfo
-	ch <- instanceNeighborCount
-	ch <- instanceESICount
-	ch <- instanceLocalInterfaces
-	ch <- instanceLocalInterfacesUp
-	ch <- instanceIRBInterfaces
-	ch <- instanceIRBInterfacesUp
-	ch <- instanceProtectInterfaces
-	ch <- instanceBridgeDomains
-	ch <- instanceLocalMACs
-	ch <- instanceRemoteMACs
-	ch <- instanceLocalMACIPs
-	ch <- instanceRemoteMACIPs
-	ch <- instanceLocalDefaultGwMACs
-	ch <- instanceRemoteDefaultGwMACs
-	ch <- instanceDuplicateMACThreshold
-	ch <- instanceDuplicateMACWindow
-
-	ch <- neighborMACRoutes
-	ch <- neighborMACIPRoutes
-	ch <- neighborAutoDiscoveryRoutes
-	ch <- neighborInclusiveMulticastRoutes
-	ch <- neighborEthernetSegmentRoutes
+	for _, d := range []*prometheus.Desc{
+		instanceInfo,
+		instanceNeighborCount, instanceESICount,
+		instanceLocalInterfaces, instanceLocalInterfacesUp,
+		instanceIRBInterfaces, instanceIRBInterfacesUp,
+		instanceProtectInterfaces, instanceBridgeDomains,
+		instanceLocalMACs, instanceRemoteMACs,
+		instanceLocalMACIPs, instanceRemoteMACIPs,
+		instanceLocalDefaultGwMACs, instanceRemoteDefaultGwMACs,
+		instanceDuplicateMACThreshold, instanceDuplicateMACWindow,
+		neighborMACRoutes, neighborMACIPRoutes,
+		neighborAutoDiscoveryRoutes, neighborInclusiveMulticastRoutes,
+		neighborEthernetSegmentRoutes,
+		interfaceStatus, irbStatus,
+		bridgeDomainInterfaceCount, bridgeDomainInterfaceUpCount,
+		esiResolved, esiRemotePECount,
+		duplicateMACTotal, duplicateMACCount,
+		l3ContextVNI, l3ContextCount,
+	} {
+		ch <- d
+	}
 }
 
-// Collect collects metrics from Junos. The extensive modifier is required:
-// the basic 'show evpn instance' output is too thin (omits route-distinguisher,
-// encapsulation, the per-PE route breakdown, and the full
-// mac-database-status-table, and renames remaining scalars).
+// Collect issues three RPCs:
+//
+//  1. show evpn instance extensive — REQUIRED. Provides per-EVI state,
+//     per-neighbor route counts, and (via the detail tables) per-interface,
+//     per-IRB, per-bridge-domain, and per-ESI status. A failure here aborts
+//     the scrape because the rest of the collector depends on knowing which
+//     EVIs exist.
+//
+//  2. show evpn database state duplicate — BEST EFFORT. Returns MAC entries
+//     suppressed by duplicate-MAC detection (the only true EVPN error
+//     signal). A failure here logs a warning and leaves the metrics absent.
+//
+//  3. show evpn l3-context — BEST EFFORT. Returns L3 (IRB) context info.
+//     Empty when EVPN-IRB is not configured.
 func (c *evpnCollector) Collect(client collector.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	// --- RPC 1: instance (required) ---
 	var instances []evpnInstance
-	err := client.RunCommandAndParseWithParser("show evpn instance extensive", func(b []byte) error {
+	if err := client.RunCommandAndParseWithParser("show evpn instance extensive", func(b []byte) error {
 		var perr error
 		instances, perr = parseInstances(b)
 		return perr
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 
 	for _, in := range instances {
-		il := append(labelValues, in.Name)
+		c.emitInstance(ch, labelValues, in)
+	}
 
-		ch <- prometheus.MustNewConstMetric(
-			instanceInfo, prometheus.GaugeValue, 1,
-			append(il, in.RouteDistinguisher, strings.TrimSpace(in.EncapType), in.RouterID, in.SourceVTEPAddr)...,
-		)
+	// --- RPC 2: duplicate-MAC (best effort) ---
+	var dupInstances []duplicateInstance
+	if err := client.RunCommandAndParseWithParser("show evpn database state duplicate", func(b []byte) error {
+		var perr error
+		dupInstances, perr = parseDuplicateMACs(b)
+		return perr
+	}); err != nil {
+		log.Warnf("evpn: 'show evpn database state duplicate' failed: %v", err)
+	} else {
+		c.emitDuplicateMACs(ch, labelValues, dupInstances)
+	}
 
-		ch <- prometheus.MustNewConstMetric(instanceNeighborCount, prometheus.GaugeValue, in.NumNeighbors, il...)
-		ch <- prometheus.MustNewConstMetric(instanceESICount, prometheus.GaugeValue, in.NumESI, il...)
-		ch <- prometheus.MustNewConstMetric(instanceLocalInterfaces, prometheus.GaugeValue, in.LocalInterfaces, il...)
-		ch <- prometheus.MustNewConstMetric(instanceLocalInterfacesUp, prometheus.GaugeValue, in.LocalInterfacesUp, il...)
-		ch <- prometheus.MustNewConstMetric(instanceIRBInterfaces, prometheus.GaugeValue, in.IRBInterfaces, il...)
-		ch <- prometheus.MustNewConstMetric(instanceIRBInterfacesUp, prometheus.GaugeValue, in.IRBInterfacesUp, il...)
-		ch <- prometheus.MustNewConstMetric(instanceProtectInterfaces, prometheus.GaugeValue, in.NumProtectInterfaces, il...)
-		ch <- prometheus.MustNewConstMetric(instanceBridgeDomains, prometheus.GaugeValue, in.NumBridgeDomains, il...)
-		ch <- prometheus.MustNewConstMetric(instanceDuplicateMACThreshold, prometheus.GaugeValue, in.DuplicateMACDetectionThreshold, il...)
-		ch <- prometheus.MustNewConstMetric(instanceDuplicateMACWindow, prometheus.GaugeValue, in.DuplicateMACDetectionWindow, il...)
-
-		if in.MACDatabase != nil {
-			db := in.MACDatabase
-			ch <- prometheus.MustNewConstMetric(instanceLocalMACs, prometheus.GaugeValue, db.LocalMACs, il...)
-			ch <- prometheus.MustNewConstMetric(instanceRemoteMACs, prometheus.GaugeValue, db.RemoteMACs, il...)
-			ch <- prometheus.MustNewConstMetric(instanceLocalMACIPs, prometheus.GaugeValue, db.LocalMACIPs, il...)
-			ch <- prometheus.MustNewConstMetric(instanceRemoteMACIPs, prometheus.GaugeValue, db.RemoteMACIPs, il...)
-			ch <- prometheus.MustNewConstMetric(instanceLocalDefaultGwMACs, prometheus.GaugeValue, db.LocalDefaultGatewayMACs, il...)
-			ch <- prometheus.MustNewConstMetric(instanceRemoteDefaultGwMACs, prometheus.GaugeValue, db.RemoteDefaultGatewayMACs, il...)
-		}
-
-		for _, n := range in.Neighbors {
-			r := n.Routes
-			if r.Address == "" {
-				continue
-			}
-			nl := append(append([]string{}, il...), r.Address)
-			ch <- prometheus.MustNewConstMetric(neighborMACRoutes, prometheus.GaugeValue, r.NumMACRoutes, nl...)
-			ch <- prometheus.MustNewConstMetric(neighborMACIPRoutes, prometheus.GaugeValue, r.NumMACIPRoutes, nl...)
-			ch <- prometheus.MustNewConstMetric(neighborAutoDiscoveryRoutes, prometheus.GaugeValue, r.NumAutoDiscoveryRoutes, nl...)
-			ch <- prometheus.MustNewConstMetric(neighborInclusiveMulticastRoutes, prometheus.GaugeValue, r.NumInclusiveMulticastRoutes, nl...)
-			ch <- prometheus.MustNewConstMetric(neighborEthernetSegmentRoutes, prometheus.GaugeValue, r.NumEthernetSegmentRoutes, nl...)
-		}
+	// --- RPC 3: l3-context (best effort) ---
+	var contexts []l3Context
+	if err := client.RunCommandAndParseWithParser("show evpn l3-context", func(b []byte) error {
+		var perr error
+		contexts, perr = parseL3Contexts(b)
+		return perr
+	}); err != nil {
+		log.Warnf("evpn: 'show evpn l3-context' failed: %v", err)
+	} else {
+		c.emitL3Contexts(ch, labelValues, contexts)
 	}
 
 	return nil
 }
 
-// parseInstances handles both single-RE and multi-RE response shapes.
-// Same dispatch pattern as the alarm and ufd collectors. When multiple REs
-// report instances they are merged; re-name is not exposed as a label today
-// (matches alarm/ufd precedent).
+// emitInstance emits all per-EVI and per-neighbor metrics derived from one
+// <evpn-instance> entry, plus the detail tables (interfaces, IRBs,
+// bridge-domains, ESIs) when present.
+func (c *evpnCollector) emitInstance(ch chan<- prometheus.Metric, labelValues []string, in evpnInstance) {
+	base := append(labelValues, in.Name)
+
+	ch <- prometheus.MustNewConstMetric(
+		instanceInfo, prometheus.GaugeValue, 1,
+		append(append([]string{}, base...), in.RouteDistinguisher, strings.TrimSpace(in.EncapType), in.RouterID, in.SourceVTEPAddr)...,
+	)
+
+	ch <- prometheus.MustNewConstMetric(instanceNeighborCount, prometheus.GaugeValue, in.NumNeighbors, base...)
+	ch <- prometheus.MustNewConstMetric(instanceESICount, prometheus.GaugeValue, in.NumESI, base...)
+	ch <- prometheus.MustNewConstMetric(instanceLocalInterfaces, prometheus.GaugeValue, in.LocalInterfaces, base...)
+	ch <- prometheus.MustNewConstMetric(instanceLocalInterfacesUp, prometheus.GaugeValue, in.LocalInterfacesUp, base...)
+	ch <- prometheus.MustNewConstMetric(instanceIRBInterfaces, prometheus.GaugeValue, in.IRBInterfaces, base...)
+	ch <- prometheus.MustNewConstMetric(instanceIRBInterfacesUp, prometheus.GaugeValue, in.IRBInterfacesUp, base...)
+	ch <- prometheus.MustNewConstMetric(instanceProtectInterfaces, prometheus.GaugeValue, in.NumProtectInterfaces, base...)
+	ch <- prometheus.MustNewConstMetric(instanceBridgeDomains, prometheus.GaugeValue, in.NumBridgeDomains, base...)
+	ch <- prometheus.MustNewConstMetric(instanceDuplicateMACThreshold, prometheus.GaugeValue, in.DuplicateMACDetectionThreshold, base...)
+	ch <- prometheus.MustNewConstMetric(instanceDuplicateMACWindow, prometheus.GaugeValue, in.DuplicateMACDetectionWindow, base...)
+
+	if in.MACDatabase != nil {
+		db := in.MACDatabase
+		ch <- prometheus.MustNewConstMetric(instanceLocalMACs, prometheus.GaugeValue, db.LocalMACs, base...)
+		ch <- prometheus.MustNewConstMetric(instanceRemoteMACs, prometheus.GaugeValue, db.RemoteMACs, base...)
+		ch <- prometheus.MustNewConstMetric(instanceLocalMACIPs, prometheus.GaugeValue, db.LocalMACIPs, base...)
+		ch <- prometheus.MustNewConstMetric(instanceRemoteMACIPs, prometheus.GaugeValue, db.RemoteMACIPs, base...)
+		ch <- prometheus.MustNewConstMetric(instanceLocalDefaultGwMACs, prometheus.GaugeValue, db.LocalDefaultGatewayMACs, base...)
+		ch <- prometheus.MustNewConstMetric(instanceRemoteDefaultGwMACs, prometheus.GaugeValue, db.RemoteDefaultGatewayMACs, base...)
+	}
+
+	for _, n := range in.Neighbors {
+		r := n.Routes
+		if r.Address == "" {
+			continue
+		}
+		nl := append(append([]string{}, base...), r.Address)
+		ch <- prometheus.MustNewConstMetric(neighborMACRoutes, prometheus.GaugeValue, r.NumMACRoutes, nl...)
+		ch <- prometheus.MustNewConstMetric(neighborMACIPRoutes, prometheus.GaugeValue, r.NumMACIPRoutes, nl...)
+		ch <- prometheus.MustNewConstMetric(neighborAutoDiscoveryRoutes, prometheus.GaugeValue, r.NumAutoDiscoveryRoutes, nl...)
+		ch <- prometheus.MustNewConstMetric(neighborInclusiveMulticastRoutes, prometheus.GaugeValue, r.NumInclusiveMulticastRoutes, nl...)
+		ch <- prometheus.MustNewConstMetric(neighborEthernetSegmentRoutes, prometheus.GaugeValue, r.NumEthernetSegmentRoutes, nl...)
+	}
+
+	// --- detail tables ---
+	for _, ifce := range in.Interfaces {
+		l := append(append([]string{}, base...), ifce.Name, ifce.ESI, ifce.Mode, ifce.EtreeRole)
+		ch <- prometheus.MustNewConstMetric(interfaceStatus, prometheus.GaugeValue, upDown(ifce.Status), l...)
+	}
+	for _, irb := range in.IRBInterfaceTbl {
+		l := append(append([]string{}, base...), irb.Name, irb.VNI, irb.L3Context)
+		ch <- prometheus.MustNewConstMetric(irbStatus, prometheus.GaugeValue, upDown(irb.Status), l...)
+	}
+	for _, bd := range in.BridgeDomains {
+		l := append(append([]string{}, base...), bd.VLANID, bd.DomainID, bd.IRBInterface, bd.Mode, bd.MACSyncStatus)
+		ch <- prometheus.MustNewConstMetric(bridgeDomainInterfaceCount, prometheus.GaugeValue, bd.Interfaces, l...)
+		ch <- prometheus.MustNewConstMetric(bridgeDomainInterfaceUpCount, prometheus.GaugeValue, bd.InterfacesUp, l...)
+	}
+	for _, esi := range in.ESIs {
+		// ESI is "resolved" if the status text contains "Resolved" (the
+		// other observed value is an empty string for unconfigured remote
+		// segments).
+		resolved := 0.0
+		if strings.Contains(strings.ToLower(esi.Status), "resolved") {
+			resolved = 1.0
+		}
+		localIfName, dfAddr, backupAddr, dfAlgo := "", "", "", ""
+		if esi.LocalIntf != nil {
+			localIfName = esi.LocalIntf.Name
+		}
+		if esi.DFInfo != nil {
+			dfAddr = esi.DFInfo.DesignatedForwarder
+			backupAddr = esi.DFInfo.BackupForwarder
+			dfAlgo = esi.DFInfo.Algorithm
+		}
+		statusLabel := strings.TrimSpace(esi.Status)
+
+		l := append(append([]string{}, base...), esi.Value, statusLabel, localIfName, dfAddr, backupAddr, dfAlgo)
+		ch <- prometheus.MustNewConstMetric(esiResolved, prometheus.GaugeValue, resolved, l...)
+
+		if esi.RemotePEInfo != nil {
+			cl := append(append([]string{}, base...), esi.Value)
+			ch <- prometheus.MustNewConstMetric(esiRemotePECount, prometheus.GaugeValue, esi.RemotePEInfo.Count, cl...)
+		}
+	}
+}
+
+// emitDuplicateMACs emits the target-level total (always) and per-instance
+// breakdown (only when count > 0).
+func (c *evpnCollector) emitDuplicateMACs(ch chan<- prometheus.Metric, labelValues []string, dupInstances []duplicateInstance) {
+	total := 0
+	for _, in := range dupInstances {
+		n := len(in.Entries)
+		if n == 0 {
+			continue
+		}
+		total += n
+		il := append(append([]string{}, labelValues...), in.Name)
+		ch <- prometheus.MustNewConstMetric(duplicateMACCount, prometheus.GaugeValue, float64(n), il...)
+	}
+	ch <- prometheus.MustNewConstMetric(duplicateMACTotal, prometheus.GaugeValue, float64(total), labelValues...)
+}
+
+// emitL3Contexts emits one _vni series per context plus a target-level _count.
+func (c *evpnCollector) emitL3Contexts(ch chan<- prometheus.Metric, labelValues []string, contexts []l3Context) {
+	for _, ctx := range contexts {
+		l := append(append([]string{}, labelValues...), ctx.Name, ctx.Type, ctx.AdvertisementMode, ctx.RouterMAC, ctx.Encapsulation)
+		ch <- prometheus.MustNewConstMetric(l3ContextVNI, prometheus.GaugeValue, ctx.VNI, l...)
+	}
+	ch <- prometheus.MustNewConstMetric(l3ContextCount, prometheus.GaugeValue, float64(len(contexts)), labelValues...)
+}
+
+// upDown converts "Up" / "Down" to 1.0 / 0.0 (case-insensitive).
+func upDown(s string) float64 {
+	if strings.EqualFold(strings.TrimSpace(s), "Up") {
+		return 1.0
+	}
+	return 0.0
+}
+
+// parseInstances handles single-RE and multi-RE response shapes for the
+// 'show evpn instance' RPC. Merging the per-RE slices; re-name is not
+// exposed as a label (matches alarm/ufd precedent).
 func parseInstances(b []byte) ([]evpnInstance, error) {
 	if strings.Contains(string(b), "<multi-routing-engine-results") {
 		var m multiEngineResult
@@ -270,10 +374,50 @@ func parseInstances(b []byte) ([]evpnInstance, error) {
 		}
 		return out, nil
 	}
-
 	var s singleEngineResult
 	if err := xml.Unmarshal(b, &s); err != nil {
 		return nil, err
 	}
 	return s.Instances, nil
+}
+
+// parseDuplicateMACs handles both response shapes for
+// 'show evpn database state duplicate'.
+func parseDuplicateMACs(b []byte) ([]duplicateInstance, error) {
+	if strings.Contains(string(b), "<multi-routing-engine-results") {
+		var m duplicateMultiResult
+		if err := xml.Unmarshal(b, &m); err != nil {
+			return nil, err
+		}
+		var out []duplicateInstance
+		for _, re := range m.Engines.Items {
+			out = append(out, re.Instances...)
+		}
+		return out, nil
+	}
+	var s duplicateSingleResult
+	if err := xml.Unmarshal(b, &s); err != nil {
+		return nil, err
+	}
+	return s.Instances, nil
+}
+
+// parseL3Contexts handles both response shapes for 'show evpn l3-context'.
+func parseL3Contexts(b []byte) ([]l3Context, error) {
+	if strings.Contains(string(b), "<multi-routing-engine-results") {
+		var m l3ContextMultiResult
+		if err := xml.Unmarshal(b, &m); err != nil {
+			return nil, err
+		}
+		var out []l3Context
+		for _, re := range m.Engines.Items {
+			out = append(out, re.Contexts...)
+		}
+		return out, nil
+	}
+	var s l3ContextSingleResult
+	if err := xml.Unmarshal(b, &s); err != nil {
+		return nil, err
+	}
+	return s.Contexts, nil
 }

--- a/pkg/features/evpn/rpc.go
+++ b/pkg/features/evpn/rpc.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+
+package evpn
+
+import "encoding/xml"
+
+// Junos emits the EVPN instance response in two shapes. On a single-RE
+// non-VC device:
+//
+//   <rpc-reply>
+//     <evpn-instance-information>
+//       <evpn-instance>...</evpn-instance>
+//       <evpn-instance>...</evpn-instance>
+//     </evpn-instance-information>
+//   </rpc-reply>
+//
+// On a multi-RE chassis or Virtual Chassis the body is wrapped:
+//
+//   <rpc-reply>
+//     <multi-routing-engine-results>
+//       <multi-routing-engine-item>
+//         <re-name>fpc0</re-name>
+//         <evpn-instance-information>...</evpn-instance-information>
+//       </multi-routing-engine-item>
+//       ...
+//     </multi-routing-engine-results>
+//   </rpc-reply>
+//
+// Both shapes must be handled. Same dispatch pattern as the alarm and
+// ufd collectors.
+
+type singleEngineResult struct {
+	XMLName   xml.Name       `xml:"rpc-reply"`
+	Instances []evpnInstance `xml:"evpn-instance-information>evpn-instance"`
+}
+
+type multiEngineResult struct {
+	XMLName xml.Name `xml:"rpc-reply"`
+	Engines struct {
+		Items []routingEngine `xml:"multi-routing-engine-item"`
+	} `xml:"multi-routing-engine-results"`
+}
+
+type routingEngine struct {
+	Name      string         `xml:"re-name"`
+	Instances []evpnInstance `xml:"evpn-instance-information>evpn-instance"`
+}
+
+// evpnInstance models one <evpn-instance> entry. Fields are mostly
+// optional - the default-evpn instance omits encapsulation, the
+// mac-database-status-table, and the per-interface tables.
+type evpnInstance struct {
+	Name                            string         `xml:"evpn-instance-name"`
+	RouteDistinguisher              string         `xml:"route-distinguisher"`
+	EncapType                       string         `xml:"evpn-encap-type"`
+	ControlWord                     string         `xml:"evpn-instance-control-word"`
+	DuplicateMACDetectionThreshold  float64        `xml:"duplicate-mac-detection-threshold"`
+	DuplicateMACDetectionWindow     float64        `xml:"duplicate-mac-detection-window"`
+	MACDatabase                     *macDatabase   `xml:"mac-database-status-table"`
+	LocalInterfaces                 float64        `xml:"local-interfaces"`
+	LocalInterfacesUp               float64        `xml:"local-interfaces-up"`
+	IRBInterfaces                   float64        `xml:"irb-interfaces"`
+	IRBInterfacesUp                 float64        `xml:"irb-interfaces-up"`
+	NumProtectInterfaces            float64        `xml:"num-protect-interfaces"`
+	NumBridgeDomains                float64        `xml:"num-bridge-domains"`
+	NumNeighbors                    float64        `xml:"evpn-num-neighbors"`
+	Neighbors                       []evpnNeighbor `xml:"evpn-neighbor"`
+	NumESI                          float64        `xml:"evpn-num-esi"`
+	RouterID                        string         `xml:"evpn-router-id"`
+	SourceVTEPAddr                  string         `xml:"evpn-source-vtep-ipaddr"`
+	SMETForwarding                  string         `xml:"evpn-smet-forwarding"`
+}
+
+type macDatabase struct {
+	LocalMACs               float64 `xml:"local-macs"`
+	RemoteMACs              float64 `xml:"remote-macs"`
+	LocalMACIPs             float64 `xml:"local-mac-ips"`
+	RemoteMACIPs            float64 `xml:"remote-mac-ips"`
+	LocalDefaultGatewayMACs float64 `xml:"local-default-gateway-macs"`
+	RemoteDefaultGatewayMACs float64 `xml:"remote-default-gateway-macs"`
+}
+
+type evpnNeighbor struct {
+	Routes evpnNeighborRoutes `xml:"evpn-neighbor-route-information"`
+}
+
+type evpnNeighborRoutes struct {
+	Address                    string  `xml:"evpn-neighbor-address"`
+	NumMACRoutes               float64 `xml:"evpn-num-mac-routes"`
+	NumMACIPRoutes             float64 `xml:"evpn-num-mac-ip-routes"`
+	NumAutoDiscoveryRoutes     float64 `xml:"evpn-num-ethernet-autodiscovery-routes"`
+	NumInclusiveMulticastRoutes float64 `xml:"evpn-num-inclusive-multicast-routes"`
+	NumEthernetSegmentRoutes   float64 `xml:"evpn-num-ethernet-segment-routes"`
+}

--- a/pkg/features/evpn/rpc.go
+++ b/pkg/features/evpn/rpc.go
@@ -53,32 +53,30 @@ type routingEngine struct {
 // populated when the device returns the extensive output and are only
 // consumed by the collector when the -evpn.detail.enabled flag is set.
 type evpnInstance struct {
-	Name                            string             `xml:"evpn-instance-name"`
-	RouteDistinguisher              string             `xml:"route-distinguisher"`
-	EncapType                       string             `xml:"evpn-encap-type"`
-	ControlWord                     string             `xml:"evpn-instance-control-word"`
-	DuplicateMACDetectionThreshold  float64            `xml:"duplicate-mac-detection-threshold"`
-	DuplicateMACDetectionWindow     float64            `xml:"duplicate-mac-detection-window"`
-	MACDatabase                     *macDatabase       `xml:"mac-database-status-table"`
-	LocalInterfaces                 float64            `xml:"local-interfaces"`
-	LocalInterfacesUp               float64            `xml:"local-interfaces-up"`
-	IRBInterfaces                   float64            `xml:"irb-interfaces"`
-	IRBInterfacesUp                 float64            `xml:"irb-interfaces-up"`
-	NumProtectInterfaces            float64            `xml:"num-protect-interfaces"`
-	NumBridgeDomains                float64            `xml:"num-bridge-domains"`
-	NumNeighbors                    float64            `xml:"evpn-num-neighbors"`
-	Neighbors                       []evpnNeighbor     `xml:"evpn-neighbor"`
-	NumESI                          float64            `xml:"evpn-num-esi"`
-	RouterID                        string             `xml:"evpn-router-id"`
-	SourceVTEPAddr                  string             `xml:"evpn-source-vtep-ipaddr"`
-	SMETForwarding                  string             `xml:"evpn-smet-forwarding"`
+	Name                           string         `xml:"evpn-instance-name"`
+	RouteDistinguisher             string         `xml:"route-distinguisher"`
+	EncapType                      string         `xml:"evpn-encap-type"`
+	DuplicateMACDetectionThreshold float64        `xml:"duplicate-mac-detection-threshold"`
+	DuplicateMACDetectionWindow    float64        `xml:"duplicate-mac-detection-window"`
+	MACDatabase                    *macDatabase   `xml:"mac-database-status-table"`
+	LocalInterfaces                float64        `xml:"local-interfaces"`
+	LocalInterfacesUp              float64        `xml:"local-interfaces-up"`
+	IRBInterfaces                  float64        `xml:"irb-interfaces"`
+	IRBInterfacesUp                float64        `xml:"irb-interfaces-up"`
+	NumProtectInterfaces           float64        `xml:"num-protect-interfaces"`
+	NumBridgeDomains               float64        `xml:"num-bridge-domains"`
+	NumNeighbors                   float64        `xml:"evpn-num-neighbors"`
+	Neighbors                      []evpnNeighbor `xml:"evpn-neighbor"`
+	NumESI                         float64        `xml:"evpn-num-esi"`
+	RouterID                       string         `xml:"evpn-router-id"`
+	SourceVTEPAddr                 string         `xml:"evpn-source-vtep-ipaddr"`
 
 	// Detail tables — populated by extensive output, parsed only when
 	// the evpn_detail feature is enabled (cardinality opt-in).
-	Interfaces      []evpnInterface    `xml:"evpn-interface-status-table>evpn-interface"`
-	IRBInterfaceTbl []irbInterface     `xml:"irb-interface-status-table>irb-interface"`
-	BridgeDomains   []bridgeDomain     `xml:"bridge-domain-status-table>bridge-domain"`
-	ESIs            []evpnESI          `xml:"evpn-esi"`
+	Interfaces      []evpnInterface `xml:"evpn-interface-status-table>evpn-interface"`
+	IRBInterfaceTbl []irbInterface  `xml:"irb-interface-status-table>irb-interface"`
+	BridgeDomains   []bridgeDomain  `xml:"bridge-domain-status-table>bridge-domain"`
+	ESIs            []evpnESI       `xml:"evpn-esi"`
 }
 
 // evpnInterface — entries inside <evpn-interface-status-table>.
@@ -112,11 +110,11 @@ type bridgeDomain struct {
 // evpnESI — entries at the <evpn-esi> level. The nested DF-election
 // and remote-PE blocks are flattened into labels.
 type evpnESI struct {
-	Value          string             `xml:"evpn-esi-value"`
-	Status         string             `xml:"evpn-esi-status"`
-	LocalIntf      *evpnESILocalIntf  `xml:"evpn-esi-local-intf-information"`
-	RemotePEInfo   *evpnESIRemotePE   `xml:"evpn-esi-remote-pe-information"`
-	DFInfo         *evpnESIDFInfo     `xml:"evpn-esi-df-information"`
+	Value        string            `xml:"evpn-esi-value"`
+	Status       string            `xml:"evpn-esi-status"`
+	LocalIntf    *evpnESILocalIntf `xml:"evpn-esi-local-intf-information"`
+	RemotePEInfo *evpnESIRemotePE  `xml:"evpn-esi-remote-pe-information"`
+	DFInfo       *evpnESIDFInfo    `xml:"evpn-esi-df-information"`
 }
 
 type evpnESILocalIntf struct {
@@ -143,7 +141,7 @@ type evpnESIDFInfo struct {
 // duplicate-MAC detection. Empty envelope on healthy fabrics.
 
 type duplicateSingleResult struct {
-	XMLName   xml.Name           `xml:"rpc-reply"`
+	XMLName   xml.Name            `xml:"rpc-reply"`
 	Instances []duplicateInstance `xml:"evpn-database-information>evpn-database-instance"`
 }
 
@@ -160,7 +158,7 @@ type duplicateRoutingEngine struct {
 }
 
 type duplicateInstance struct {
-	Name    string             `xml:"instance-name"`
+	Name    string              `xml:"instance-name"`
 	Entries []duplicateMACEntry `xml:"mac-entry"`
 }
 
@@ -199,11 +197,11 @@ type l3Context struct {
 }
 
 type macDatabase struct {
-	LocalMACs               float64 `xml:"local-macs"`
-	RemoteMACs              float64 `xml:"remote-macs"`
-	LocalMACIPs             float64 `xml:"local-mac-ips"`
-	RemoteMACIPs            float64 `xml:"remote-mac-ips"`
-	LocalDefaultGatewayMACs float64 `xml:"local-default-gateway-macs"`
+	LocalMACs                float64 `xml:"local-macs"`
+	RemoteMACs               float64 `xml:"remote-macs"`
+	LocalMACIPs              float64 `xml:"local-mac-ips"`
+	RemoteMACIPs             float64 `xml:"remote-mac-ips"`
+	LocalDefaultGatewayMACs  float64 `xml:"local-default-gateway-macs"`
 	RemoteDefaultGatewayMACs float64 `xml:"remote-default-gateway-macs"`
 }
 
@@ -212,10 +210,10 @@ type evpnNeighbor struct {
 }
 
 type evpnNeighborRoutes struct {
-	Address                    string  `xml:"evpn-neighbor-address"`
-	NumMACRoutes               float64 `xml:"evpn-num-mac-routes"`
-	NumMACIPRoutes             float64 `xml:"evpn-num-mac-ip-routes"`
-	NumAutoDiscoveryRoutes     float64 `xml:"evpn-num-ethernet-autodiscovery-routes"`
+	Address                     string  `xml:"evpn-neighbor-address"`
+	NumMACRoutes                float64 `xml:"evpn-num-mac-routes"`
+	NumMACIPRoutes              float64 `xml:"evpn-num-mac-ip-routes"`
+	NumAutoDiscoveryRoutes      float64 `xml:"evpn-num-ethernet-autodiscovery-routes"`
 	NumInclusiveMulticastRoutes float64 `xml:"evpn-num-inclusive-multicast-routes"`
-	NumEthernetSegmentRoutes   float64 `xml:"evpn-num-ethernet-segment-routes"`
+	NumEthernetSegmentRoutes    float64 `xml:"evpn-num-ethernet-segment-routes"`
 }

--- a/pkg/features/evpn/rpc.go
+++ b/pkg/features/evpn/rpc.go
@@ -51,7 +51,7 @@ type routingEngine struct {
 // mac-database-status-table, and the per-interface tables. The detail
 // sub-tables (Interfaces, IRBInterfaces, BridgeDomains, ESIs) are
 // populated when the device returns the extensive output and are only
-// consumed by the collector when the -evpn.detail.enabled flag is set.
+// consumed by the collector when the EVPN feature is enabled.
 type evpnInstance struct {
 	Name                           string         `xml:"evpn-instance-name"`
 	RouteDistinguisher             string         `xml:"route-distinguisher"`
@@ -71,8 +71,8 @@ type evpnInstance struct {
 	RouterID                       string         `xml:"evpn-router-id"`
 	SourceVTEPAddr                 string         `xml:"evpn-source-vtep-ipaddr"`
 
-	// Detail tables — populated by extensive output, parsed only when
-	// the evpn_detail feature is enabled (cardinality opt-in).
+	// Detail tables — populated by extensive output when supported by the device.
+	// The collector parses these tables whenever they are present.
 	Interfaces      []evpnInterface `xml:"evpn-interface-status-table>evpn-interface"`
 	IRBInterfaceTbl []irbInterface  `xml:"irb-interface-status-table>irb-interface"`
 	BridgeDomains   []bridgeDomain  `xml:"bridge-domain-status-table>bridge-domain"`

--- a/pkg/features/evpn/rpc.go
+++ b/pkg/features/evpn/rpc.go
@@ -48,27 +48,154 @@ type routingEngine struct {
 
 // evpnInstance models one <evpn-instance> entry. Fields are mostly
 // optional - the default-evpn instance omits encapsulation, the
-// mac-database-status-table, and the per-interface tables.
+// mac-database-status-table, and the per-interface tables. The detail
+// sub-tables (Interfaces, IRBInterfaces, BridgeDomains, ESIs) are
+// populated when the device returns the extensive output and are only
+// consumed by the collector when the -evpn.detail.enabled flag is set.
 type evpnInstance struct {
-	Name                            string         `xml:"evpn-instance-name"`
-	RouteDistinguisher              string         `xml:"route-distinguisher"`
-	EncapType                       string         `xml:"evpn-encap-type"`
-	ControlWord                     string         `xml:"evpn-instance-control-word"`
-	DuplicateMACDetectionThreshold  float64        `xml:"duplicate-mac-detection-threshold"`
-	DuplicateMACDetectionWindow     float64        `xml:"duplicate-mac-detection-window"`
-	MACDatabase                     *macDatabase   `xml:"mac-database-status-table"`
-	LocalInterfaces                 float64        `xml:"local-interfaces"`
-	LocalInterfacesUp               float64        `xml:"local-interfaces-up"`
-	IRBInterfaces                   float64        `xml:"irb-interfaces"`
-	IRBInterfacesUp                 float64        `xml:"irb-interfaces-up"`
-	NumProtectInterfaces            float64        `xml:"num-protect-interfaces"`
-	NumBridgeDomains                float64        `xml:"num-bridge-domains"`
-	NumNeighbors                    float64        `xml:"evpn-num-neighbors"`
-	Neighbors                       []evpnNeighbor `xml:"evpn-neighbor"`
-	NumESI                          float64        `xml:"evpn-num-esi"`
-	RouterID                        string         `xml:"evpn-router-id"`
-	SourceVTEPAddr                  string         `xml:"evpn-source-vtep-ipaddr"`
-	SMETForwarding                  string         `xml:"evpn-smet-forwarding"`
+	Name                            string             `xml:"evpn-instance-name"`
+	RouteDistinguisher              string             `xml:"route-distinguisher"`
+	EncapType                       string             `xml:"evpn-encap-type"`
+	ControlWord                     string             `xml:"evpn-instance-control-word"`
+	DuplicateMACDetectionThreshold  float64            `xml:"duplicate-mac-detection-threshold"`
+	DuplicateMACDetectionWindow     float64            `xml:"duplicate-mac-detection-window"`
+	MACDatabase                     *macDatabase       `xml:"mac-database-status-table"`
+	LocalInterfaces                 float64            `xml:"local-interfaces"`
+	LocalInterfacesUp               float64            `xml:"local-interfaces-up"`
+	IRBInterfaces                   float64            `xml:"irb-interfaces"`
+	IRBInterfacesUp                 float64            `xml:"irb-interfaces-up"`
+	NumProtectInterfaces            float64            `xml:"num-protect-interfaces"`
+	NumBridgeDomains                float64            `xml:"num-bridge-domains"`
+	NumNeighbors                    float64            `xml:"evpn-num-neighbors"`
+	Neighbors                       []evpnNeighbor     `xml:"evpn-neighbor"`
+	NumESI                          float64            `xml:"evpn-num-esi"`
+	RouterID                        string             `xml:"evpn-router-id"`
+	SourceVTEPAddr                  string             `xml:"evpn-source-vtep-ipaddr"`
+	SMETForwarding                  string             `xml:"evpn-smet-forwarding"`
+
+	// Detail tables — populated by extensive output, parsed only when
+	// the evpn_detail feature is enabled (cardinality opt-in).
+	Interfaces      []evpnInterface    `xml:"evpn-interface-status-table>evpn-interface"`
+	IRBInterfaceTbl []irbInterface     `xml:"irb-interface-status-table>irb-interface"`
+	BridgeDomains   []bridgeDomain     `xml:"bridge-domain-status-table>bridge-domain"`
+	ESIs            []evpnESI          `xml:"evpn-esi"`
+}
+
+// evpnInterface — entries inside <evpn-interface-status-table>.
+type evpnInterface struct {
+	Name      string `xml:"evpn-interface-name"`
+	ESI       string `xml:"evpn-interface-esi"`
+	Mode      string `xml:"evpn-interface-mode"`
+	Status    string `xml:"evpn-interface-status"`
+	EtreeRole string `xml:"evpn-interface-etree-role"`
+}
+
+// irbInterface — entries inside <irb-interface-status-table>.
+type irbInterface struct {
+	Name      string `xml:"irb-interface-name"`
+	VNI       string `xml:"irb-interface-vni-id"`
+	Status    string `xml:"irb-interface-status"`
+	L3Context string `xml:"irb-interface-l3-context"`
+}
+
+// bridgeDomain — entries inside <bridge-domain-status-table>.
+type bridgeDomain struct {
+	VLANID        string  `xml:"vlan-id"`
+	DomainID      string  `xml:"domain-id"`
+	Interfaces    float64 `xml:"interfaces"`
+	InterfacesUp  float64 `xml:"interfaces-up"`
+	IRBInterface  string  `xml:"irb-interface"`
+	Mode          string  `xml:"mode"`
+	MACSyncStatus string  `xml:"mac-sync-status"`
+}
+
+// evpnESI — entries at the <evpn-esi> level. The nested DF-election
+// and remote-PE blocks are flattened into labels.
+type evpnESI struct {
+	Value          string             `xml:"evpn-esi-value"`
+	Status         string             `xml:"evpn-esi-status"`
+	LocalIntf      *evpnESILocalIntf  `xml:"evpn-esi-local-intf-information"`
+	RemotePEInfo   *evpnESIRemotePE   `xml:"evpn-esi-remote-pe-information"`
+	DFInfo         *evpnESIDFInfo     `xml:"evpn-esi-df-information"`
+}
+
+type evpnESILocalIntf struct {
+	Name   string `xml:"evpn-esi-local-intf-name"`
+	Status string `xml:"evpn-esi-local-intf-status"`
+}
+
+type evpnESIRemotePE struct {
+	Count float64 `xml:"evpn-esi-num-remote-pe"`
+}
+
+type evpnESIDFInfo struct {
+	Algorithm           string `xml:"esi-df-election-algorithm"`
+	DesignatedForwarder string `xml:"esi-designated-forwarder"`
+	BackupForwarder     string `xml:"esi-backup-forwarder"`
+}
+
+// =================================================================
+// show evpn database state duplicate
+// =================================================================
+//
+// Returns the same <evpn-database-information> envelope as the
+// unfiltered command, with only entries currently suppressed for
+// duplicate-MAC detection. Empty envelope on healthy fabrics.
+
+type duplicateSingleResult struct {
+	XMLName   xml.Name           `xml:"rpc-reply"`
+	Instances []duplicateInstance `xml:"evpn-database-information>evpn-database-instance"`
+}
+
+type duplicateMultiResult struct {
+	XMLName xml.Name `xml:"rpc-reply"`
+	Engines struct {
+		Items []duplicateRoutingEngine `xml:"multi-routing-engine-item"`
+	} `xml:"multi-routing-engine-results"`
+}
+
+type duplicateRoutingEngine struct {
+	Name      string              `xml:"re-name"`
+	Instances []duplicateInstance `xml:"evpn-database-information>evpn-database-instance"`
+}
+
+type duplicateInstance struct {
+	Name    string             `xml:"instance-name"`
+	Entries []duplicateMACEntry `xml:"mac-entry"`
+}
+
+type duplicateMACEntry struct {
+	MACAddress string `xml:"mac-address"`
+}
+
+// =================================================================
+// show evpn l3-context
+// =================================================================
+
+type l3ContextSingleResult struct {
+	XMLName  xml.Name    `xml:"rpc-reply"`
+	Contexts []l3Context `xml:"evpn-l3-context-information>evpn-l3-context"`
+}
+
+type l3ContextMultiResult struct {
+	XMLName xml.Name `xml:"rpc-reply"`
+	Engines struct {
+		Items []l3ContextRoutingEngine `xml:"multi-routing-engine-item"`
+	} `xml:"multi-routing-engine-results"`
+}
+
+type l3ContextRoutingEngine struct {
+	Name     string      `xml:"re-name"`
+	Contexts []l3Context `xml:"evpn-l3-context-information>evpn-l3-context"`
+}
+
+type l3Context struct {
+	Name              string  `xml:"context-name"`
+	Type              string  `xml:"context-type"`
+	AdvertisementMode string  `xml:"context-advertisement-mode"`
+	RouterMAC         string  `xml:"context-router-mac"`
+	Encapsulation     string  `xml:"context-encapsulation"`
+	VNI               float64 `xml:"context-vni"`
 }
 
 type macDatabase struct {

--- a/pkg/features/evpn/rpc_test.go
+++ b/pkg/features/evpn/rpc_test.go
@@ -277,3 +277,244 @@ func TestParseMultiEngine(t *testing.T) {
 		}
 	}
 }
+
+// =================================================================
+// Detail tables (Phase A) — exercise the same parseInstances() path
+// but populate the per-interface / per-IRB / per-bridge-domain /
+// per-ESI subtables. Synthetic data — RFC 5737 IPs, IANA documentation
+// MACs.
+// =================================================================
+const detailedEVI = `<rpc-reply>
+  <evpn-instance-information>
+    <evpn-instance>
+      <evpn-instance-name>EVI-A</evpn-instance-name>
+      <route-distinguisher>65000:1</route-distinguisher>
+      <evpn-encap-type>VXLAN</evpn-encap-type>
+      <local-interfaces>2</local-interfaces>
+      <local-interfaces-up>1</local-interfaces-up>
+      <evpn-interface-status-table>
+        <evpn-interface>
+          <evpn-interface-name>ae10.0</evpn-interface-name>
+          <evpn-interface-esi>01:23:45:00:00:00:00:00:00:01</evpn-interface-esi>
+          <evpn-interface-mode>all-active</evpn-interface-mode>
+          <evpn-interface-status>Up</evpn-interface-status>
+          <evpn-interface-etree-role>Root</evpn-interface-etree-role>
+        </evpn-interface>
+        <evpn-interface>
+          <evpn-interface-name>ge-0/0/0.0</evpn-interface-name>
+          <evpn-interface-esi>00:00:00:00:00:00:00:00:00:00</evpn-interface-esi>
+          <evpn-interface-mode>single-homed</evpn-interface-mode>
+          <evpn-interface-status>Down</evpn-interface-status>
+          <evpn-interface-etree-role>Root</evpn-interface-etree-role>
+        </evpn-interface>
+      </evpn-interface-status-table>
+      <irb-interfaces>1</irb-interfaces>
+      <irb-interfaces-up>1</irb-interfaces-up>
+      <irb-interface-status-table>
+        <irb-interface>
+          <irb-interface-name>irb.10</irb-interface-name>
+          <irb-interface-vni-id>10001</irb-interface-vni-id>
+          <irb-interface-status>Up</irb-interface-status>
+          <irb-interface-l3-context>vrf-a</irb-interface-l3-context>
+        </irb-interface>
+      </irb-interface-status-table>
+      <num-bridge-domains>1</num-bridge-domains>
+      <bridge-domain-status-table>
+        <bridge-domain>
+          <vlan-id>10</vlan-id>
+          <domain-id>10001</domain-id>
+          <interfaces>3</interfaces>
+          <interfaces-up>2</interfaces-up>
+          <irb-interface>irb.10</irb-interface>
+          <mode>Extended</mode>
+          <mac-sync-status>Enabled</mac-sync-status>
+        </bridge-domain>
+      </bridge-domain-status-table>
+      <evpn-num-esi>2</evpn-num-esi>
+      <evpn-esi>
+        <evpn-esi-value>01:23:45:00:00:00:00:00:00:01</evpn-esi-value>
+        <evpn-esi-status>Resolved by IFL ae10.0</evpn-esi-status>
+        <evpn-esi-local-intf-information>
+          <evpn-esi-local-intf-name>ae10.0</evpn-esi-local-intf-name>
+          <evpn-esi-local-intf-status>Up/Forwarding</evpn-esi-local-intf-status>
+        </evpn-esi-local-intf-information>
+        <evpn-esi-remote-pe-information>
+          <evpn-esi-num-remote-pe>1</evpn-esi-num-remote-pe>
+        </evpn-esi-remote-pe-information>
+        <evpn-esi-df-information>
+          <esi-df-election-algorithm>MOD based</esi-df-election-algorithm>
+          <esi-designated-forwarder>192.0.2.1</esi-designated-forwarder>
+          <esi-backup-forwarder>192.0.2.10</esi-backup-forwarder>
+        </evpn-esi-df-information>
+      </evpn-esi>
+      <evpn-esi>
+        <evpn-esi-value>05:ab:cd:00:00:00:00:00:01:00</evpn-esi-value>
+        <evpn-esi-status></evpn-esi-status>
+        <evpn-esi-remote-pe-information>
+        </evpn-esi-remote-pe-information>
+      </evpn-esi>
+    </evpn-instance>
+  </evpn-instance-information>
+</rpc-reply>`
+
+func TestParseDetailTables(t *testing.T) {
+	inst, err := parseInstances([]byte(detailedEVI))
+	if err != nil {
+		t.Fatalf("parseInstances: %v", err)
+	}
+	if len(inst) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(inst))
+	}
+	g := inst[0]
+
+	if len(g.Interfaces) != 2 {
+		t.Errorf("interfaces: got %d, want 2", len(g.Interfaces))
+	}
+	if g.Interfaces[0].Name != "ae10.0" || g.Interfaces[0].Status != "Up" {
+		t.Errorf("interface[0]: got %+v", g.Interfaces[0])
+	}
+	if g.Interfaces[1].Status != "Down" {
+		t.Errorf("interface[1] status: got %q", g.Interfaces[1].Status)
+	}
+
+	if len(g.IRBInterfaceTbl) != 1 {
+		t.Errorf("irb: got %d, want 1", len(g.IRBInterfaceTbl))
+	}
+	if g.IRBInterfaceTbl[0].VNI != "10001" || g.IRBInterfaceTbl[0].L3Context != "vrf-a" {
+		t.Errorf("irb[0]: got %+v", g.IRBInterfaceTbl[0])
+	}
+
+	if len(g.BridgeDomains) != 1 {
+		t.Errorf("bridge-domains: got %d", len(g.BridgeDomains))
+	}
+	if g.BridgeDomains[0].Interfaces != 3 || g.BridgeDomains[0].InterfacesUp != 2 {
+		t.Errorf("bridge-domain counts: got %v/%v", g.BridgeDomains[0].Interfaces, g.BridgeDomains[0].InterfacesUp)
+	}
+
+	if len(g.ESIs) != 2 {
+		t.Errorf("esi: got %d", len(g.ESIs))
+	}
+	// First ESI is resolved with full DF info.
+	if g.ESIs[0].DFInfo == nil || g.ESIs[0].DFInfo.DesignatedForwarder != "192.0.2.1" {
+		t.Errorf("esi[0].df: got %+v", g.ESIs[0].DFInfo)
+	}
+	if g.ESIs[0].RemotePEInfo == nil || g.ESIs[0].RemotePEInfo.Count != 1 {
+		t.Errorf("esi[0].remote-pe-count: got %+v", g.ESIs[0].RemotePEInfo)
+	}
+	// Second ESI has no DF info, no remote PEs — minimal entry.
+	if g.ESIs[1].DFInfo != nil {
+		t.Errorf("esi[1].df: expected nil, got %+v", g.ESIs[1].DFInfo)
+	}
+}
+
+// =================================================================
+// show evpn database state duplicate fixtures
+// =================================================================
+const duplicateEmpty = `<rpc-reply>
+  <evpn-database-information>
+  </evpn-database-information>
+</rpc-reply>`
+
+const duplicatePopulated = `<rpc-reply>
+  <evpn-database-information>
+    <evpn-database-instance>
+      <instance-name>EVI-A</instance-name>
+      <mac-entry>
+        <vni-id>10001</vni-id>
+        <mac-address>00:00:5e:00:53:01</mac-address>
+      </mac-entry>
+      <mac-entry>
+        <vni-id>10001</vni-id>
+        <mac-address>00:00:5e:00:53:02</mac-address>
+      </mac-entry>
+    </evpn-database-instance>
+    <evpn-database-instance>
+      <instance-name>EVI-B</instance-name>
+      <mac-entry>
+        <vni-id>10002</vni-id>
+        <mac-address>00:00:5e:00:53:11</mac-address>
+      </mac-entry>
+    </evpn-database-instance>
+  </evpn-database-information>
+</rpc-reply>`
+
+func TestParseDuplicateMACsEmpty(t *testing.T) {
+	inst, err := parseDuplicateMACs([]byte(duplicateEmpty))
+	if err != nil {
+		t.Fatalf("parseDuplicateMACs: %v", err)
+	}
+	if len(inst) != 0 {
+		t.Errorf("expected 0 instances, got %d", len(inst))
+	}
+}
+
+func TestParseDuplicateMACsPopulated(t *testing.T) {
+	inst, err := parseDuplicateMACs([]byte(duplicatePopulated))
+	if err != nil {
+		t.Fatalf("parseDuplicateMACs: %v", err)
+	}
+	if len(inst) != 2 {
+		t.Fatalf("expected 2 instances, got %d", len(inst))
+	}
+	if inst[0].Name != "EVI-A" || len(inst[0].Entries) != 2 {
+		t.Errorf("inst[0]: name=%q entries=%d", inst[0].Name, len(inst[0].Entries))
+	}
+	if inst[1].Name != "EVI-B" || len(inst[1].Entries) != 1 {
+		t.Errorf("inst[1]: name=%q entries=%d", inst[1].Name, len(inst[1].Entries))
+	}
+}
+
+// =================================================================
+// show evpn l3-context fixtures
+// =================================================================
+const l3ContextEmpty = `<rpc-reply>
+  <evpn-l3-context-information>
+  </evpn-l3-context-information>
+</rpc-reply>`
+
+const l3ContextPopulated = `<rpc-reply>
+  <evpn-l3-context-information>
+    <evpn-l3-context>
+      <context-name>vrf-a</context-name>
+      <context-type>cfg</context-type>
+      <context-advertisement-mode>direct</context-advertisement-mode>
+      <context-router-mac>00:00:5e:00:53:42</context-router-mac>
+      <context-encapsulation>VXLAN</context-encapsulation>
+      <context-vni>10001</context-vni>
+    </evpn-l3-context>
+    <evpn-l3-context>
+      <context-name>vrf-b</context-name>
+      <context-type>cfg</context-type>
+      <context-advertisement-mode>direct</context-advertisement-mode>
+      <context-router-mac>00:00:5e:00:53:43</context-router-mac>
+      <context-encapsulation>MPLS</context-encapsulation>
+      <context-vni>20002</context-vni>
+    </evpn-l3-context>
+  </evpn-l3-context-information>
+</rpc-reply>`
+
+func TestParseL3ContextsEmpty(t *testing.T) {
+	c, err := parseL3Contexts([]byte(l3ContextEmpty))
+	if err != nil {
+		t.Fatalf("parseL3Contexts: %v", err)
+	}
+	if len(c) != 0 {
+		t.Errorf("expected 0 contexts, got %d", len(c))
+	}
+}
+
+func TestParseL3ContextsPopulated(t *testing.T) {
+	c, err := parseL3Contexts([]byte(l3ContextPopulated))
+	if err != nil {
+		t.Fatalf("parseL3Contexts: %v", err)
+	}
+	if len(c) != 2 {
+		t.Fatalf("expected 2 contexts, got %d", len(c))
+	}
+	if c[0].Name != "vrf-a" || c[0].VNI != 10001 || c[0].Encapsulation != "VXLAN" {
+		t.Errorf("ctx[0]: got %+v", c[0])
+	}
+	if c[1].Name != "vrf-b" || c[1].VNI != 20002 || c[1].Encapsulation != "MPLS" {
+		t.Errorf("ctx[1]: got %+v", c[1])
+	}
+}

--- a/pkg/features/evpn/rpc_test.go
+++ b/pkg/features/evpn/rpc_test.go
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: MIT
+
+package evpn
+
+import "testing"
+
+// healthySingleEVI - synthetic shape modelled on real EX-class extensive
+// output but populated entirely with RFC 5737 documentation IPs and
+// synthetic identifiers. Single EVI with one neighbor and a small MAC
+// database.
+const healthySingleEVI = `<rpc-reply>
+  <evpn-instance-information>
+    <evpn-instance>
+      <evpn-instance-name>EVI-A</evpn-instance-name>
+      <route-distinguisher>65000:1</route-distinguisher>
+      <evpn-encap-type>VXLAN</evpn-encap-type>
+      <evpn-instance-control-word>enabled</evpn-instance-control-word>
+      <duplicate-mac-detection-threshold>5</duplicate-mac-detection-threshold>
+      <duplicate-mac-detection-window>180</duplicate-mac-detection-window>
+      <mac-database-status-table>
+        <local-macs>10</local-macs>
+        <remote-macs>4</remote-macs>
+        <local-mac-ips>10</local-mac-ips>
+        <remote-mac-ips>4</remote-mac-ips>
+        <local-default-gateway-macs>1</local-default-gateway-macs>
+        <remote-default-gateway-macs>0</remote-default-gateway-macs>
+      </mac-database-status-table>
+      <local-interfaces>3</local-interfaces>
+      <local-interfaces-up>3</local-interfaces-up>
+      <irb-interfaces>1</irb-interfaces>
+      <irb-interfaces-up>1</irb-interfaces-up>
+      <num-protect-interfaces>0</num-protect-interfaces>
+      <num-bridge-domains>1</num-bridge-domains>
+      <evpn-num-neighbors>1</evpn-num-neighbors>
+      <evpn-neighbor>
+        <evpn-neighbor-route-information>
+          <evpn-neighbor-address>192.0.2.1</evpn-neighbor-address>
+          <evpn-num-mac-routes>4</evpn-num-mac-routes>
+          <evpn-num-mac-ip-routes>4</evpn-num-mac-ip-routes>
+          <evpn-num-ethernet-autodiscovery-routes>2</evpn-num-ethernet-autodiscovery-routes>
+          <evpn-num-inclusive-multicast-routes>1</evpn-num-inclusive-multicast-routes>
+          <evpn-num-ethernet-segment-routes>0</evpn-num-ethernet-segment-routes>
+        </evpn-neighbor-route-information>
+      </evpn-neighbor>
+      <evpn-num-esi>2</evpn-num-esi>
+      <evpn-router-id>192.0.2.10</evpn-router-id>
+      <evpn-source-vtep-ipaddr>192.0.2.10</evpn-source-vtep-ipaddr>
+      <evpn-smet-forwarding>Disabled</evpn-smet-forwarding>
+    </evpn-instance>
+  </evpn-instance-information>
+</rpc-reply>`
+
+// multiEVIMixed - synthetic two-EVI sample. The first EVI mimics
+// __default_evpn__ (no encap, no mac-database, no per-PE breakdown -
+// just the aggregate neighbour count). The second is a fully populated
+// VXLAN EVI with two neighbors.
+const multiEVIMixed = `<rpc-reply>
+  <evpn-instance-information>
+    <evpn-instance>
+      <evpn-instance-name>__default_evpn__</evpn-instance-name>
+      <route-distinguisher>65000:0</route-distinguisher>
+      <num-bridge-domains>0</num-bridge-domains>
+      <evpn-num-neighbors>1</evpn-num-neighbors>
+      <evpn-neighbor>
+        <evpn-neighbor-route-information>
+          <evpn-neighbor-address>192.0.2.1</evpn-neighbor-address>
+          <evpn-num-mac-routes>0</evpn-num-mac-routes>
+          <evpn-num-mac-ip-routes>0</evpn-num-mac-ip-routes>
+          <evpn-num-ethernet-autodiscovery-routes>0</evpn-num-ethernet-autodiscovery-routes>
+          <evpn-num-inclusive-multicast-routes>0</evpn-num-inclusive-multicast-routes>
+          <evpn-num-ethernet-segment-routes>2</evpn-num-ethernet-segment-routes>
+        </evpn-neighbor-route-information>
+      </evpn-neighbor>
+    </evpn-instance>
+    <evpn-instance>
+      <evpn-instance-name>EVI-B</evpn-instance-name>
+      <route-distinguisher>65000:2</route-distinguisher>
+      <evpn-encap-type>VXLAN</evpn-encap-type>
+      <evpn-instance-control-word>enabled</evpn-instance-control-word>
+      <mac-database-status-table>
+        <local-macs>50</local-macs>
+        <remote-macs>20</remote-macs>
+        <local-mac-ips>48</local-mac-ips>
+        <remote-mac-ips>20</remote-mac-ips>
+        <local-default-gateway-macs>0</local-default-gateway-macs>
+        <remote-default-gateway-macs>0</remote-default-gateway-macs>
+      </mac-database-status-table>
+      <local-interfaces>6</local-interfaces>
+      <local-interfaces-up>5</local-interfaces-up>
+      <irb-interfaces>0</irb-interfaces>
+      <irb-interfaces-up>0</irb-interfaces-up>
+      <num-protect-interfaces>0</num-protect-interfaces>
+      <num-bridge-domains>1</num-bridge-domains>
+      <evpn-num-neighbors>2</evpn-num-neighbors>
+      <evpn-neighbor>
+        <evpn-neighbor-route-information>
+          <evpn-neighbor-address>192.0.2.1</evpn-neighbor-address>
+          <evpn-num-mac-routes>15</evpn-num-mac-routes>
+          <evpn-num-mac-ip-routes>15</evpn-num-mac-ip-routes>
+          <evpn-num-ethernet-autodiscovery-routes>4</evpn-num-ethernet-autodiscovery-routes>
+          <evpn-num-inclusive-multicast-routes>1</evpn-num-inclusive-multicast-routes>
+          <evpn-num-ethernet-segment-routes>2</evpn-num-ethernet-segment-routes>
+        </evpn-neighbor-route-information>
+      </evpn-neighbor>
+      <evpn-neighbor>
+        <evpn-neighbor-route-information>
+          <evpn-neighbor-address>192.0.2.2</evpn-neighbor-address>
+          <evpn-num-mac-routes>5</evpn-num-mac-routes>
+          <evpn-num-mac-ip-routes>5</evpn-num-mac-ip-routes>
+          <evpn-num-ethernet-autodiscovery-routes>0</evpn-num-ethernet-autodiscovery-routes>
+          <evpn-num-inclusive-multicast-routes>1</evpn-num-inclusive-multicast-routes>
+          <evpn-num-ethernet-segment-routes>0</evpn-num-ethernet-segment-routes>
+        </evpn-neighbor-route-information>
+      </evpn-neighbor>
+      <evpn-num-esi>4</evpn-num-esi>
+      <evpn-router-id>192.0.2.10</evpn-router-id>
+      <evpn-source-vtep-ipaddr>192.0.2.10</evpn-source-vtep-ipaddr>
+      <evpn-smet-forwarding>Disabled</evpn-smet-forwarding>
+    </evpn-instance>
+  </evpn-instance-information>
+</rpc-reply>`
+
+// multiEngineSample - synthetic multi-RE / Virtual Chassis wrap. Each
+// RE reports its own EVPN instance; the dispatch logic must flatten
+// them into a single list.
+const multiEngineSample = `<rpc-reply>
+  <multi-routing-engine-results>
+    <multi-routing-engine-item>
+      <re-name>fpc0</re-name>
+      <evpn-instance-information>
+        <evpn-instance>
+          <evpn-instance-name>EVI-A</evpn-instance-name>
+          <route-distinguisher>65000:1</route-distinguisher>
+          <evpn-encap-type>VXLAN</evpn-encap-type>
+          <evpn-num-neighbors>1</evpn-num-neighbors>
+          <evpn-num-esi>0</evpn-num-esi>
+        </evpn-instance>
+      </evpn-instance-information>
+    </multi-routing-engine-item>
+    <multi-routing-engine-item>
+      <re-name>fpc1</re-name>
+      <evpn-instance-information>
+        <evpn-instance>
+          <evpn-instance-name>EVI-B</evpn-instance-name>
+          <route-distinguisher>65000:2</route-distinguisher>
+          <evpn-encap-type>VXLAN</evpn-encap-type>
+          <evpn-num-neighbors>1</evpn-num-neighbors>
+          <evpn-num-esi>0</evpn-num-esi>
+        </evpn-instance>
+      </evpn-instance-information>
+    </multi-routing-engine-item>
+  </multi-routing-engine-results>
+</rpc-reply>`
+
+func TestParseSingleEVI(t *testing.T) {
+	inst, err := parseInstances([]byte(healthySingleEVI))
+	if err != nil {
+		t.Fatalf("parseInstances: %v", err)
+	}
+	if len(inst) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(inst))
+	}
+	g := inst[0]
+	if g.Name != "EVI-A" {
+		t.Errorf("name: got %q", g.Name)
+	}
+	if g.RouteDistinguisher != "65000:1" {
+		t.Errorf("rd: got %q", g.RouteDistinguisher)
+	}
+	if g.EncapType != "VXLAN" {
+		t.Errorf("encap: got %q", g.EncapType)
+	}
+	if g.NumNeighbors != 1 {
+		t.Errorf("num-neighbors: got %v", g.NumNeighbors)
+	}
+	if g.NumESI != 2 {
+		t.Errorf("num-esi: got %v", g.NumESI)
+	}
+	if g.LocalInterfaces != 3 || g.LocalInterfacesUp != 3 {
+		t.Errorf("local-interfaces: got %v/%v", g.LocalInterfaces, g.LocalInterfacesUp)
+	}
+	if g.MACDatabase == nil {
+		t.Fatal("expected mac-database-status-table to parse")
+	}
+	if g.MACDatabase.LocalMACs != 10 || g.MACDatabase.RemoteMACs != 4 {
+		t.Errorf("mac counts: got %v/%v", g.MACDatabase.LocalMACs, g.MACDatabase.RemoteMACs)
+	}
+	if g.MACDatabase.LocalMACIPs != 10 || g.MACDatabase.RemoteMACIPs != 4 {
+		t.Errorf("mac-ip counts: got %v/%v", g.MACDatabase.LocalMACIPs, g.MACDatabase.RemoteMACIPs)
+	}
+	if len(g.Neighbors) != 1 {
+		t.Fatalf("expected 1 neighbor, got %d", len(g.Neighbors))
+	}
+	r := g.Neighbors[0].Routes
+	if r.Address != "192.0.2.1" {
+		t.Errorf("neighbor addr: got %q", r.Address)
+	}
+	if r.NumMACRoutes != 4 || r.NumMACIPRoutes != 4 {
+		t.Errorf("type-2 counts: got %v/%v", r.NumMACRoutes, r.NumMACIPRoutes)
+	}
+	if r.NumAutoDiscoveryRoutes != 2 {
+		t.Errorf("type-1 count: got %v", r.NumAutoDiscoveryRoutes)
+	}
+	if r.NumInclusiveMulticastRoutes != 1 {
+		t.Errorf("type-3 count: got %v", r.NumInclusiveMulticastRoutes)
+	}
+	if g.DuplicateMACDetectionThreshold != 5 {
+		t.Errorf("dup-mac threshold: got %v", g.DuplicateMACDetectionThreshold)
+	}
+	if g.DuplicateMACDetectionWindow != 180 {
+		t.Errorf("dup-mac window: got %v", g.DuplicateMACDetectionWindow)
+	}
+}
+
+func TestParseMultiEVIMixed(t *testing.T) {
+	inst, err := parseInstances([]byte(multiEVIMixed))
+	if err != nil {
+		t.Fatalf("parseInstances: %v", err)
+	}
+	if len(inst) != 2 {
+		t.Fatalf("expected 2 instances, got %d", len(inst))
+	}
+
+	// Default-evpn-style instance: no mac-database, no encap.
+	def := inst[0]
+	if def.Name != "__default_evpn__" {
+		t.Errorf("default name: got %q", def.Name)
+	}
+	if def.EncapType != "" {
+		t.Errorf("default encap expected empty, got %q", def.EncapType)
+	}
+	if def.MACDatabase != nil {
+		t.Errorf("default mac-database expected nil, got %#v", def.MACDatabase)
+	}
+	if def.NumNeighbors != 1 {
+		t.Errorf("default num-neighbors: got %v", def.NumNeighbors)
+	}
+	if len(def.Neighbors) != 1 || def.Neighbors[0].Routes.NumEthernetSegmentRoutes != 2 {
+		t.Errorf("default neighbor ES routes: got %#v", def.Neighbors)
+	}
+
+	// Fully populated VXLAN EVI with two PEs.
+	full := inst[1]
+	if full.Name != "EVI-B" {
+		t.Errorf("EVI-B name: got %q", full.Name)
+	}
+	if len(full.Neighbors) != 2 {
+		t.Fatalf("EVI-B neighbors: got %d", len(full.Neighbors))
+	}
+	if full.NumESI != 4 {
+		t.Errorf("EVI-B num-esi: got %v", full.NumESI)
+	}
+	if full.MACDatabase == nil || full.MACDatabase.LocalMACs != 50 {
+		t.Errorf("EVI-B local-macs: got %#v", full.MACDatabase)
+	}
+}
+
+func TestParseMultiEngine(t *testing.T) {
+	inst, err := parseInstances([]byte(multiEngineSample))
+	if err != nil {
+		t.Fatalf("parseInstances: %v", err)
+	}
+	if len(inst) != 2 {
+		t.Fatalf("expected 2 merged instances, got %d", len(inst))
+	}
+	names := map[string]bool{"EVI-A": false, "EVI-B": false}
+	for _, in := range inst {
+		if _, ok := names[in.Name]; !ok {
+			t.Errorf("unexpected instance name %q", in.Name)
+			continue
+		}
+		names[in.Name] = true
+	}
+	for n, seen := range names {
+		if !seen {
+			t.Errorf("expected to see instance %q but didn't", n)
+		}
+	}
+}

--- a/pkg/features/evpnipprefix/collector.go
+++ b/pkg/features/evpnipprefix/collector.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+
+package evpnipprefix
+
+import (
+	"encoding/xml"
+	"strings"
+
+	"github.com/czerwonk/junos_exporter/pkg/collector"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix = "junos_evpn_ip_prefix_"
+
+var (
+	localCount         *prometheus.Desc
+	remoteCount        *prometheus.Desc
+	advertisementCount *prometheus.Desc
+)
+
+func init() {
+	countLabels := []string{"target", "context", "afi"}
+	advLabels := []string{"target", "context", "afi", "status"}
+
+	localCount = prometheus.NewDesc(prefix+"local_count",
+		"Locally originated EVPN Type-5 IP-prefix routes per L3 context and AFI",
+		countLabels, nil)
+	remoteCount = prometheus.NewDesc(prefix+"remote_count",
+		"Remotely advertised EVPN Type-5 IP-prefix routes per L3 context and AFI",
+		countLabels, nil)
+	advertisementCount = prometheus.NewDesc(prefix+"advertisement_count",
+		"Per-PE EVPN Type-5 advertisements grouped by status (accepted, rejected, ...) per L3 context and AFI",
+		advLabels, nil)
+}
+
+type evpnIPPrefixCollector struct{}
+
+// Name returns the name of the collector.
+func (*evpnIPPrefixCollector) Name() string { return "evpn_ip_prefix" }
+
+// NewCollector creates a new collector.
+func NewCollector() collector.RPCCollector { return &evpnIPPrefixCollector{} }
+
+// Describe describes the metrics.
+func (*evpnIPPrefixCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- localCount
+	ch <- remoteCount
+	ch <- advertisementCount
+}
+
+// Collect issues `show evpn ip-prefix-database` and emits per-context per-AFI
+// counters. Per-prefix series are intentionally NOT emitted — cardinality on
+// a busy fabric (thousands of prefixes × multiple advertising PEs) would be
+// untenable for Prometheus. Operators who need per-prefix detail should query
+// the CLI directly.
+func (c *evpnIPPrefixCollector) Collect(client collector.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var contexts []pfxL3Context
+	err := client.RunCommandAndParseWithParser("show evpn ip-prefix-database", func(b []byte) error {
+		var perr error
+		contexts, perr = parseContexts(b)
+		return perr
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, ctx := range contexts {
+		// Locally originated prefixes — one count per AFI.
+		for _, t := range ctx.LocalTables {
+			afi := afiFromDescription(t.Description)
+			l := append(append([]string{}, labelValues...), ctx.Name, afi)
+			ch <- prometheus.MustNewConstMetric(localCount, prometheus.GaugeValue, float64(len(t.Entries)), l...)
+		}
+
+		// Remotely received prefixes — count of prefix entries per AFI,
+		// plus a count of advertisements per status per AFI.
+		for _, t := range ctx.RemoteTables {
+			afi := afiFromDescription(t.Description)
+			l := append(append([]string{}, labelValues...), ctx.Name, afi)
+			ch <- prometheus.MustNewConstMetric(remoteCount, prometheus.GaugeValue, float64(len(t.Entries)), l...)
+
+			byStatus := map[string]int{}
+			for _, e := range t.Entries {
+				for _, adv := range e.Advertisements {
+					byStatus[normalizeStatus(adv.Status)]++
+				}
+			}
+			for status, n := range byStatus {
+				sl := append(append([]string{}, labelValues...), ctx.Name, afi, status)
+				ch <- prometheus.MustNewConstMetric(advertisementCount, prometheus.GaugeValue, float64(n), sl...)
+			}
+		}
+	}
+
+	return nil
+}
+
+// afiFromDescription extracts the AFI from <table-description> text such as
+// "IPv4->EVPN" or "EVPN->IPv6", returning "v4" or "v6". The arrow direction
+// is irrelevant — the AFI is the same for both ends of the table.
+func afiFromDescription(d string) string {
+	switch {
+	case strings.Contains(d, "IPv4"):
+		return "v4"
+	case strings.Contains(d, "IPv6"):
+		return "v6"
+	default:
+		return strings.ToLower(strings.TrimSpace(d))
+	}
+}
+
+// normalizeStatus lowercases the status string so the label values are stable
+// regardless of the device's exact capitalisation.
+func normalizeStatus(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return "unknown"
+	}
+	return s
+}
+
+// parseContexts handles both single-RE and multi-RE response shapes. Same
+// substring-dispatch pattern as the other recent collectors.
+func parseContexts(b []byte) ([]pfxL3Context, error) {
+	if strings.Contains(string(b), "<multi-routing-engine-results") {
+		var m multiEngineResult
+		if err := xml.Unmarshal(b, &m); err != nil {
+			return nil, err
+		}
+		var out []pfxL3Context
+		for _, re := range m.Engines.Items {
+			out = append(out, re.Contexts...)
+		}
+		return out, nil
+	}
+
+	var s singleEngineResult
+	if err := xml.Unmarshal(b, &s); err != nil {
+		return nil, err
+	}
+	return s.Contexts, nil
+}

--- a/pkg/features/evpnipprefix/rpc.go
+++ b/pkg/features/evpnipprefix/rpc.go
@@ -42,7 +42,7 @@ import "encoding/xml"
 // local-origin, two remote-received) distinguished by <table-description>.
 
 type singleEngineResult struct {
-	XMLName  xml.Name      `xml:"rpc-reply"`
+	XMLName  xml.Name       `xml:"rpc-reply"`
 	Contexts []pfxL3Context `xml:"evpn-ip-prefix-database-information>evpn-pfxdb-l3-context"`
 }
 
@@ -59,13 +59,13 @@ type routingEngine struct {
 }
 
 type pfxL3Context struct {
-	Name           string             `xml:"context-name"`
-	LocalTables    []pfxLocalTable    `xml:"evpn-pfxdb-ip-table"`
-	RemoteTables   []pfxRemoteTable   `xml:"evpn-pfxdb-evpn-ip-table"`
+	Name         string           `xml:"context-name"`
+	LocalTables  []pfxLocalTable  `xml:"evpn-pfxdb-ip-table"`
+	RemoteTables []pfxRemoteTable `xml:"evpn-pfxdb-evpn-ip-table"`
 }
 
 type pfxLocalTable struct {
-	Description string         `xml:"table-description"`
+	Description string          `xml:"table-description"`
 	Entries     []pfxLocalEntry `xml:"evpn-pfxdb-ip-entry"`
 }
 
@@ -80,8 +80,8 @@ type pfxRemoteTable struct {
 }
 
 type pfxRemoteEntry struct {
-	Prefix         string                 `xml:"entry-prefix"`
-	ETag           string                 `xml:"entry-etag"`
+	Prefix         string                   `xml:"entry-prefix"`
+	ETag           string                   `xml:"entry-etag"`
 	Advertisements []pfxRemoteAdvertisement `xml:"evpn-pfxdb-evpn-ip-adv"`
 }
 

--- a/pkg/features/evpnipprefix/rpc.go
+++ b/pkg/features/evpnipprefix/rpc.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+
+package evpnipprefix
+
+import "encoding/xml"
+
+// Response shape for `show evpn ip-prefix-database`:
+//
+//   <rpc-reply>
+//     <evpn-ip-prefix-database-information>
+//       <evpn-pfxdb-l3-context>                  ← repeats per L3 context
+//         <context-name>vrf-a</context-name>
+//
+//         <evpn-pfxdb-ip-table>                  ← appears once per direction
+//           <table-description>IPv4->EVPN | IPv6->EVPN</table-description>
+//           <evpn-pfxdb-ip-entry>                ← repeats per local prefix
+//             <entry-prefix>...</entry-prefix>
+//             <entry-evpn-route-status>...</entry-evpn-route-status>
+//           </evpn-pfxdb-ip-entry>
+//         </evpn-pfxdb-ip-table>
+//
+//         <evpn-pfxdb-evpn-ip-table>             ← appears once per direction
+//           <table-description>EVPN->IPv4 | EVPN->IPv6</table-description>
+//           <evpn-pfxdb-evpn-ip-entry>           ← repeats per remote prefix
+//             <entry-prefix>...</entry-prefix>
+//             <entry-etag>0</entry-etag>
+//             <evpn-pfxdb-evpn-ip-adv>           ← repeats per advertising PE
+//               <route-distinguisher>...</route-distinguisher>
+//               <adv-vni>...</adv-vni>
+//               <adv-router-mac>...</adv-router-mac>
+//               <adv-bgp-nexthop>...</adv-bgp-nexthop>
+//               <adv-ip-route-status>Accepted|Rejected</adv-ip-route-status>
+//               <adv-ip-route-error>n/a|...</adv-ip-route-error>
+//             </evpn-pfxdb-evpn-ip-adv>
+//           </evpn-pfxdb-evpn-ip-entry>
+//         </evpn-pfxdb-evpn-ip-table>
+//       </evpn-pfxdb-l3-context>
+//     </evpn-ip-prefix-database-information>
+//   </rpc-reply>
+//
+// Each L3 context emits exactly four <evpn-pfxdb-*-table> entries (two
+// local-origin, two remote-received) distinguished by <table-description>.
+
+type singleEngineResult struct {
+	XMLName  xml.Name      `xml:"rpc-reply"`
+	Contexts []pfxL3Context `xml:"evpn-ip-prefix-database-information>evpn-pfxdb-l3-context"`
+}
+
+type multiEngineResult struct {
+	XMLName xml.Name `xml:"rpc-reply"`
+	Engines struct {
+		Items []routingEngine `xml:"multi-routing-engine-item"`
+	} `xml:"multi-routing-engine-results"`
+}
+
+type routingEngine struct {
+	Name     string         `xml:"re-name"`
+	Contexts []pfxL3Context `xml:"evpn-ip-prefix-database-information>evpn-pfxdb-l3-context"`
+}
+
+type pfxL3Context struct {
+	Name           string             `xml:"context-name"`
+	LocalTables    []pfxLocalTable    `xml:"evpn-pfxdb-ip-table"`
+	RemoteTables   []pfxRemoteTable   `xml:"evpn-pfxdb-evpn-ip-table"`
+}
+
+type pfxLocalTable struct {
+	Description string         `xml:"table-description"`
+	Entries     []pfxLocalEntry `xml:"evpn-pfxdb-ip-entry"`
+}
+
+type pfxLocalEntry struct {
+	Prefix string `xml:"entry-prefix"`
+	Status string `xml:"entry-evpn-route-status"`
+}
+
+type pfxRemoteTable struct {
+	Description string           `xml:"table-description"`
+	Entries     []pfxRemoteEntry `xml:"evpn-pfxdb-evpn-ip-entry"`
+}
+
+type pfxRemoteEntry struct {
+	Prefix         string                 `xml:"entry-prefix"`
+	ETag           string                 `xml:"entry-etag"`
+	Advertisements []pfxRemoteAdvertisement `xml:"evpn-pfxdb-evpn-ip-adv"`
+}
+
+type pfxRemoteAdvertisement struct {
+	RouteDistinguisher string `xml:"route-distinguisher"`
+	VNI                string `xml:"adv-vni"`
+	RouterMAC          string `xml:"adv-router-mac"`
+	BGPNexthop         string `xml:"adv-bgp-nexthop"`
+	Status             string `xml:"adv-ip-route-status"`
+	Error              string `xml:"adv-ip-route-error"`
+}

--- a/pkg/features/evpnipprefix/rpc_test.go
+++ b/pkg/features/evpnipprefix/rpc_test.go
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+
+package evpnipprefix
+
+import "testing"
+
+const emptyResponse = `<rpc-reply>
+  <evpn-ip-prefix-database-information>
+  </evpn-ip-prefix-database-information>
+</rpc-reply>`
+
+// populated — one L3 context with all four tables present, IPv4 and IPv6,
+// mix of Accepted and Rejected advertisements. RFC 5737 / RFC 3849
+// documentation ranges throughout.
+const populated = `<rpc-reply>
+  <evpn-ip-prefix-database-information>
+    <evpn-pfxdb-l3-context>
+      <context-name>vrf-a</context-name>
+      <evpn-pfxdb-ip-table>
+        <table-description>IPv4-&gt;EVPN</table-description>
+        <evpn-pfxdb-ip-entry>
+          <entry-prefix>192.0.2.0/24</entry-prefix>
+          <entry-evpn-route-status>Created</entry-evpn-route-status>
+        </evpn-pfxdb-ip-entry>
+        <evpn-pfxdb-ip-entry>
+          <entry-prefix>198.51.100.0/24</entry-prefix>
+          <entry-evpn-route-status>Created</entry-evpn-route-status>
+        </evpn-pfxdb-ip-entry>
+        <evpn-pfxdb-ip-entry>
+          <entry-prefix>203.0.113.0/24</entry-prefix>
+          <entry-evpn-route-status>Created</entry-evpn-route-status>
+        </evpn-pfxdb-ip-entry>
+      </evpn-pfxdb-ip-table>
+      <evpn-pfxdb-ip-table>
+        <table-description>IPv6-&gt;EVPN</table-description>
+        <evpn-pfxdb-ip-entry>
+          <entry-prefix>2001:db8::/32</entry-prefix>
+          <entry-evpn-route-status>Created</entry-evpn-route-status>
+        </evpn-pfxdb-ip-entry>
+      </evpn-pfxdb-ip-table>
+      <evpn-pfxdb-evpn-ip-table>
+        <table-description>EVPN-&gt;IPv4</table-description>
+        <evpn-pfxdb-evpn-ip-entry>
+          <entry-prefix>192.0.2.0/24</entry-prefix>
+          <entry-etag>0</entry-etag>
+          <evpn-pfxdb-evpn-ip-adv>
+            <route-distinguisher>65000:1</route-distinguisher>
+            <adv-vni>10001</adv-vni>
+            <adv-router-mac>00:00:5e:00:53:01</adv-router-mac>
+            <adv-bgp-nexthop>192.0.2.1</adv-bgp-nexthop>
+            <adv-ip-route-status>Accepted</adv-ip-route-status>
+            <adv-ip-route-error>n/a</adv-ip-route-error>
+          </evpn-pfxdb-evpn-ip-adv>
+          <evpn-pfxdb-evpn-ip-adv>
+            <route-distinguisher>65000:2</route-distinguisher>
+            <adv-vni>10001</adv-vni>
+            <adv-router-mac>00:00:5e:00:53:02</adv-router-mac>
+            <adv-bgp-nexthop>192.0.2.2</adv-bgp-nexthop>
+            <adv-ip-route-status>Accepted</adv-ip-route-status>
+            <adv-ip-route-error>n/a</adv-ip-route-error>
+          </evpn-pfxdb-evpn-ip-adv>
+        </evpn-pfxdb-evpn-ip-entry>
+        <evpn-pfxdb-evpn-ip-entry>
+          <entry-prefix>203.0.113.0/24</entry-prefix>
+          <entry-etag>0</entry-etag>
+          <evpn-pfxdb-evpn-ip-adv>
+            <route-distinguisher>65000:3</route-distinguisher>
+            <adv-vni>10001</adv-vni>
+            <adv-router-mac>00:00:5e:00:53:03</adv-router-mac>
+            <adv-bgp-nexthop>192.0.2.3</adv-bgp-nexthop>
+            <adv-ip-route-status>Rejected</adv-ip-route-status>
+            <adv-ip-route-error>policy</adv-ip-route-error>
+          </evpn-pfxdb-evpn-ip-adv>
+        </evpn-pfxdb-evpn-ip-entry>
+      </evpn-pfxdb-evpn-ip-table>
+      <evpn-pfxdb-evpn-ip-table>
+        <table-description>EVPN-&gt;IPv6</table-description>
+      </evpn-pfxdb-evpn-ip-table>
+    </evpn-pfxdb-l3-context>
+  </evpn-ip-prefix-database-information>
+</rpc-reply>`
+
+const multiEngineSample = `<rpc-reply>
+  <multi-routing-engine-results>
+    <multi-routing-engine-item>
+      <re-name>fpc0</re-name>
+      <evpn-ip-prefix-database-information>
+        <evpn-pfxdb-l3-context>
+          <context-name>vrf-a</context-name>
+        </evpn-pfxdb-l3-context>
+      </evpn-ip-prefix-database-information>
+    </multi-routing-engine-item>
+    <multi-routing-engine-item>
+      <re-name>fpc1</re-name>
+      <evpn-ip-prefix-database-information>
+        <evpn-pfxdb-l3-context>
+          <context-name>vrf-b</context-name>
+        </evpn-pfxdb-l3-context>
+      </evpn-ip-prefix-database-information>
+    </multi-routing-engine-item>
+  </multi-routing-engine-results>
+</rpc-reply>`
+
+func TestParseEmpty(t *testing.T) {
+	c, err := parseContexts([]byte(emptyResponse))
+	if err != nil {
+		t.Fatalf("parseContexts: %v", err)
+	}
+	if len(c) != 0 {
+		t.Errorf("expected 0 contexts, got %d", len(c))
+	}
+}
+
+func TestParsePopulated(t *testing.T) {
+	c, err := parseContexts([]byte(populated))
+	if err != nil {
+		t.Fatalf("parseContexts: %v", err)
+	}
+	if len(c) != 1 {
+		t.Fatalf("expected 1 context, got %d", len(c))
+	}
+	ctx := c[0]
+	if ctx.Name != "vrf-a" {
+		t.Errorf("context name: got %q", ctx.Name)
+	}
+	if len(ctx.LocalTables) != 2 {
+		t.Errorf("local-tables: got %d, want 2", len(ctx.LocalTables))
+	}
+	if len(ctx.LocalTables[0].Entries) != 3 {
+		t.Errorf("IPv4 local entries: got %d, want 3", len(ctx.LocalTables[0].Entries))
+	}
+	if len(ctx.LocalTables[1].Entries) != 1 {
+		t.Errorf("IPv6 local entries: got %d, want 1", len(ctx.LocalTables[1].Entries))
+	}
+	if len(ctx.RemoteTables) != 2 {
+		t.Errorf("remote-tables: got %d, want 2", len(ctx.RemoteTables))
+	}
+	if len(ctx.RemoteTables[0].Entries) != 2 {
+		t.Errorf("IPv4 remote entries: got %d, want 2", len(ctx.RemoteTables[0].Entries))
+	}
+	if len(ctx.RemoteTables[1].Entries) != 0 {
+		t.Errorf("IPv6 remote entries: got %d, want 0", len(ctx.RemoteTables[1].Entries))
+	}
+
+	// Walk the per-PE advertisements to validate status counts.
+	accepted, rejected := 0, 0
+	for _, e := range ctx.RemoteTables[0].Entries {
+		for _, adv := range e.Advertisements {
+			switch adv.Status {
+			case "Accepted":
+				accepted++
+			case "Rejected":
+				rejected++
+			}
+		}
+	}
+	if accepted != 2 || rejected != 1 {
+		t.Errorf("advertisement statuses: got %d accepted / %d rejected, want 2/1", accepted, rejected)
+	}
+}
+
+func TestParseMultiEngine(t *testing.T) {
+	c, err := parseContexts([]byte(multiEngineSample))
+	if err != nil {
+		t.Fatalf("parseContexts: %v", err)
+	}
+	if len(c) != 2 {
+		t.Fatalf("expected 2 merged contexts, got %d", len(c))
+	}
+	names := map[string]bool{"vrf-a": false, "vrf-b": false}
+	for _, ctx := range c {
+		if _, ok := names[ctx.Name]; ok {
+			names[ctx.Name] = true
+		} else {
+			t.Errorf("unexpected context name %q", ctx.Name)
+		}
+	}
+	for n, seen := range names {
+		if !seen {
+			t.Errorf("expected to see context %q", n)
+		}
+	}
+}
+
+func TestAfiFromDescription(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"IPv4->EVPN", "v4"},
+		{"IPv6->EVPN", "v6"},
+		{"EVPN->IPv4", "v4"},
+		{"EVPN->IPv6", "v6"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := afiFromDescription(c.in)
+		if got != c.want {
+			t.Errorf("afiFromDescription(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
  Adds two new collectors that together fill the EVPN-EVI / EVPN-VXLAN coverage gap. The existing `l2vpn` / `l2circuit` / `vpws` collectors cover different services (RFC
  4761 Kompella BGP L2VPN, Martini circuits, and EVPN-VPWS pseudowires respectively), none of which expose EVPN-EVI state.

This single PR delivers a complete-but-toggleable surface so operators can start monitoring EVPN with a
  single flag, while keeping the one potentially-large RPC behind its own flag.

  ### Design at a glance

  | Flag | RPCs called | What it gives you |
  |---|---|---|
  | `-evpn.enabled` (default `false`) | `show evpn instance extensive`<br>`show evpn database state duplicate`<br>`show evpn l3-context` | Per-EVI state, per-PE route counts
   (Type-1/2/3/4), detail tables (per-interface, per-IRB, per-bridge-domain, per-ESI with DF election), duplicate-MAC alert signal, L3 contexts |
  | `-evpn_ip_prefix.enabled` (default `false`) | `show evpn ip-prefix-database` | Per-context per-AFI Type-5 prefix counts and accepted/rejected advertisement counts |

  The two flags exist because the `ip-prefix-database` response scales with prefix population on busy DC fabrics, while the rest of the EVPN data scales with EVI / ESI count
   (bounded by topology, not by traffic). Operators with very large Type-5 deployments can leave `evpn_ip_prefix` off and re-enable per device.

  The three RPCs under `-evpn.enabled` are dispatched as **one required + two best-effort**: the instance RPC failure aborts the scrape, the other two log a warning and
  continue. This means a device that doesn't support the L3-context query (older Junos, non-IRB EVPN) still produces all the other EVPN metrics.

  ### Metrics — `-evpn.enabled`

  **Per-EVI scalars** (`show evpn instance extensive`):

  | Metric | Labels |
  |---|---|
  | `junos_evpn_instance_info` | `instance, rd, encap, router_id, source_vtep` |
  | `junos_evpn_instance_neighbor_count` | `instance` |
  | `junos_evpn_instance_esi_count` | `instance` |
  | `junos_evpn_instance_local_interfaces` / `_local_interfaces_up` | `instance` |
  | `junos_evpn_instance_irb_interfaces` / `_irb_interfaces_up` | `instance` |
  | `junos_evpn_instance_protect_interfaces` | `instance` |
  | `junos_evpn_instance_bridge_domains` | `instance` |
  | `junos_evpn_instance_local_mac_count` / `_remote_mac_count` | `instance` |
  | `junos_evpn_instance_local_mac_ip_count` / `_remote_mac_ip_count` | `instance` |
  | `junos_evpn_instance_local_default_gateway_mac_count` / `_remote_default_gateway_mac_count` | `instance` |
  | `junos_evpn_instance_duplicate_mac_threshold` / `_duplicate_mac_window_seconds` | `instance` |

  **Per-neighbor route counts** (Types 1–4):

  | Metric | Labels |
  |---|---|
  | `junos_evpn_neighbor_mac_routes` | `instance, neighbor` |
  | `junos_evpn_neighbor_mac_ip_routes` | `instance, neighbor` |
  | `junos_evpn_neighbor_ethernet_autodiscovery_routes` | `instance, neighbor` |
  | `junos_evpn_neighbor_inclusive_multicast_routes` | `instance, neighbor` |
  | `junos_evpn_neighbor_ethernet_segment_routes` | `instance, neighbor` |

  **Detail tables** (parsed from the same `show evpn instance extensive` response — no extra RPC):

  | Metric | Labels | Notes |
  |---|---|---|
  | `junos_evpn_interface_status` | `instance, interface, esi, mode, etree_role` | 0 = Down, 1 = Up |
  | `junos_evpn_irb_status` | `instance, irb_interface, vni_id, l3_context` | 0 = Down, 1 = Up |
  | `junos_evpn_bridge_domain_interface_count` | `instance, vlan_id, domain_id, irb_interface, mode, mac_sync` | |
  | `junos_evpn_bridge_domain_interface_up_count` | same labels | |
  | `junos_evpn_esi_resolved` | `instance, esi` | 0 = unresolved, 1 = resolved |
  | `junos_evpn_esi_remote_pe_count` | `instance, esi` | |
  | `junos_evpn_esi_designated_forwarder_info` | `instance, esi, designated_forwarder, backup_forwarder, df_algorithm, local_interface` | gauge=1, info-pattern — see *ESI
  label split* below |

  **Duplicate-MAC** (`show evpn database state duplicate` — the only EVPN error signal that needs its own RPC):

  | Metric | Labels | Behaviour |
  |---|---|---|
  | `junos_evpn_duplicate_mac_total` | (target only) | Always emitted; `> 0` indicates a forwarding loop or split-brain |
  | `junos_evpn_duplicate_mac_count` | `instance` | Emitted only for EVIs with non-zero count |

  **L3 contexts** (`show evpn l3-context`):

  | Metric | Labels |
  |---|---|
  | `junos_evpn_l3_context_vni` | `context, type, advertisement_mode, router_mac, encapsulation` |
  | `junos_evpn_l3_context_count` | (target only) |

  ### Metrics — `-evpn_ip_prefix.enabled`

  `show evpn ip-prefix-database`. Per-prefix series are deliberately **not** emitted (cardinality on busy fabrics would be untenable); the collector aggregates per L3
  context × AFI × status.

  | Metric | Labels |
  |---|---|
  | `junos_evpn_ip_prefix_local_count` | `context, afi` (`v4` / `v6`) |
  | `junos_evpn_ip_prefix_remote_count` | `context, afi` |
  | `junos_evpn_ip_prefix_advertisement_count` | `context, afi, status` (`accepted`, `rejected`, …) |

  ### ESI label split (intentional design)

  `junos_evpn_esi_resolved` exposes only stable labels (`instance, esi`). The metadata that changes at runtime — `designated_forwarder`, `backup_forwarder`, `df_algorithm`,
  `local_interface` — lives on a separate gauge=1 `junos_evpn_esi_designated_forwarder_info` series. This follows the `node_exporter` info-pattern (`node_uname_info`, etc.)
  and means:

  - Alert queries (`junos_evpn_esi_resolved == 0`) have **stable series identity** across DF-election events.
  - DF rotations create new series on `_designated_forwarder_info` (intentional churn there), which lets operators detect DF instability with `changes()`.
  - Grafana dashboards join the two for combined views:

  ```promql
  junos_evpn_esi_resolved
    * on(target, instance, esi)
      group_left(designated_forwarder, backup_forwarder, local_interface)
        junos_evpn_esi_designated_forwarder_info
  ```

  The earlier version of this PR carried the DF labels on the state metric directly; we found in review that every DF rotation created a new time-series identity while the
  previous one went stale (TSDB churn + broken aggregations across rotations). Commit message `65bce0f` has the full reasoning.

  ### Response-shape handling

  Both new packages implement the multi-RE / Virtual Chassis dispatch pattern used by `pkg/features/alarm`, `pkg/features/ufd`, and now four EVPN parsers. Substring check on
   `<multi-routing-engine-results`; if present, the body is unmarshaled into the multi-RE struct and per-RE entries are merged. `re-name` is intentionally not exposed as a
  label (matches the `alarm` / `ufd` precedent — EVPN config is synced across VC members, so the per-RE distinction is not operationally meaningful for these metrics).

  ### Tests

  Synthetic XML fixtures only — no production data in the repo. All identifiers use RFC 5737 / RFC 3849 documentation ranges, IANA documentation MAC range
  (`00:00:5E:00:53:xx`), synthetic ESI hex (`01:23:45:00:00:00:00:00:00:01`), and placeholder names (`EVI-A`, `vrf-a`, …).

  Coverage:

  ```
  === RUN   TestParseSingleEVI               (evpn)
  === RUN   TestParseMultiEVIMixed           (evpn)
  === RUN   TestParseMultiEngine             (evpn)
  === RUN   TestParseDetailTables            (evpn)
  === RUN   TestParseDuplicateMACsEmpty      (evpn)
  === RUN   TestParseDuplicateMACsPopulated  (evpn)
  === RUN   TestParseL3ContextsEmpty         (evpn)
  === RUN   TestParseL3ContextsPopulated     (evpn)
  === RUN   TestParseEmpty                   (evpn_ip_prefix)
  === RUN   TestParsePopulated               (evpn_ip_prefix)
  === RUN   TestParseMultiEngine             (evpn_ip_prefix)
  === RUN   TestAfiFromDescription           (evpn_ip_prefix)
  PASS
  ```

  ### Verified against

  Two production EX-class devices running Junos 23.4R2 family; one with three EVIs (single-RE), one with two EVIs and 16 ESIs in all-active multihoming. Validated each
  metric value against the corresponding XML field — example cross-check on the busier device:

  | Metric | XML field | Both values |
  |---|---|---|
  | `instance_local_mac_count{instance="<EVI>"}` | `<local-macs>` | 100 |
  | `instance_remote_mac_count{instance="<EVI>"}` | `<remote-macs>` | 6 |
  | `neighbor_mac_routes{neighbor="…"}` | `<evpn-num-mac-routes>` | 6 |
  | `neighbor_ethernet_autodiscovery_routes{…}` | `<evpn-num-ethernet-autodiscovery-routes>` | 4 |
  | `interface_status{interface="ae102.0",mode="all-active"}` | `<evpn-interface-status>Up</…>` | 1 |
  | `esi_resolved{esi="01:00:20:…:66:00"}` | `<evpn-esi-status>Resolved by IFL ae102.0</…>` | 1 |
  | `ip_prefix_local_count{afi="v4"}` | count of `<evpn-pfxdb-ip-entry>` in IPv4→EVPN table | 5 |
  | `ip_prefix_advertisement_count{afi="v4",status="accepted"}` | count of `<evpn-pfxdb-evpn-ip-adv>` with `Accepted` status | 34 |

  Scrape latency on the busier device: ~0.95 s for `evpn`, ~0.24 s for `evpn_ip_prefix`. Well within a 30-second scrape interval.

  ### Wiring

  - `collectors.go` — two new imports + two registrations
  - `internal/config/config.go` — `EVPN` and `EVPNIPPrefix` fields on `FeatureConfig`, defaults `false`
  - `main.go` — `-evpn.enabled` and `-evpn_ip_prefix.enabled` flags + bindings
  - `README.md` — entries in the Features list, a state-mapping section, an annotated per-device example, and a `### Enriching other collectors via PromQL join` note showing
   the `group_left` pattern for picking up dynamic-interface-labels on EVPN metrics

  All wiring inserts are in alphabetical positions to keep three-way merges trivial.

  ### Example alert rules

  ```yaml
  groups:
  - name: evpn
    rules:
    - alert: EVPNDuplicateMAC
      expr: junos_evpn_duplicate_mac_total > 0
      for: 1m
      annotations:
        summary: "EVPN duplicate-MAC suppression active on {{ $labels.target }} — likely forwarding loop or split-brain"

    - alert: EVPNESIUnresolved
      expr: junos_evpn_esi_resolved == 0
      for: 2m
      annotations:
        summary: "EVPN ESI {{ $labels.esi }} unresolved on {{ $labels.target }} ({{ $labels.instance }})"

    - alert: EVPNInterfaceDown
      expr: junos_evpn_interface_status == 0
      for: 1m

    - alert: EVPNIRBDown
      expr: junos_evpn_irb_status == 0
      for: 1m

    - alert: EVPNType5Rejected
      expr: junos_evpn_ip_prefix_advertisement_count{status="rejected"} > 0
      for: 5m

    - alert: EVPNDFElectionFlapping
      expr: |
        changes(
          count by (target, instance, esi) (
            junos_evpn_esi_designated_forwarder_info
          )[15m:30s]
        ) > 3
  ```
  
  
  
  This was implemented with the help of https://claude.ai