### PR TITLE
ssh: source key passphrase from env var or file

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,23 @@ junos_exporter supports SSH authentication via key or password based authenticat
 Authentication order is ssh key, if none is found the cli flag is checked, the config file is checked last. If no valid auth method is specified junos_exporter exits with an error.
 Specify the ssh username with the cli flag `-ssh.user`, with the `username` key under the configuration file or use the default username of `junos_exporter`.
 
+#### SSH key passphrase
+
+If the SSH key is encrypted, its passphrase can be provided from one of
+three mutually-exclusive sources:
+
+- `-ssh.keyPassphrase=<string>` — literal value. Avoid for production use:
+  the passphrase appears in `ps` output and shell history.
+- `-ssh.keyPassphraseEnv=<NAME>` — read from environment variable `NAME`.
+  The variable must be set and non-empty at startup.
+- `-ssh.keyPassphraseFile=<PATH>` — read from a file (a single trailing
+  newline is trimmed). Suitable for use with systemd `LoadCredential=`
+  or Kubernetes secrets.
+
+Setting more than one of these flags is a configuration error and the
+exporter exits at startup. Only the global flag is affected; the
+per-device `key_passphrase` field in the YAML config is unchanged.
+
 ### Target Parameter
 By default, all configured targets will be scrapped when `/metrics` is hit. As an alternative, it is possible to scrape a specific target by passing the target's hostname/IP address to the target parameter - e.g. ` http://localhost:9326/metrics?target=1.2.3.4`. The specific target must be present in the configuration file or passed in with the ssh.targets flag, you can also specify the `-config.ignore-targets` flag if you don't want to specify targets in the config or commandline, if none of this matches the request will be denied. This can be used with the below example Prometheus config:
 

--- a/README.md
+++ b/README.md
@@ -157,22 +157,30 @@ junos_exporter supports SSH authentication via key or password based authenticat
 Authentication order is ssh key, if none is found the cli flag is checked, the config file is checked last. If no valid auth method is specified junos_exporter exits with an error.
 Specify the ssh username with the cli flag `-ssh.user`, with the `username` key under the configuration file or use the default username of `junos_exporter`.
 
-#### SSH key passphrase
+#### SSH key passphrase and password
 
-If the SSH key is encrypted, its passphrase can be provided from one of
-three mutually-exclusive sources:
+Both the SSH key passphrase and the SSH password can be supplied from any
+one of three mutually-exclusive sources -- a literal flag value, the
+contents of an environment variable, or the contents of a file:
 
-- `-ssh.keyPassphrase=<string>` — literal value. Avoid for production use:
-  the passphrase appears in `ps` output and shell history.
-- `-ssh.keyPassphraseEnv=<NAME>` — read from environment variable `NAME`.
-  The variable must be set and non-empty at startup.
-- `-ssh.keyPassphraseFile=<PATH>` — read from a file (a single trailing
-  newline is trimmed). Suitable for use with systemd `LoadCredential=`
-  or Kubernetes secrets.
+| Secret | Literal | Environment variable | File |
+|---|---|---|---|
+| Key passphrase | `-ssh.keyPassphrase=<string>` | `-ssh.keyPassphraseEnv=<NAME>` | `-ssh.keyPassphraseFile=<PATH>` |
+| Password       | `-ssh.password=<string>`      | `-ssh.passwordEnv=<NAME>`      | `-ssh.passwordFile=<PATH>`      |
 
-Setting more than one of these flags is a configuration error and the
-exporter exits at startup. Only the global flag is affected; the
-per-device `key_passphrase` field in the YAML config is unchanged.
+- The literal forms (`-ssh.keyPassphrase` / `-ssh.password`) are convenient
+  but the value appears in `ps` output and shell history -- avoid for
+  production.
+- The `*Env` flags read from the named environment variable. The variable
+  must exist and be non-empty at startup, otherwise the exporter exits.
+- The `*File` flags read from the given path; a single trailing newline is
+  trimmed. Suitable for systemd `LoadCredential=`, Docker secrets and
+  Kubernetes secrets.
+
+Within each group (passphrase, password) setting more than one source is a
+configuration error and the exporter exits at startup with a clear message.
+Only the global flags are affected; the per-device `key_passphrase` and
+`password` fields in the YAML config are unchanged.
 
 ### Target Parameter
 By default, all configured targets will be scrapped when `/metrics` is hit. As an alternative, it is possible to scrape a specific target by passing the target's hostname/IP address to the target parameter - e.g. ` http://localhost:9326/metrics?target=1.2.3.4`. The specific target must be present in the configuration file or passed in with the ssh.targets flag, you can also specify the `-config.ignore-targets` flag if you don't want to specify targets in the config or commandline, if none of this matches the request will be denied. This can be used with the below example Prometheus config:

--- a/main.go
+++ b/main.go
@@ -37,7 +37,9 @@ var (
 	sshKeyPassphrase            = flag.String("ssh.keyPassphrase", "", "Passphrase to decrypt key file if it's encrypted (mutually exclusive with -ssh.keyPassphraseEnv and -ssh.keyPassphraseFile)")
 	sshKeyPassphraseEnv         = flag.String("ssh.keyPassphraseEnv", "", "Name of an environment variable to read the SSH key passphrase from")
 	sshKeyPassphraseFile        = flag.String("ssh.keyPassphraseFile", "", "Path to a file containing the SSH key passphrase (trailing newline trimmed)")
-	sshPassword                 = flag.String("ssh.password", "", "Password to use when connecting to junos devices using ssh")
+	sshPassword                 = flag.String("ssh.password", "", "Password to use when connecting to junos devices using ssh (mutually exclusive with -ssh.passwordEnv and -ssh.passwordFile)")
+	sshPasswordEnv              = flag.String("ssh.passwordEnv", "", "Name of an environment variable to read the SSH password from")
+	sshPasswordFile             = flag.String("ssh.passwordFile", "", "Path to a file containing the SSH password (trailing newline trimmed)")
 	sshReconnectInterval        = flag.Duration("ssh.reconnect-interval", 30*time.Second, "Duration to wait before reconnecting to a device after connection got lost")
 	sshKeepAliveInterval        = flag.Duration("ssh.keep-alive-interval", 10*time.Second, "Duration to wait between keep alive messages")
 	sshKeepAliveTimeout         = flag.Duration("ssh.keep-alive-timeout", 15*time.Second, "Duration to wait for keep alive message response")
@@ -125,8 +127,8 @@ func main() {
 		os.Exit(0)
 	}
 
-	if err := resolveKeyPassphrase(); err != nil {
-		log.Fatalf("could not resolve ssh key passphrase: %v", err)
+	if err := resolveSSHSecrets(); err != nil {
+		log.Fatalf("could not resolve ssh credentials: %v", err)
 	}
 
 	err := initialize()
@@ -223,40 +225,59 @@ func reinitialize() error {
 	return initialize()
 }
 
-// resolveKeyPassphrase materialises *sshKeyPassphrase from one of three
-// mutually-exclusive sources: the literal -ssh.keyPassphrase flag, the
-// environment variable named by -ssh.keyPassphraseEnv, or the file at
-// -ssh.keyPassphraseFile. Setting more than one is a configuration error.
-func resolveKeyPassphrase() error {
+// resolveSSHSecrets materialises both *sshKeyPassphrase and *sshPassword from
+// their respective literal flag / environment variable / file sources. Within
+// each group, the three sources are mutually exclusive.
+func resolveSSHSecrets() error {
+	if err := resolveSecretFromSources(
+		sshKeyPassphrase, sshKeyPassphraseEnv, sshKeyPassphraseFile,
+		"-ssh.keyPassphrase", "-ssh.keyPassphraseEnv", "-ssh.keyPassphraseFile",
+	); err != nil {
+		return fmt.Errorf("ssh key passphrase: %w", err)
+	}
+	if err := resolveSecretFromSources(
+		sshPassword, sshPasswordEnv, sshPasswordFile,
+		"-ssh.password", "-ssh.passwordEnv", "-ssh.passwordFile",
+	); err != nil {
+		return fmt.Errorf("ssh password: %w", err)
+	}
+	return nil
+}
+
+// resolveSecretFromSources reads a secret from one of three mutually-exclusive
+// sources -- a literal flag, an environment variable named by another flag, or
+// a file path named by a third flag -- and writes the resolved value back into
+// *literal so downstream code can keep reading the same pointer.
+func resolveSecretFromSources(literal, envName, filePath *string, literalFlag, envFlag, fileFlag string) error {
 	set := 0
-	if *sshKeyPassphrase != "" {
+	if *literal != "" {
 		set++
 	}
-	if *sshKeyPassphraseEnv != "" {
+	if *envName != "" {
 		set++
 	}
-	if *sshKeyPassphraseFile != "" {
+	if *filePath != "" {
 		set++
 	}
 	if set > 1 {
-		return fmt.Errorf("-ssh.keyPassphrase, -ssh.keyPassphraseEnv and -ssh.keyPassphraseFile are mutually exclusive; set at most one")
+		return fmt.Errorf("%s, %s and %s are mutually exclusive; set at most one", literalFlag, envFlag, fileFlag)
 	}
 
-	if *sshKeyPassphraseEnv != "" {
-		v := os.Getenv(*sshKeyPassphraseEnv)
+	if *envName != "" {
+		v := os.Getenv(*envName)
 		if v == "" {
-			return fmt.Errorf("environment variable %q referenced by -ssh.keyPassphraseEnv is empty or unset", *sshKeyPassphraseEnv)
+			return fmt.Errorf("environment variable %q referenced by %s is empty or unset", *envName, envFlag)
 		}
-		*sshKeyPassphrase = v
+		*literal = v
 		return nil
 	}
 
-	if *sshKeyPassphraseFile != "" {
-		b, err := os.ReadFile(*sshKeyPassphraseFile)
+	if *filePath != "" {
+		b, err := os.ReadFile(*filePath)
 		if err != nil {
-			return fmt.Errorf("could not read -ssh.keyPassphraseFile %q: %w", *sshKeyPassphraseFile, err)
+			return fmt.Errorf("could not read %s %q: %w", fileFlag, *filePath, err)
 		}
-		*sshKeyPassphrase = strings.TrimRight(string(b), "\r\n")
+		*literal = strings.TrimRight(string(b), "\r\n")
 		return nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -34,7 +34,9 @@ var (
 	sshHosts                    = flag.String("ssh.targets", "", "Hosts to scrape")
 	sshUsername                 = flag.String("ssh.user", "junos_exporter", "Username to use when connecting to junos devices using ssh")
 	sshKeyFile                  = flag.String("ssh.keyfile", "", "Public key file to use when connecting to junos devices using ssh")
-	sshKeyPassphrase            = flag.String("ssh.keyPassphrase", "", "Passphrase to decrypt key file if it's encrypted")
+	sshKeyPassphrase            = flag.String("ssh.keyPassphrase", "", "Passphrase to decrypt key file if it's encrypted (mutually exclusive with -ssh.keyPassphraseEnv and -ssh.keyPassphraseFile)")
+	sshKeyPassphraseEnv         = flag.String("ssh.keyPassphraseEnv", "", "Name of an environment variable to read the SSH key passphrase from")
+	sshKeyPassphraseFile        = flag.String("ssh.keyPassphraseFile", "", "Path to a file containing the SSH key passphrase (trailing newline trimmed)")
 	sshPassword                 = flag.String("ssh.password", "", "Password to use when connecting to junos devices using ssh")
 	sshReconnectInterval        = flag.Duration("ssh.reconnect-interval", 30*time.Second, "Duration to wait before reconnecting to a device after connection got lost")
 	sshKeepAliveInterval        = flag.Duration("ssh.keep-alive-interval", 10*time.Second, "Duration to wait between keep alive messages")
@@ -121,6 +123,10 @@ func main() {
 	if *showVersion {
 		printVersion()
 		os.Exit(0)
+	}
+
+	if err := resolveKeyPassphrase(); err != nil {
+		log.Fatalf("could not resolve ssh key passphrase: %v", err)
 	}
 
 	err := initialize()
@@ -215,6 +221,46 @@ func reinitialize() error {
 	}
 
 	return initialize()
+}
+
+// resolveKeyPassphrase materialises *sshKeyPassphrase from one of three
+// mutually-exclusive sources: the literal -ssh.keyPassphrase flag, the
+// environment variable named by -ssh.keyPassphraseEnv, or the file at
+// -ssh.keyPassphraseFile. Setting more than one is a configuration error.
+func resolveKeyPassphrase() error {
+	set := 0
+	if *sshKeyPassphrase != "" {
+		set++
+	}
+	if *sshKeyPassphraseEnv != "" {
+		set++
+	}
+	if *sshKeyPassphraseFile != "" {
+		set++
+	}
+	if set > 1 {
+		return fmt.Errorf("-ssh.keyPassphrase, -ssh.keyPassphraseEnv and -ssh.keyPassphraseFile are mutually exclusive; set at most one")
+	}
+
+	if *sshKeyPassphraseEnv != "" {
+		v := os.Getenv(*sshKeyPassphraseEnv)
+		if v == "" {
+			return fmt.Errorf("environment variable %q referenced by -ssh.keyPassphraseEnv is empty or unset", *sshKeyPassphraseEnv)
+		}
+		*sshKeyPassphrase = v
+		return nil
+	}
+
+	if *sshKeyPassphraseFile != "" {
+		b, err := os.ReadFile(*sshKeyPassphraseFile)
+		if err != nil {
+			return fmt.Errorf("could not read -ssh.keyPassphraseFile %q: %w", *sshKeyPassphraseFile, err)
+		}
+		*sshKeyPassphrase = strings.TrimRight(string(b), "\r\n")
+		return nil
+	}
+
+	return nil
 }
 
 func loadConfig() (*config.Config, error) {


### PR DESCRIPTION
Adds two new flags so the SSH private-key passphrase no longer has to be passed on the command line where it would leak into ps output and shell history:

  -ssh.keyPassphraseEnv=<NAME>   read from environment variable NAME
  -ssh.keyPassphraseFile=<PATH>  read from file (trailing newline trimmed)

These plus the existing -ssh.keyPassphrase are mutually exclusive; the exporter exits at startup with a clear error if more than one is set, if the named environment variable is empty/unset, or if the file cannot be read.

The resolver overwrites *sshKeyPassphrase, so devices.go and the connector keep reading the same variable -- no plumbing changes.

The per-device key_passphrase field in the YAML config is unchanged and remains the place to configure per-device passphrases.