### PR TITLE
Add interface if_index labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,15 @@ junos_evpn_interface_status
 ```
 This requires the `interfaces` collector to be enabled (the default).
 
+## Interface Index Label
+Interface, interface queue, and interface diagnostics metrics include an `if_index` label when the Junos RPC response provides one. This is the device-local SNMP IF-MIB `ifIndex` for the interface. In Grafana table panels, convert it to a numeric field when numeric ordering is required.
+
+Example:
+```
+name="ae10", if_index="524"
+name="xe-0/0/10.0", if_index="621"
+```
+
 ### Custom Label RegEx
 
 To override the default behavior a `interface_description_regex` can be supplied. This parameter can be given at a global level or per device. To use per-device regexes the target devices need to be defined in the exporter config. Per-device regex cannot be used in combination with `-config.ignore-targets`.

--- a/pkg/features/interfacediagnostics/collector.go
+++ b/pkg/features/interfacediagnostics/collector.go
@@ -60,7 +60,7 @@ type description struct {
 func newDescriptions(dynLabels dynamiclabels.Labels) *description {
 	d := new(description)
 
-	l := []string{"target", "name"}
+	l := []string{"target", "name", "if_index"}
 	l = append(l, dynLabels.Keys()...)
 
 	d.moduleVoltageDesc = prometheus.NewDesc(prefix+"module_voltage", "Module voltage", l, nil)
@@ -108,7 +108,7 @@ func newDescriptions(dynLabels dynamiclabels.Labels) *description {
 	d.laserRxOpticalPowerHighWarnThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_rx_high_warn_threshold_dbm", "Laser rx power high warn threshold_dbm in dBm", l, nil)
 	d.laserRxOpticalPowerLowWarnThresholdDbmDesc = prometheus.NewDesc(prefix+"laser_rx_low_warn_threshold_dbm", "Laser rx power low warn threshold_dbm in dBm", l, nil)
 
-	transceiver_labels := []string{"target", "name", "serial_number", "description", "speed", "fiber_type", "vendor_name", "vendor_part_number", "wavelength"}
+	transceiver_labels := []string{"target", "name", "if_index", "serial_number", "description", "speed", "fiber_type", "vendor_name", "vendor_part_number", "wavelength"}
 	d.transceiverDesc = prometheus.NewDesc("junos_interface_transceiver", "Transceiver Info", transceiver_labels, nil)
 
 	return d
@@ -208,15 +208,17 @@ func (c *interfaceDiagnosticsCollector) Collect(client collector.Client, ch chan
 		diagnosticsDict[index] = diag
 
 		desc := ""
+		snmpIndex := ""
 		media := ifMediaDict[slotIndex(diag.Name)]
 		if media != nil {
 			desc = media.Description
+			snmpIndex = media.SnmpIndex
 		}
 
 		dynLabels := dynamiclabels.ParseDescription(desc, c.descriptionRe)
 		d := newDescriptions(dynLabels)
 
-		l := append(labelValues, diag.Name)
+		l := append(labelValues, diag.Name, snmpIndex)
 		l = append(l, dynLabels.Values()...)
 
 		ch <- prometheus.MustNewConstMetric(d.moduleTemperatureDesc, prometheus.GaugeValue, diag.ModuleTemperature, l...)
@@ -360,6 +362,7 @@ func (c *interfaceDiagnosticsCollector) createTransceiverMetrics(client collecto
 	for _, t := range transceiverInfo {
 		chassisInfo := t.ChassisHardwareInfo
 		port_speed := "0"
+		snmpIndex := ""
 		oper_status := 0.0
 
 		if media, hit := ifMediaDict[t.Name]; hit {
@@ -368,11 +371,12 @@ func (c *interfaceDiagnosticsCollector) createTransceiverMetrics(client collecto
 			}
 			t.Name = media.Name
 			port_speed = media.Speed
+			snmpIndex = media.SnmpIndex
 		} else {
 			t.Name = "slot-" + t.Name
 		}
 
-		transceiver_labels := append(labelValues, t.Name, chassisInfo.SerialNumber, chassisInfo.Description, port_speed, t.PicPort.FiberMode, strings.TrimSpace(t.PicPort.SFPVendorName), strings.TrimSpace(t.PicPort.SFPVendorPno), t.PicPort.Wavelength)
+		transceiver_labels := append(labelValues, t.Name, snmpIndex, chassisInfo.SerialNumber, chassisInfo.Description, port_speed, t.PicPort.FiberMode, strings.TrimSpace(t.PicPort.SFPVendorName), strings.TrimSpace(t.PicPort.SFPVendorPno), t.PicPort.Wavelength)
 
 		d := newDescriptions(nil)
 

--- a/pkg/features/interfacequeue/collector.go
+++ b/pkg/features/interfacequeue/collector.go
@@ -37,7 +37,7 @@ type description struct {
 func newDescriptions(dynLabels dynamiclabels.Labels) *description {
 	d := new(description)
 
-	l := []string{"target", "name", "description"}
+	l := []string{"target", "name", "if_index", "description"}
 	l = append(l, "queue_number")
 	l = append(l, "forwarding_class")
 	l = append(l, dynLabels.Keys()...)
@@ -124,7 +124,7 @@ func (c *interfaceQueueCollector) Collect(client collector.Client, ch chan<- pro
 }
 
 func (c *interfaceQueueCollector) collectForInterface(iface physicalInterface, ch chan<- prometheus.Metric, labelValues []string) {
-	lv := append(labelValues, []string{iface.Name, iface.Description}...)
+	lv := append(labelValues, []string{iface.Name, iface.SnmpIndex, iface.Description}...)
 	dynLabels := dynamiclabels.ParseDescription(iface.Description, c.descriptionRe)
 
 	for _, q := range iface.QueueCounters.Queues {

--- a/pkg/features/interfacequeue/rpc.go
+++ b/pkg/features/interfacequeue/rpc.go
@@ -11,6 +11,7 @@ type result struct {
 type physicalInterface struct {
 	Name          string `xml:"name"`
 	Description   string `xml:"description"`
+	SnmpIndex     string `xml:"snmp-index"`
 	QueueCounters struct {
 		Queues []queue `xml:"queue"`
 	} `xml:"queue-counters"`

--- a/pkg/features/interfaces/collector.go
+++ b/pkg/features/interfaces/collector.go
@@ -60,7 +60,7 @@ type description struct {
 
 func newDescriptions(dynLabels dynamiclabels.Labels) *description {
 	d := new(description)
-	l := []string{"target", "name", "description", "mac"}
+	l := []string{"target", "name", "if_index", "description", "mac"}
 	l = append(l, dynLabels.Keys()...)
 
 	d.receiveBytesDesc = prometheus.NewDesc(prefix+"receive_bytes", "Received data in bytes", l, nil)
@@ -205,6 +205,7 @@ func (c *interfaceCollector) interfaceStats(client collector.Client) ([]*interfa
 			ErrorStatus:             !(phy.AdminStatus == phy.OperStatus),
 			Description:             phy.Description,
 			Mac:                     phy.MacAddress,
+			SnmpIndex:               phy.SnmpIndex,
 			ReceiveDrops:            float64(phy.InputErrors.Drops),
 			ReceiveErrors:           float64(phy.InputErrors.Errors),
 			ReceiveBytes:            float64(phy.Stats.InputBytes),
@@ -261,6 +262,7 @@ func (c *interfaceCollector) interfaceStats(client collector.Client) ([]*interfa
 				Name:                log.Name,
 				Description:         log.Description,
 				Mac:                 phy.MacAddress,
+				SnmpIndex:           log.SnmpIndex,
 				ReceiveBytes:        float64(s.InputBytes),
 				ReceivePackets:      float64(s.InputPackets),
 				TransmitBytes:       float64(s.OutputBytes),
@@ -279,7 +281,7 @@ func (c *interfaceCollector) interfaceStats(client collector.Client) ([]*interfa
 }
 
 func (c *interfaceCollector) collectForInterface(s *interfaceStats, ch chan<- prometheus.Metric, labelValues []string) {
-	lv := append(labelValues, []string{s.Name, s.Description, s.Mac}...)
+	lv := append(labelValues, []string{s.Name, s.SnmpIndex, s.Description, s.Mac}...)
 	dynLabels := dynamiclabels.ParseDescription(s.Description, c.descriptionRe)
 	lv = append(lv, dynLabels.Values()...)
 	d := newDescriptions(dynLabels)

--- a/pkg/features/interfaces/interface_stats.go
+++ b/pkg/features/interfaces/interface_stats.go
@@ -9,6 +9,7 @@ type interfaceStats struct {
 	ErrorStatus             bool
 	Description             string
 	Mac                     string
+	SnmpIndex               string
 	IsPhysical              bool
 	Speed                   string
 	BPDUError               bool

--- a/pkg/features/interfaces/rpc.go
+++ b/pkg/features/interfaces/rpc.go
@@ -14,6 +14,7 @@ type phyInterface struct {
 	OperStatus        string         `xml:"oper-status"`
 	Description       string         `xml:"description"`
 	MacAddress        string         `xml:"current-physical-address"`
+	SnmpIndex         string         `xml:"snmp-index"`
 	Speed             string         `xml:"speed"`
 	BPDUError         string         `xml:"bpdu-error"`
 	Stats             trafficStat    `xml:"traffic-statistics"`
@@ -39,6 +40,7 @@ type phyInterface struct {
 type logInterface struct {
 	Name        string         `xml:"name"`
 	Description string         `xml:"description"`
+	SnmpIndex   string         `xml:"snmp-index"`
 	Stats       trafficStat    `xml:"traffic-statistics"`
 	LagStats    lagTrafficStat `xml:"lag-traffic-statistics"`
 }


### PR DESCRIPTION
Expose Junos SNMP IF-MIB interface indexes as if_index labels on interface, interface queue, diagnostics, and transceiver metrics to allow sorting interfaces in dashboards.