### PR TITLE
 fix: use configured interface speed (if-speed-cfg) instead of hardware speed

### DIFF
--- a/pkg/features/interfaces/collector.go
+++ b/pkg/features/interfaces/collector.go
@@ -210,6 +210,7 @@ func (c *interfaceCollector) interfaceStats(client collector.Client) ([]*interfa
 			ReceiveBytes:            float64(phy.Stats.InputBytes),
 			ReceivePackets:          float64(phy.Stats.InputPackets),
 			Speed:                   phy.Speed,
+			IfSpeedCfg:              phy.IfSpeedCfg,
 			BPDUError:               phy.BPDUError == "detected",
 			TransmitDrops:           float64(phy.OutputErrors.Drops),
 			TransmitErrors:          float64(phy.OutputErrors.Errors),
@@ -307,32 +308,7 @@ func (c *interfaceCollector) collectForInterface(s *interfaceStats, ch chan<- pr
 			err = 1
 		}
 
-		speed := "0"
-		if strings.Contains(strings.ToLower(s.Speed), "mbps") {
-			speed = strings.Replace(strings.ToLower(s.Speed), "mbps", "000000", 1)
-		}
-		if strings.Contains(s.Speed, "Gbps") {
-			speed = strings.Replace(s.Speed, "Gbps", "000000000", 1)
-		}
-		if strings.Contains(s.Speed, "Auto") || strings.Contains(s.Speed, "Unspecified") {
-			//some cards have just 'Auto' as speed, let's check if it's Gigabit
-			if strings.Contains(s.Name, "ge-") {
-				speed = "1000000000"
-			} else if strings.Contains(s.Name, "xe-") {
-				speed = "10000000000"
-			} else {
-				speed = strings.Replace(s.Speed, "Auto", "0", 1)
-				speed = strings.Replace(speed, "Unspecified", "0", 1)
-			}
-		}
-		if strings.Contains(s.Speed, "Unlimited") {
-			speed = strings.Replace(s.Speed, "Unlimited", "0", 1)
-		}
-
-		// Trimming all white spaces in the entire string
-		speed = strings.ReplaceAll(speed, " ", "")
-
-		sp64, _ := strconv.ParseFloat(speed, 64)
+		sp64 := interfaceSpeedBPS(s)
 
 		if s.BPDUError {
 			ch <- prometheus.MustNewConstMetric(d.interfaceBPDUErrorDesc, prometheus.GaugeValue, float64(1), lv...)
@@ -379,6 +355,57 @@ func (c *interfaceCollector) collectForInterface(s *interfaceStats, ch chan<- pr
 		ch <- prometheus.MustNewConstMetric(d.fecModeDesc, prometheus.CounterValue, s.FECMode, lv...)
 
 	}
+}
+
+// interfaceSpeedBPS returns the interface speed in bits per second. It prefers
+// the configured speed (if-speed-cfg) over the hardware "speed", which reports
+// the port's physical capability (e.g. 10Gbps on an MX204 port configured to
+// 1G). Speeds that don't denote a fixed rate (Auto, Unspecified, Unlimited)
+// fall back to the interface naming convention or 0.
+func interfaceSpeedBPS(s *interfaceStats) float64 {
+	// Match case-insensitively; lowercase everything up front.
+	effectiveSpeed := strings.ToLower(s.Speed)
+
+	// if-speed-cfg uses a compact form ("1g", "100m"); normalize it to the
+	// hardware format ("1gbps", "100mbps") so the same parsing applies.
+	if cfg := strings.ToLower(s.IfSpeedCfg); cfg != "" && !strings.Contains(cfg, "auto") {
+		effectiveSpeed = strings.Replace(cfg, "g", "gbps", 1)
+		effectiveSpeed = strings.Replace(effectiveSpeed, "m", "mbps", 1)
+	}
+
+	switch {
+	case strings.Contains(effectiveSpeed, "mbps"):
+		return speedWithUnitToBPS(effectiveSpeed, "mbps", 1e6)
+	case strings.Contains(effectiveSpeed, "gbps"):
+		return speedWithUnitToBPS(effectiveSpeed, "gbps", 1e9)
+	case strings.Contains(effectiveSpeed, "auto"), strings.Contains(effectiveSpeed, "unspecified"):
+		// some cards have just 'Auto' as speed, let's check if it's Gigabit
+		if strings.Contains(s.Name, "ge-") {
+			return 1e9
+		}
+		if strings.Contains(s.Name, "xe-") {
+			return 10e9
+		}
+		return 0
+	default:
+		// includes "Unlimited" and any unrecognized value
+		return 0
+	}
+}
+
+// speedWithUnitToBPS strips the unit (e.g. "Gbps") from a speed string, parses
+// the remaining number and multiplies it by factor to get a bits-per-second
+// value. It returns 0 when the number can't be parsed. Multiplying (rather than
+// appending zeros) keeps fractional speeds such as "2.5Gbps" correct.
+func speedWithUnitToBPS(speed, unit string, factor float64) float64 {
+	number := strings.ReplaceAll(strings.Replace(speed, unit, "", 1), " ", "")
+
+	value, err := strconv.ParseFloat(number, 64)
+	if err != nil {
+		return 0
+	}
+
+	return value * factor
 }
 
 func convertFECModeToFloat64(s string) float64 {

--- a/pkg/features/interfaces/collector_test.go
+++ b/pkg/features/interfaces/collector_test.go
@@ -69,3 +69,141 @@ func TestInterfaceCollectorCommand(t *testing.T) {
 		})
 	}
 }
+
+func TestInterfaceSpeed(t *testing.T) {
+	tests := []struct {
+		name       string
+		speed      string
+		ifSpeedCfg string
+		ifName     string
+		expected   float64
+	}{
+		{
+			name:       "configured 1G overrides 10G hardware speed",
+			speed:      "10Gbps",
+			ifSpeedCfg: "1G",
+			ifName:     "xe-0/1/5",
+			expected:   1e9,
+		},
+		{
+			name:       "configured 100M",
+			speed:      "1Gbps",
+			ifSpeedCfg: "100M",
+			ifName:     "ge-0/0/0",
+			expected:   100e6,
+		},
+		{
+			name:       "configured lowercase 1g",
+			speed:      "10Gbps",
+			ifSpeedCfg: "1g",
+			ifName:     "xe-0/1/5",
+			expected:   1e9,
+		},
+		{
+			name:       "configured 40G",
+			speed:      "40Gbps",
+			ifSpeedCfg: "40G",
+			ifName:     "et-0/0/0",
+			expected:   40e9,
+		},
+		{
+			name:       "configured fractional 2.5G",
+			speed:      "10Gbps",
+			ifSpeedCfg: "2.5G",
+			ifName:     "ge-0/0/0",
+			expected:   2.5e9,
+		},
+		{
+			name:       "configured Auto falls back to hardware speed",
+			speed:      "10Gbps",
+			ifSpeedCfg: "Auto",
+			ifName:     "xe-0/1/5",
+			expected:   10e9,
+		},
+		{
+			name:       "configured AUTO (uppercase) falls back to hardware speed",
+			speed:      "10Gbps",
+			ifSpeedCfg: "AUTO",
+			ifName:     "xe-0/1/5",
+			expected:   10e9,
+		},
+		{
+			name:       "no configured speed uses hardware speed",
+			speed:      "1Gbps",
+			ifSpeedCfg: "",
+			ifName:     "ge-0/0/0",
+			expected:   1e9,
+		},
+		{
+			name:       "hardware speed in mbps",
+			speed:      "1000mbps",
+			ifSpeedCfg: "",
+			ifName:     "ge-0/0/0",
+			expected:   1e9,
+		},
+		{
+			name:       "hardware speed with uppercase Mbps",
+			speed:      "100Mbps",
+			ifSpeedCfg: "",
+			ifName:     "ge-0/0/0",
+			expected:   100e6,
+		},
+		{
+			name:       "hardware speed with uppercase GBPS",
+			speed:      "10GBPS",
+			ifSpeedCfg: "",
+			ifName:     "xe-0/0/0",
+			expected:   10e9,
+		},
+		{
+			name:       "Auto on a non ge/xe interface yields 0",
+			speed:      "Auto",
+			ifSpeedCfg: "",
+			ifName:     "et-0/0/0",
+			expected:   0,
+		},
+		{
+			name:       "Unspecified on a ge interface yields 1G",
+			speed:      "Unspecified",
+			ifSpeedCfg: "",
+			ifName:     "ge-0/0/0",
+			expected:   1e9,
+		},
+		{
+			name:       "Unlimited yields 0",
+			speed:      "Unlimited",
+			ifSpeedCfg: "",
+			ifName:     "lo0",
+			expected:   0,
+		},
+		{
+			name:       "configured 400G",
+			speed:      "100Gbps",
+			ifSpeedCfg: "400G",
+			ifName:     "et-0/0/0",
+			expected:   4e11,
+		},
+		{
+			name:       "unrecognized value yields 0",
+			speed:      "bogus",
+			ifSpeedCfg: "",
+			ifName:     "ge-0/0/0",
+			expected:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &interfaceStats{
+				IsPhysical: true,
+				Name:       tt.ifName,
+				Speed:      tt.speed,
+				IfSpeedCfg: tt.ifSpeedCfg,
+			}
+
+			if got := interfaceSpeedBPS(s); got != tt.expected {
+				t.Errorf("interfaceSpeedBPS() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/features/interfaces/interface_stats.go
+++ b/pkg/features/interfaces/interface_stats.go
@@ -11,6 +11,7 @@ type interfaceStats struct {
 	Mac                     string
 	IsPhysical              bool
 	Speed                   string
+	IfSpeedCfg              string
 	BPDUError               bool
 	ReceiveBytes            float64
 	ReceivePackets          float64

--- a/pkg/features/interfaces/rpc.go
+++ b/pkg/features/interfaces/rpc.go
@@ -15,6 +15,7 @@ type phyInterface struct {
 	Description       string         `xml:"description"`
 	MacAddress        string         `xml:"current-physical-address"`
 	Speed             string         `xml:"speed"`
+	IfSpeedCfg        string         `xml:"if-speed-cfg"`
 	BPDUError         string         `xml:"bpdu-error"`
 	Stats             trafficStat    `xml:"traffic-statistics"`
 	LogicalInterfaces []logInterface `xml:"logical-interface"`


### PR DESCRIPTION
On some routers an interface can be configured to run slower than what the
hardware actually supports. For example on an MX204 a 10G port can be limited
to 1G with `speed 1g`. In that case junos still reports 10Gbps in the `speed`
field and only shows the real configured value in `if-speed-cfg`:

```
<speed>10Gbps</speed>
<if-speed-cfg>1G</if-speed-cfg>
```
          
Currently, this breaks saturation/utilization alerting because
the speed is off by factor 10 e.g..

Added tests for the different cases.