### PR TITLE
Add SRX MNHA (Multi-Node High Availability) feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ devices:
     # interface_description_regex: '\[([^=\]]+)(=[^\]]+)?\]'
     # interface_name_regex: '[!(d)][!(i)]*'
     # firewall_filter_name_regex: 'test-filter.*'
+    # mnha_srg_ids: '0,1'
     features:
       isis: true
   - host: switch\d+
@@ -336,6 +337,7 @@ devices:
 # interface_description_regex: '\[([^=\]]+)(=[^\]]+)?\]'
 # interface_name_regex: '[!(d)][!(i)]*'
 # firewall_filter_name_regex: 'test-filter.*'
+# mnha_srg_ids: '0,1'
 features:
   accounting: false
   alarm: true
@@ -468,6 +470,24 @@ This regex can be supplied via:
   ```
 
 If provided, the exporter will execute `show firewall filter regex <regex>` with your custom pattern instead of `.*`.
+
+
+### Configuring MNHA Services-Redundancy-Group IDs
+
+By default, the `mnha` collector only scrapes services-redundancy-group `0`.
+If your devices define additional SRGs, you can configure which group IDs to scrape using the `mnha_srg_ids` option, a comma-separated list.
+
+This option can be supplied via:
+- **CLI Flag**: `-mnha.srg-ids="0,1,2"`
+- **Config File (Global)**: `mnha_srg_ids: '0,1,2'`
+- **Config File (Per-Device)**: Under a specific device configuration:
+  ```yaml
+  devices:
+    - host: router1
+      mnha_srg_ids: '0,1'
+  ```
+
+Per-device config takes precedence over the global config file value, which takes precedence over the CLI flag.
 
 
 ### Grafana Dashboards

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following metrics are supported by now:
 * Subscribers Information (show subscribers client-type dhcp detail)
 * PoE (show poe interface)
 * UFD (uplink-failure-detection group state)
+* MNHA (Mixed/Multi-Node High Availability, SRX): node/peer BFD & ICL status, cold-sync, SPU/hardware monitoring, PFE loopback checks, services-redundancy-group state
 
 ## Feature specific mappings
 Some collected time series behave like enums - Integer values represent a certain state/meaning.
@@ -71,6 +72,13 @@ Some collected time series behave like enums - Integer values represent a certai
 5: lost
 6: not-configured
 7: ineligible
+```
+
+### MNHA (`junos_mnha_node_status`, `junos_mnha_srg_state`)
+```
+ 1: ONLINE
+ 0: OFFLINE
+-1: unknown/other
 ```
 
 ### L2circuits
@@ -356,6 +364,7 @@ features:
   lldp: false
   mac: false
   macsec: true
+  mnha: false
   mpls_lsp: false
   nat: false
   nat2: false

--- a/collectors.go
+++ b/collectors.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/czerwonk/junos_exporter/pkg/features/ddosprotection"
 	"github.com/czerwonk/junos_exporter/pkg/features/poe"
@@ -36,6 +38,7 @@ import (
 	"github.com/czerwonk/junos_exporter/pkg/features/lldp"
 	"github.com/czerwonk/junos_exporter/pkg/features/mac"
 	"github.com/czerwonk/junos_exporter/pkg/features/macsec"
+	"github.com/czerwonk/junos_exporter/pkg/features/mnha"
 	"github.com/czerwonk/junos_exporter/pkg/features/mplslsp"
 	"github.com/czerwonk/junos_exporter/pkg/features/nat"
 	"github.com/czerwonk/junos_exporter/pkg/features/nat2"
@@ -152,6 +155,9 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device, descRe *
 	c.addCollectorIfEnabledForDevice(device, "twamp", f.TWAMP, twamp.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "system_statistics", f.SystemStatistics, systemstatistics.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "ufd", f.UFD, ufd.NewCollector)
+	c.addCollectorIfEnabledForDevice(device, "mnha", f.MNHA, func() collector.RPCCollector {
+		return mnha.NewCollector(parseMNHASRGIDs(*mnhaSRGIDs))
+	})
 
 }
 
@@ -191,4 +197,26 @@ func (c *collectors) collectorsForDevice(device *connector.Device) []collector.R
 	}
 
 	return cols
+}
+
+// parseMNHASRGIDs parses a comma-separated list of services-redundancy-group
+// IDs (e.g. "0,1,2"). Non-numeric entries are ignored.
+func parseMNHASRGIDs(s string) []int {
+	ids := make([]int, 0)
+
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		id, err := strconv.Atoi(part)
+		if err != nil {
+			continue
+		}
+
+		ids = append(ids, id)
+	}
+
+	return ids
 }

--- a/collectors.go
+++ b/collectors.go
@@ -156,7 +156,12 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device, descRe *
 	c.addCollectorIfEnabledForDevice(device, "system_statistics", f.SystemStatistics, systemstatistics.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "ufd", f.UFD, ufd.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "mnha", f.MNHA, func() collector.RPCCollector {
-		return mnha.NewCollector(parseMNHASRGIDs(*mnhaSRGIDs))
+		srgIDs := deviceMNHASRGIDs(c.cfg, device.Host)
+		if srgIDs == "" {
+			srgIDs = *mnhaSRGIDs
+		}
+
+		return mnha.NewCollector(parseMNHASRGIDs(srgIDs))
 	})
 
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,6 +116,7 @@ type FeatureConfig struct {
 	TWAMP               bool `yaml:"twamp,omitempty"`
 	SystemStatistics    bool `yaml:"system_statistics,omitempty"`
 	UFD                 bool `yaml:"ufd,omitempty"`
+	MNHA                bool `yaml:"mnha,omitempty"`
 }
 
 // New creates a new config

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	IfDescReg               *regexp.Regexp  `yaml:"-"`
 	InterfaceNameRegex      string          `yaml:"interface_name_regex,omitempty"`
 	FirewallFilterNameRegex string          `yaml:"firewall_filter_name_regex,omitempty"`
+	MNHASRGIDs              string          `yaml:"mnha_srg_ids,omitempty"`
 }
 
 func (c *Config) load(dynamicIfaceLabels bool) error {
@@ -61,6 +62,7 @@ type DeviceConfig struct {
 	HostPattern             *regexp.Regexp
 	InterfaceNameRegex      string `yaml:"interface_name_regex,omitempty"`
 	FirewallFilterNameRegex string `yaml:"firewall_filter_name_regex,omitempty"`
+	MNHASRGIDs              string `yaml:"mnha_srg_ids,omitempty"`
 }
 
 // FeatureConfig is the list of collectors enabled or disabled

--- a/junos_collector.go
+++ b/junos_collector.go
@@ -98,6 +98,16 @@ func deviceFirewallFilterNameRegex(cfg *config.Config, host string) string {
 	return cfg.FirewallFilterNameRegex
 }
 
+func deviceMNHASRGIDs(cfg *config.Config, host string) string {
+	dc := cfg.FindDeviceConfig(host)
+
+	if dc != nil && dc.MNHASRGIDs != "" {
+		return dc.MNHASRGIDs
+	}
+
+	return cfg.MNHASRGIDs
+}
+
 func clientForDevice(device *connector.Device, connManager *connector.SSHConnectionManager) (*rpc.Client, error) {
 	conn, err := connManager.GetSSHConnection(device)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -112,6 +112,8 @@ var (
 	twampEnabled                = flag.Bool("twamp.enabled", false, "Scrape TWAMP metrics")
 	systemstatisticsEnabled     = flag.Bool("systemstatistics.enabled", true, "Scrape system statistics metrics")
 	ufdEnabled                  = flag.Bool("ufd.enabled", false, "Scrape UFD (uplink-failure-detection) metrics")
+	mnhaEnabled                 = flag.Bool("mnha.enabled", false, "Scrape MNHA (Mixed/Multi-Node High Availability) metrics")
+	mnhaSRGIDs                  = flag.String("mnha.srg-ids", "0", "Comma-separated list of MNHA services-redundancy-group IDs to scrape")
 	cfg                         *config.Config
 	devices                     []*connector.Device
 	connManager                 *connector.SSHConnectionManager
@@ -350,6 +352,7 @@ func loadConfigFromFlags() *config.Config {
 	f.LLDP = *lldpEnabled
 	f.MAC = *macEnabled
 	f.MACSec = *macsecEnabled
+	f.MNHA = *mnhaEnabled
 	f.MPLSLSP = *mplsLSPEnabled
 	f.NAT = *natEnabled
 	f.NAT2 = *nat2Enabled

--- a/pkg/features/mnha/collect_test.go
+++ b/pkg/features/mnha/collect_test.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT
+
+package mnha
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"testing"
+
+	"github.com/czerwonk/junos_exporter/pkg/connector"
+	"github.com/czerwonk/junos_exporter/pkg/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+const srgSampleGroup1Offline = `<rpc-reply>
+    <chassis-high-availability-default-srg-info>
+        <current-state>OFFLINE</current-state>
+        <peer-id>2</peer-id>
+    </chassis-high-availability-default-srg-info>
+</rpc-reply>`
+
+// mnhaMockClient is a minimal collector.Client fake, modelled on the one used
+// in pkg/features/interfaces/collector_test.go. It serves canned XML bodies
+// keyed by the exact command string and records every command it was asked
+// to run, so tests can assert on dispatch (which commands, how many times).
+type mnhaMockClient struct {
+	commands  []string
+	responses map[string]string
+	failing   map[string]error
+}
+
+func (m *mnhaMockClient) RunCommandAndParse(cmd string, obj any) error {
+	m.commands = append(m.commands, cmd)
+
+	if err, ok := m.failing[cmd]; ok {
+		return err
+	}
+
+	body, ok := m.responses[cmd]
+	if !ok {
+		return fmt.Errorf("mnhaMockClient: no canned response for %q", cmd)
+	}
+
+	return xml.Unmarshal([]byte(body), obj)
+}
+
+func (m *mnhaMockClient) RunCommandAndParseWithParser(cmd string, parser rpc.Parser) error {
+	m.commands = append(m.commands, cmd)
+
+	body, ok := m.responses[cmd]
+	if !ok {
+		return fmt.Errorf("mnhaMockClient: no canned response for %q", cmd)
+	}
+
+	return parser([]byte(body))
+}
+
+func (m *mnhaMockClient) IsSatelliteEnabled() bool {
+	return false
+}
+
+func (m *mnhaMockClient) IsScrapingLicenseEnabled() bool {
+	return false
+}
+
+func (m *mnhaMockClient) Device() *connector.Device {
+	return &connector.Device{Host: "srx1"}
+}
+
+func (m *mnhaMockClient) Context() context.Context {
+	return context.Background()
+}
+
+func drain(ch chan prometheus.Metric) []prometheus.Metric {
+	close(ch)
+	var out []prometheus.Metric
+	for m := range ch {
+		out = append(out, m)
+	}
+	return out
+}
+
+const detailCmd = "show chassis high-availability information detail"
+
+func srgCmd(id int) string {
+	return fmt.Sprintf("show chassis high-availability services-redundancy-group %d", id)
+}
+
+func TestCollectDefaultGroupReusesDetailResponse(t *testing.T) {
+	client := &mnhaMockClient{
+		responses: map[string]string{
+			detailCmd: detailSample,
+		},
+	}
+
+	col := NewCollector(nil).(*mnhaCollector) // nil -> defaults to [0]
+	ch := make(chan prometheus.Metric, 64)
+
+	err := col.Collect(client, ch, []string{"srx1"})
+	assert.NoError(t, err)
+
+	metrics := drain(ch)
+	assert.Equal(t, []string{detailCmd}, client.commands, "SRG 0 must be served from the detail response, not a second round-trip")
+
+	srgMetrics := findByDesc(metrics, srgStateDesc)
+	assert.Len(t, srgMetrics, 1)
+	labels := labelMap(t, srgMetrics[0])
+	assert.Equal(t, "0", labels["srg_id"])
+	assert.Equal(t, "2", labels["peer_id"], "from the embedded default-srg-info block, peer-id 2")
+	assert.Equal(t, "ONLINE", labels["state"])
+}
+
+func TestCollectMultipleGroupsQueriesOnlyNonDefault(t *testing.T) {
+	client := &mnhaMockClient{
+		responses: map[string]string{
+			detailCmd: detailSample,
+			srgCmd(1): srgSampleGroup1Offline,
+		},
+	}
+
+	col := NewCollector([]int{0, 1}).(*mnhaCollector)
+	ch := make(chan prometheus.Metric, 64)
+
+	err := col.Collect(client, ch, []string{"srx1"})
+	assert.NoError(t, err)
+
+	metrics := drain(ch)
+	assert.Equal(t, []string{detailCmd, srgCmd(1)}, client.commands, "group 0 must not trigger its own RPC when detail already succeeded")
+
+	srgMetrics := findByDesc(metrics, srgStateDesc)
+	assert.Len(t, srgMetrics, 2)
+
+	byGroup := map[string]map[string]string{}
+	for _, m := range srgMetrics {
+		l := labelMap(t, m)
+		byGroup[l["srg_id"]] = l
+	}
+
+	assert.Equal(t, "ONLINE", byGroup["0"]["state"])
+	assert.Equal(t, "OFFLINE", byGroup["1"]["state"])
+}
+
+func TestCollectFallsBackToExplicitQueryWhenDetailFails(t *testing.T) {
+	client := &mnhaMockClient{
+		responses: map[string]string{
+			srgCmd(0): srgSample,
+		},
+		failing: map[string]error{
+			detailCmd: fmt.Errorf("permission denied"),
+		},
+	}
+
+	col := NewCollector(nil).(*mnhaCollector)
+	ch := make(chan prometheus.Metric, 64)
+
+	err := col.Collect(client, ch, []string{"srx1"})
+	assert.Error(t, err, "the detail command's error must still surface")
+	assert.Equal(t, []string{detailCmd, srgCmd(0)}, client.commands, "must fall back to an explicit SRG 0 query once detail fails")
+
+	metrics := drain(ch)
+	srgMetrics := findByDesc(metrics, srgStateDesc)
+	assert.Len(t, srgMetrics, 1, "SRG state should still be collected despite the detail failure")
+}
+
+func TestCollectJoinsErrorsFromBothCalls(t *testing.T) {
+	client := &mnhaMockClient{
+		responses: map[string]string{},
+		failing: map[string]error{
+			detailCmd: fmt.Errorf("detail failed"),
+			srgCmd(0): fmt.Errorf("srg failed"),
+		},
+	}
+
+	col := NewCollector(nil).(*mnhaCollector)
+	ch := make(chan prometheus.Metric, 64)
+
+	err := col.Collect(client, ch, []string{"srx1"})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "detail failed")
+	assert.ErrorContains(t, err, "srg failed")
+
+	metrics := drain(ch)
+	assert.Empty(t, metrics)
+}

--- a/pkg/features/mnha/collector.go
+++ b/pkg/features/mnha/collector.go
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: MIT
+
+package mnha
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/czerwonk/junos_exporter/pkg/collector"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix string = "junos_mnha_"
+
+var (
+	nodeStatusDesc            *prometheus.Desc
+	peerBFDUpDesc             *prometheus.Desc
+	peerFwdBFDUpDesc          *prometheus.Desc
+	peerEncryptionEnabledDesc *prometheus.Desc
+	peerDetectTimeMsDesc      *prometheus.Desc
+	coldSyncCompleteDesc      *prometheus.Desc
+	peerPacketErrorsTotalDesc *prometheus.Desc
+	peerPacketsTotalDesc      *prometheus.Desc
+	coldSyncCompletedTotal    *prometheus.Desc
+	coldSyncFailedTotal       *prometheus.Desc
+	spuMonitoringEnabledDesc  *prometheus.Desc
+	spuUpDesc                 *prometheus.Desc
+	npcUpDesc                 *prometheus.Desc
+	spuDownDesc               *prometheus.Desc
+	npcDownDesc               *prometheus.Desc
+	chinfoBlobErrorsTotal     *prometheus.Desc
+	loopbackCheckSuccessDesc  *prometheus.Desc
+	hwMonitoringEnabledDesc   *prometheus.Desc
+	hwCtrlPlaneErrorsTotal    *prometheus.Desc
+	hwDataPlaneErrorsTotal    *prometheus.Desc
+	srgStateDesc              *prometheus.Desc
+)
+
+var detectTimeRe = regexp.MustCompile(`^\s*(\d+)\s*\*\s*(\d+)\s*ms\s*$`)
+
+func init() {
+	l := []string{"target", "grid_id", "local_id", "local_ip", "local_fwd_ip", "status"}
+	nodeStatusDesc = prometheus.NewDesc(prefix+"node_status", "MNHA local node status (1 online, 0 offline, -1 unknown)", l, nil)
+
+	l = []string{"target", "peer_id", "peer_ip", "local_interface"}
+	peerBFDUpDesc = prometheus.NewDesc(prefix+"peer_bfd_up", "MNHA peer BFD session state over the ICL (1 up, 0 down)", l, nil)
+
+	l = []string{"target", "peer_id", "peer_fwd_ip", "local_fwd_interface"}
+	peerFwdBFDUpDesc = prometheus.NewDesc(prefix+"peer_fwd_bfd_up", "MNHA peer forwarding-path BFD session state (1 up, 0 down)", l, nil)
+
+	l = []string{"target", "peer_id"}
+	peerEncryptionEnabledDesc = prometheus.NewDesc(prefix+"peer_encryption_enabled", "1 if the MNHA ICL is encrypted, 0 otherwise", l, nil)
+	peerDetectTimeMsDesc = prometheus.NewDesc(prefix+"peer_detect_time_milliseconds", "MNHA peer BFD failure detection time in milliseconds", l, nil)
+
+	l = []string{"target", "peer_id", "status"}
+	coldSyncCompleteDesc = prometheus.NewDesc(prefix+"cold_sync_complete", "1 if MNHA cold synchronization with the peer is complete, 0 otherwise", l, nil)
+
+	l = []string{"target", "peer_id", "direction"}
+	peerPacketErrorsTotalDesc = prometheus.NewDesc(prefix+"peer_packet_errors_total", "Total MNHA ICL packet errors by direction (send, receive)", l, nil)
+
+	l = []string{"target", "peer_id", "packet_type", "direction"}
+	peerPacketsTotalDesc = prometheus.NewDesc(prefix+"peer_packets_total", "Total MNHA ICL packets by type and direction (send, receive)", l, nil)
+
+	l = []string{"target"}
+	coldSyncCompletedTotal = prometheus.NewDesc(prefix+"cold_sync_completed_total", "Total number of completed MNHA cold synchronizations", l, nil)
+	coldSyncFailedTotal = prometheus.NewDesc(prefix+"cold_sync_failed_total", "Total number of failed MNHA cold synchronizations", l, nil)
+	spuMonitoringEnabledDesc = prometheus.NewDesc(prefix+"spu_monitoring_enabled", "1 if MNHA SPU monitoring is enabled, 0 otherwise", l, nil)
+	spuUpDesc = prometheus.NewDesc(prefix+"spu_up", "Number of SPUs reported up by MNHA monitoring", l, nil)
+	npcUpDesc = prometheus.NewDesc(prefix+"npc_up", "Number of NPCs reported up by MNHA monitoring", l, nil)
+	spuDownDesc = prometheus.NewDesc(prefix+"spu_down", "Number of SPUs reported down by MNHA monitoring", l, nil)
+	npcDownDesc = prometheus.NewDesc(prefix+"npc_down", "Number of NPCs reported down by MNHA monitoring", l, nil)
+	chinfoBlobErrorsTotal = prometheus.NewDesc(prefix+"chinfo_blob_errors_total", "Total MNHA chassis-info blob errors", l, nil)
+	hwMonitoringEnabledDesc = prometheus.NewDesc(prefix+"hardware_monitoring_enabled", "1 if MNHA hardware monitoring is enabled, 0 otherwise", l, nil)
+	hwCtrlPlaneErrorsTotal = prometheus.NewDesc(prefix+"hardware_control_plane_errors_total", "Total MNHA hardware monitoring control-plane errors", l, nil)
+	hwDataPlaneErrorsTotal = prometheus.NewDesc(prefix+"hardware_data_plane_errors_total", "Total MNHA hardware monitoring data-plane errors", l, nil)
+
+	l = []string{"target", "pfe_name", "check"}
+	loopbackCheckSuccessDesc = prometheus.NewDesc(prefix+"loopback_check_success", "1 if the MNHA PFE loopback self-test succeeded (loopback, nexthop, mbuf), 0 otherwise", l, nil)
+
+	l = []string{"target", "srg_id", "peer_id", "state"}
+	srgStateDesc = prometheus.NewDesc(prefix+"srg_state", "MNHA services-redundancy-group state (1 online, 0 offline, -1 unknown)", l, nil)
+}
+
+type mnhaCollector struct {
+	srgIDs []int
+}
+
+// NewCollector creates a new collector for MNHA (Mixed/Multi-Node High Availability).
+// srgIDs configures which services-redundancy-groups are polled individually
+// via "show chassis high-availability services-redundancy-group <id>".
+// If empty, group 0 (the default group) is used.
+func NewCollector(srgIDs []int) collector.RPCCollector {
+	if len(srgIDs) == 0 {
+		srgIDs = []int{0}
+	}
+
+	return &mnhaCollector{srgIDs: srgIDs}
+}
+
+// Name returns the name of the collector
+func (*mnhaCollector) Name() string {
+	return "MNHA"
+}
+
+// Describe describes the metrics
+func (*mnhaCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- nodeStatusDesc
+	ch <- peerBFDUpDesc
+	ch <- peerFwdBFDUpDesc
+	ch <- peerEncryptionEnabledDesc
+	ch <- peerDetectTimeMsDesc
+	ch <- coldSyncCompleteDesc
+	ch <- peerPacketErrorsTotalDesc
+	ch <- peerPacketsTotalDesc
+	ch <- coldSyncCompletedTotal
+	ch <- coldSyncFailedTotal
+	ch <- spuMonitoringEnabledDesc
+	ch <- spuUpDesc
+	ch <- npcUpDesc
+	ch <- spuDownDesc
+	ch <- npcDownDesc
+	ch <- chinfoBlobErrorsTotal
+	ch <- loopbackCheckSuccessDesc
+	ch <- hwMonitoringEnabledDesc
+	ch <- hwCtrlPlaneErrorsTotal
+	ch <- hwDataPlaneErrorsTotal
+	ch <- srgStateDesc
+}
+
+// Collect collects metrics from JunOS
+func (c *mnhaCollector) Collect(client collector.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var errs []error
+
+	var res detailResult
+	detailErr := client.RunCommandAndParse("show chassis high-availability information detail", &res)
+	if detailErr != nil {
+		errs = append(errs, detailErr)
+	} else {
+		collectDetail(&res, ch, labelValues)
+	}
+
+	for _, id := range c.srgIDs {
+		var srg srgBlock
+
+		// SRG 0 (the default group) is already reported by the "detail" call
+		// above (chassis-high-availability-default-srg-info), so avoid a
+		// second SSH round-trip for the common case of a single default group.
+		if id == 0 && detailErr == nil {
+			srg = res.Info.DefaultSRG
+		} else {
+			var result srgResult
+			cmd := fmt.Sprintf("show chassis high-availability services-redundancy-group %d", id)
+			if err := client.RunCommandAndParse(cmd, &result); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			srg = result.SRG
+		}
+
+		state := strings.ToUpper(strings.TrimSpace(srg.CurrentState))
+		l := append(labelValues, strconv.Itoa(id), strconv.Itoa(srg.PeerID), state)
+		ch <- prometheus.MustNewConstMetric(srgStateDesc, prometheus.GaugeValue, onlineOfflineValue(state), l...)
+	}
+
+	return errors.Join(errs...)
+}
+
+func collectDetail(res *detailResult, ch chan<- prometheus.Metric, labelValues []string) {
+	info := res.Info
+	node := info.NodeInfo
+	peer := node.Peer
+
+	nodeStatus := strings.ToUpper(strings.TrimSpace(node.NodeStatus))
+	l := append(labelValues, strconv.Itoa(node.GridID), strconv.Itoa(node.LocalID), node.LocalIP, node.LocalFwdIP, nodeStatus)
+	ch <- prometheus.MustNewConstMetric(nodeStatusDesc, prometheus.GaugeValue, onlineOfflineValue(nodeStatus), l...)
+
+	peerID := strconv.Itoa(peer.PeerID)
+
+	l = append(labelValues, peerID, peer.PeerIPAddress, peer.LocalInterface)
+	ch <- prometheus.MustNewConstMetric(peerBFDUpDesc, prometheus.GaugeValue, upDownValue(peer.BFDStatus), l...)
+
+	l = append(labelValues, peerID, peer.PeerFwdIPAddress, peer.LocalFwdInterface)
+	ch <- prometheus.MustNewConstMetric(peerFwdBFDUpDesc, prometheus.GaugeValue, upDownValue(peer.PeerFwdBFDStatus), l...)
+
+	l = append(labelValues, peerID)
+	ch <- prometheus.MustNewConstMetric(peerEncryptionEnabledDesc, prometheus.GaugeValue, yesNoValue(peer.EncryptionStatus), l...)
+
+	if ms, ok := parseDetectTimeMs(peer.DetectTime); ok {
+		ch <- prometheus.MustNewConstMetric(peerDetectTimeMsDesc, prometheus.GaugeValue, ms, l...)
+	}
+
+	coldSyncStatus := strings.ToUpper(strings.TrimSpace(peer.ColdSyncStatus))
+	l = append(labelValues, peerID, coldSyncStatus)
+	ch <- prometheus.MustNewConstMetric(coldSyncCompleteDesc, prometheus.GaugeValue, boolValue(coldSyncStatus == "COMPLETE"), l...)
+
+	l = append(labelValues, peerID, "send")
+	ch <- prometheus.MustNewConstMetric(peerPacketErrorsTotalDesc, prometheus.CounterValue, float64(peer.PacketStats.SendErrCount), l...)
+	l = append(labelValues, peerID, "receive")
+	ch <- prometheus.MustNewConstMetric(peerPacketErrorsTotalDesc, prometheus.CounterValue, float64(peer.PacketStats.RecvErrCount), l...)
+
+	for _, s := range peer.PacketStats.Stats {
+		l = append(labelValues, peerID, s.Type, "send")
+		ch <- prometheus.MustNewConstMetric(peerPacketsTotalDesc, prometheus.CounterValue, float64(s.SendCount), l...)
+		l = append(labelValues, peerID, s.Type, "receive")
+		ch <- prometheus.MustNewConstMetric(peerPacketsTotalDesc, prometheus.CounterValue, float64(s.RecvCount), l...)
+	}
+
+	ch <- prometheus.MustNewConstMetric(coldSyncCompletedTotal, prometheus.CounterValue, float64(info.ColdSyncMonitoring.Statistics.Completed), labelValues...)
+	ch <- prometheus.MustNewConstMetric(coldSyncFailedTotal, prometheus.CounterValue, float64(info.ColdSyncMonitoring.Statistics.Failed), labelValues...)
+
+	ch <- prometheus.MustNewConstMetric(spuMonitoringEnabledDesc, prometheus.GaugeValue, enabledDisabledValue(info.SPUMonitoring.Status.State), labelValues...)
+	ch <- prometheus.MustNewConstMetric(spuUpDesc, prometheus.GaugeValue, float64(info.SPUMonitoring.Statistics.SPUUp), labelValues...)
+	ch <- prometheus.MustNewConstMetric(npcUpDesc, prometheus.GaugeValue, float64(info.SPUMonitoring.Statistics.NPCUp), labelValues...)
+	ch <- prometheus.MustNewConstMetric(spuDownDesc, prometheus.GaugeValue, float64(info.SPUMonitoring.Statistics.SPUDown), labelValues...)
+	ch <- prometheus.MustNewConstMetric(npcDownDesc, prometheus.GaugeValue, float64(info.SPUMonitoring.Statistics.NPCDown), labelValues...)
+	ch <- prometheus.MustNewConstMetric(chinfoBlobErrorsTotal, prometheus.CounterValue, float64(info.SPUMonitoring.Statistics.ChinfoBlobErrs), labelValues...)
+
+	ch <- prometheus.MustNewConstMetric(hwMonitoringEnabledDesc, prometheus.GaugeValue, enabledDisabledValue(info.HardwareMonitoring.Status.ActivationStatus), labelValues...)
+	ch <- prometheus.MustNewConstMetric(hwCtrlPlaneErrorsTotal, prometheus.CounterValue, float64(info.HardwareMonitoring.Status.CtrlPlaneErrors), labelValues...)
+	ch <- prometheus.MustNewConstMetric(hwDataPlaneErrorsTotal, prometheus.CounterValue, float64(info.HardwareMonitoring.Status.DataPlaneErrors), labelValues...)
+
+	for _, check := range info.LoopbackInformation.Checks {
+		cl := append(labelValues, check.PFEName, "loopback")
+		ch <- prometheus.MustNewConstMetric(loopbackCheckSuccessDesc, prometheus.GaugeValue, boolValue(strings.EqualFold(check.LoopbackStatus, "Success")), cl...)
+
+		cl = append(labelValues, check.PFEName, "nexthop")
+		ch <- prometheus.MustNewConstMetric(loopbackCheckSuccessDesc, prometheus.GaugeValue, boolValue(strings.EqualFold(check.NexthopStatus, "Success")), cl...)
+
+		cl = append(labelValues, check.PFEName, "mbuf")
+		ch <- prometheus.MustNewConstMetric(loopbackCheckSuccessDesc, prometheus.GaugeValue, boolValue(strings.EqualFold(check.MbufStatus, "Success")), cl...)
+	}
+}
+
+func onlineOfflineValue(status string) float64 {
+	switch status {
+	case "ONLINE":
+		return 1
+	case "OFFLINE":
+		return 0
+	default:
+		return -1
+	}
+}
+
+func upDownValue(status string) float64 {
+	return boolValue(strings.EqualFold(strings.TrimSpace(status), "UP"))
+}
+
+func yesNoValue(status string) float64 {
+	return boolValue(strings.EqualFold(strings.TrimSpace(status), "YES"))
+}
+
+func enabledDisabledValue(status string) float64 {
+	return boolValue(strings.EqualFold(strings.TrimSpace(status), "Enabled"))
+}
+
+func boolValue(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// parseDetectTimeMs parses Junos' "<count> * <interval>ms" detect-time format,
+// e.g. "3 * 1000ms" (3 missed intervals of 1000ms) into a total in milliseconds.
+func parseDetectTimeMs(s string) (float64, bool) {
+	m := detectTimeRe.FindStringSubmatch(s)
+	if m == nil {
+		return 0, false
+	}
+
+	count, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return 0, false
+	}
+
+	interval, err := strconv.ParseFloat(m[2], 64)
+	if err != nil {
+		return 0, false
+	}
+
+	return count * interval, true
+}

--- a/pkg/features/mnha/collector_test.go
+++ b/pkg/features/mnha/collector_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+
+package mnha
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+// findByDesc returns the metrics matching a given Desc, relying on Desc
+// pointer identity (descs are package-level vars created once in init()).
+func findByDesc(metrics []prometheus.Metric, desc *prometheus.Desc) []prometheus.Metric {
+	var out []prometheus.Metric
+	for _, m := range metrics {
+		if m.Desc() == desc {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func labelMap(t *testing.T, m prometheus.Metric) map[string]string {
+	t.Helper()
+
+	var dm dto.Metric
+	if err := m.Write(&dm); err != nil {
+		t.Fatalf("writing metric: %v", err)
+	}
+
+	out := make(map[string]string, len(dm.Label))
+	for _, lp := range dm.Label {
+		out[lp.GetName()] = lp.GetValue()
+	}
+
+	return out
+}
+
+func metricValue(t *testing.T, m prometheus.Metric) float64 {
+	t.Helper()
+
+	var dm dto.Metric
+	if err := m.Write(&dm); err != nil {
+		t.Fatalf("writing metric: %v", err)
+	}
+
+	if dm.Gauge != nil {
+		return dm.Gauge.GetValue()
+	}
+
+	return dm.Counter.GetValue()
+}
+
+func TestCollectDetail(t *testing.T) {
+	var res detailResult
+	if err := xml.Unmarshal([]byte(detailSample), &res); err != nil {
+		t.Fatal(err)
+	}
+
+	ch := make(chan prometheus.Metric, 64)
+	collectDetail(&res, ch, []string{"srx1"})
+	close(ch)
+
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+	assert.Len(t, metrics, 30, "total metrics emitted")
+
+	nodeMetrics := findByDesc(metrics, nodeStatusDesc)
+	assert.Len(t, nodeMetrics, 1)
+	assert.Equal(t, 1.0, metricValue(t, nodeMetrics[0]))
+	nodeLabels := labelMap(t, nodeMetrics[0])
+	assert.Equal(t, "srx1", nodeLabels["target"])
+	assert.Equal(t, "0", nodeLabels["grid_id"])
+	assert.Equal(t, "1", nodeLabels["local_id"])
+	assert.Equal(t, "ONLINE", nodeLabels["status"])
+
+	bfdMetrics := findByDesc(metrics, peerBFDUpDesc)
+	assert.Len(t, bfdMetrics, 1)
+	assert.Equal(t, 1.0, metricValue(t, bfdMetrics[0]), "peer BFD is UP in the sample")
+
+	detectMetrics := findByDesc(metrics, peerDetectTimeMsDesc)
+	assert.Len(t, detectMetrics, 1)
+	assert.Equal(t, 3000.0, metricValue(t, detectMetrics[0]))
+
+	coldSyncMetrics := findByDesc(metrics, coldSyncCompleteDesc)
+	assert.Len(t, coldSyncMetrics, 1)
+	assert.Equal(t, 1.0, metricValue(t, coldSyncMetrics[0]))
+
+	packetMetrics := findByDesc(metrics, peerPacketsTotalDesc)
+	assert.Len(t, packetMetrics, 8, "4 packet types x send/receive")
+
+	loopbackMetrics := findByDesc(metrics, loopbackCheckSuccessDesc)
+	assert.Len(t, loopbackMetrics, 3, "loopback/nexthop/mbuf for the single PFE in the sample")
+	for _, m := range loopbackMetrics {
+		assert.Equal(t, 1.0, metricValue(t, m), "all loopback checks succeed in the sample")
+	}
+
+	spuUpMetrics := findByDesc(metrics, spuUpDesc)
+	assert.Len(t, spuUpMetrics, 1)
+	assert.Equal(t, 1.0, metricValue(t, spuUpMetrics[0]))
+}
+
+func TestParseDetectTimeMs(t *testing.T) {
+	ms, ok := parseDetectTimeMs("3 * 1000ms")
+	assert.True(t, ok)
+	assert.Equal(t, 3000.0, ms)
+
+	_, ok = parseDetectTimeMs("N/A")
+	assert.False(t, ok)
+}
+
+func TestOnlineOfflineValue(t *testing.T) {
+	assert.Equal(t, 1.0, onlineOfflineValue("ONLINE"))
+	assert.Equal(t, 0.0, onlineOfflineValue("OFFLINE"))
+	assert.Equal(t, -1.0, onlineOfflineValue("SOMETHING-ELSE"))
+}
+
+func TestUpDownValue(t *testing.T) {
+	assert.Equal(t, 1.0, upDownValue("UP"))
+	assert.Equal(t, 0.0, upDownValue("DOWN"))
+}
+
+func TestYesNoValue(t *testing.T) {
+	assert.Equal(t, 1.0, yesNoValue("YES"))
+	assert.Equal(t, 0.0, yesNoValue("NO"))
+}
+
+func TestEnabledDisabledValue(t *testing.T) {
+	assert.Equal(t, 1.0, enabledDisabledValue("Enabled"))
+	assert.Equal(t, 0.0, enabledDisabledValue("Disabled"))
+}

--- a/pkg/features/mnha/rpc.go
+++ b/pkg/features/mnha/rpc.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+
+package mnha
+
+import "encoding/xml"
+
+// detailResult is the response to "show chassis high-availability information detail".
+type detailResult struct {
+	XMLName xml.Name `xml:"rpc-reply"`
+	Info    struct {
+		NodeInfo            nodeInfo        `xml:"chassis-high-availability-node-info"`
+		ColdSyncMonitoring  coldSyncMonitor `xml:"cold-synchronization-monitoring-information"`
+		SPUMonitoring       spuMonitoring   `xml:"spu-monitoring-information"`
+		LoopbackInformation loopbackInfo    `xml:"loopback-information"`
+		HardwareMonitoring  hwMonitoring    `xml:"high-availability-hardware-monitoring-information"`
+		DefaultSRG          srgBlock        `xml:"chassis-high-availability-default-srg-info"`
+	} `xml:"chassis-high-availability-detail-information"`
+}
+
+type nodeInfo struct {
+	NodeStatus string   `xml:"node-status"`
+	GridID     int      `xml:"grid-id"`
+	LocalID    int      `xml:"local-id"`
+	LocalIP    string   `xml:"local-ip"`
+	LocalFwdIP string   `xml:"local-fwd-ip"`
+	Peer       peerInfo `xml:"chassis-high-availability-peer-info-detail"`
+}
+
+type peerInfo struct {
+	PeerID            int             `xml:"high-availability-peer-id"`
+	PeerIPAddress     string          `xml:"high-availability-peer-ip-address"`
+	LocalInterface    string          `xml:"high-availability-local-interface"`
+	RoutingInstance   string          `xml:"high-availability-peer-rt-instance"`
+	EncryptionStatus  string          `xml:"high-availability-peer-encryption-status"`
+	BFDStatus         string          `xml:"high-availability-peer-bfd-status"`
+	DetectTime        string          `xml:"high-availability-peer-detect-time"`
+	ColdSyncStatus    string          `xml:"cold-sync-status"`
+	PeerFwdIPAddress  string          `xml:"high-availability-peer-fwd-ip-address"`
+	LocalFwdInterface string          `xml:"high-availability-local-fwd-interface"`
+	PeerFwdBFDStatus  string          `xml:"high-availability-peer-fwd-bfd-status"`
+	PacketStats       peerPacketStats `xml:"high-availability-peer-packet-stats"`
+}
+
+type peerPacketStats struct {
+	SendErrCount int                  `xml:"packet-send-err-cnt"`
+	RecvErrCount int                  `xml:"packet-recv-err-cnt"`
+	Stats        []peerPacketTypeStat `xml:"peer-packet-send-rcv-stats>peer-packet-stats-list"`
+}
+
+type peerPacketTypeStat struct {
+	Type      string `xml:"peer-packet-type"`
+	SendCount int    `xml:"peer-packet-send-cnt"`
+	RecvCount int    `xml:"peer-packet-rcv-cnt"`
+}
+
+type coldSyncMonitor struct {
+	Statistics coldSyncStatistics `xml:"cold-synchronization-statistics"`
+}
+
+type coldSyncStatistics struct {
+	Completed int `xml:"current-cold-synchronization-completed"`
+	Failed    int `xml:"current-cold-synchronization-failed"`
+}
+
+type spuMonitoring struct {
+	Status     spuMonitoringStatus `xml:"spu-monitoring-status"`
+	Statistics spuMonitoringStats  `xml:"spu-monitoring-statistics"`
+}
+
+type spuMonitoringStatus struct {
+	State string `xml:"spu-monitoring-state"`
+}
+
+type spuMonitoringStats struct {
+	SPUUp          int `xml:"spu-up-count"`
+	NPCUp          int `xml:"npc-up-count"`
+	SPUDown        int `xml:"spu-down-count"`
+	NPCDown        int `xml:"npc-down-count"`
+	ChinfoBlobErrs int `xml:"chinfo-blob-error-count"`
+}
+
+type loopbackInfo struct {
+	Checks []loopbackCheck `xml:"loopback-information-list"`
+}
+
+type loopbackCheck struct {
+	PFEName        string `xml:"pfe-name"`
+	LoopbackStatus string `xml:"loopback-status"`
+	NexthopStatus  string `xml:"nexthop-status"`
+	MbufStatus     string `xml:"mbuf-status"`
+}
+
+type hwMonitoring struct {
+	Status hwMonitoringStatus `xml:"high-availability-hardware-monitoring-status-information"`
+}
+
+type hwMonitoringStatus struct {
+	ActivationStatus string `xml:"high-availability-hardware-monitoring-activation-status"`
+	CtrlPlaneErrors  int    `xml:"high-availability-hardware-monitoring-ctrl-plane-errors"`
+	DataPlaneErrors  int    `xml:"high-availability-hardware-monitoring-data-plane-errors"`
+}
+
+// srgBlock is the state of a single services-redundancy-group, e.g.:
+//
+//	<chassis-high-availability-default-srg-info>
+//	  <current-state>ONLINE</current-state>
+//	  <peer-id>2</peer-id>
+//	</chassis-high-availability-default-srg-info>
+type srgBlock struct {
+	CurrentState string `xml:"current-state"`
+	PeerID       int    `xml:"peer-id"`
+}
+
+// srgResult is the response to "show chassis high-availability services-redundancy-group <id>".
+//
+// Verified against a real device for group 0 only, where the reply wraps the
+// state in <chassis-high-availability-default-srg-info> - the same element
+// used for the default group inside the "detail" output. Non-default groups
+// (id > 0) are assumed to use the same element name; this has not been
+// confirmed against real output and may need a second struct if Junos uses a
+// different wrapper (e.g. a non-"default" element) for those.
+type srgResult struct {
+	XMLName xml.Name `xml:"rpc-reply"`
+	SRG     srgBlock `xml:"chassis-high-availability-default-srg-info"`
+}

--- a/pkg/features/mnha/rpc_test.go
+++ b/pkg/features/mnha/rpc_test.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MIT
+
+package mnha
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Sample captured from a real SRX pair: "show chassis high-availability information detail | display xml"
+const detailSample = `<rpc-reply xmlns:junos="http://xml.juniper.net/junos/24.4R2-S2.6/junos">
+    <chassis-high-availability-detail-information>
+        <chassis-high-availability-node-info>
+            <node-status>ONLINE</node-status>
+            <grid-id>0</grid-id>
+            <local-id>1</local-id>
+            <local-ip>192.168.12.250</local-ip>
+            <local-fwd-ip>192.168.12.249</local-fwd-ip>
+            <chassis-high-availability-peer-info-detail>
+                <high-availability-peer-desc></high-availability-peer-desc>
+                <high-availability-peer-id>2</high-availability-peer-id>
+                <high-availability-peer-ip-address>192.168.12.251</high-availability-peer-ip-address>
+                <high-availability-local-interface>lo0.1</high-availability-local-interface>
+                <high-availability-peer-rt-instance>mnha_icl</high-availability-peer-rt-instance>
+                <high-availability-peer-encryption-status>NO</high-availability-peer-encryption-status>
+                <high-availability-peer-bfd-status>UP</high-availability-peer-bfd-status>
+                <high-availability-peer-detect-time>3 * 1000ms</high-availability-peer-detect-time>
+                <cold-sync-status>COMPLETE</cold-sync-status>
+                <high-availability-peer-fwd-ip-address>192.168.12.252</high-availability-peer-fwd-ip-address>
+                <high-availability-local-fwd-interface>lo0.1</high-availability-local-fwd-interface>
+                <high-availability-peer-fwd-bfd-status>UP</high-availability-peer-fwd-bfd-status>
+                <peer-internal-interface>N/A</peer-internal-interface>
+                <peer-internal-local-ip>N/A</peer-internal-local-ip>
+                <peer-internal-peer-ip>N/A</peer-internal-peer-ip>
+                <peer-internal-routing-instance>N/A</peer-internal-routing-instance>
+                <local-fwd-ip>192.168.12.249</local-fwd-ip>
+                <high-availability-peer-packet-stats>
+                    <packet-send-err-cnt>0</packet-send-err-cnt>
+                    <packet-recv-err-cnt>0</packet-recv-err-cnt>
+                    <peer-packet-send-rcv-stats>
+                        <peer-packet-stats-list>
+                            <peer-packet-type>SRG Status Msg</peer-packet-type>
+                            <peer-packet-send-cnt>0</peer-packet-send-cnt>
+                            <peer-packet-rcv-cnt>0</peer-packet-rcv-cnt>
+                        </peer-packet-stats-list>
+                        <peer-packet-stats-list>
+                            <peer-packet-type>SRG Status Ack</peer-packet-type>
+                            <peer-packet-send-cnt>0</peer-packet-send-cnt>
+                            <peer-packet-rcv-cnt>0</peer-packet-rcv-cnt>
+                        </peer-packet-stats-list>
+                        <peer-packet-stats-list>
+                            <peer-packet-type>Attribute Msg</peer-packet-type>
+                            <peer-packet-send-cnt>3</peer-packet-send-cnt>
+                            <peer-packet-rcv-cnt>2</peer-packet-rcv-cnt>
+                        </peer-packet-stats-list>
+                        <peer-packet-stats-list>
+                            <peer-packet-type>Attribute Ack</peer-packet-type>
+                            <peer-packet-send-cnt>2</peer-packet-send-cnt>
+                            <peer-packet-rcv-cnt>2</peer-packet-rcv-cnt>
+                        </peer-packet-stats-list>
+                    </peer-packet-send-rcv-stats>
+                </high-availability-peer-packet-stats>
+            </chassis-high-availability-peer-info-detail>
+        </chassis-high-availability-node-info>
+        <high-availability-peer-status-events>
+            <high-availability-peer-status-event>May 20 10:08:24.090 : HA Peer 192.168.12.252 BFD conn came up</high-availability-peer-status-event>
+        </high-availability-peer-status-events>
+        <high-availability-hw-upgrade-events>
+        </high-availability-hw-upgrade-events>
+        <cold-synchronization-monitoring-information>
+            <cold-synchronization-status-information>
+                <cold-synchronization-completed>N/A</cold-synchronization-completed>
+                <cold-synchronization-not-completed>N/A</cold-synchronization-not-completed>
+                <cold-synchronization-unknown>N/A</cold-synchronization-unknown>
+                <cold-synchronization-weight>0</cold-synchronization-weight>
+            </cold-synchronization-status-information>
+            <cold-synchronization-progress>CS Prereq               1 of 1 SPUs completed</cold-synchronization-progress>
+            <cold-synchronization-statistics>
+                <current-cold-synchronization-completed>4</current-cold-synchronization-completed>
+                <current-cold-synchronization-failed>1</current-cold-synchronization-failed>
+            </cold-synchronization-statistics>
+            <cold-synchronization-events>
+                <cold-synchronization-event>May 20 10:08:25.783 : Cold sync for PFE flowd is RTO sync in process</cold-synchronization-event>
+            </cold-synchronization-events>
+        </cold-synchronization-monitoring-information>
+        <spu-monitoring-information>
+            <spu-monitoring-status>
+                <spu-monitoring-state>Enabled</spu-monitoring-state>
+                <spu-monitoring-weight>0</spu-monitoring-weight>
+                <spu-monitoring-spu-state>
+                </spu-monitoring-spu-state>
+            </spu-monitoring-status>
+            <spu-monitoring-statistics>
+                <spu-up-count>1</spu-up-count>
+                <npc-up-count>0</npc-up-count>
+                <spu-down-count>0</spu-down-count>
+                <npc-down-count>0</npc-down-count>
+                <chinfo-blob-error-count>0</chinfo-blob-error-count>
+            </spu-monitoring-statistics>
+            <spu-monitoring-events>
+            </spu-monitoring-events>
+        </spu-monitoring-information>
+        <loopback-information>
+            <loopback-information-list>
+                <pfe-name>flowd</pfe-name>
+                <loopback-status>Success</loopback-status>
+                <nexthop-status>Success</nexthop-status>
+                <mbuf-status>Success</mbuf-status>
+            </loopback-information-list>
+        </loopback-information>
+        <high-availability-hardware-monitoring-information>
+            <high-availability-hardware-monitoring-status-information>
+                <high-availability-hardware-monitoring-activation-status>Enabled</high-availability-hardware-monitoring-activation-status>
+                <high-availability-hardware-monitoring-ctrl-plane-errors>0</high-availability-hardware-monitoring-ctrl-plane-errors>
+                <high-availability-hardware-monitoring-data-plane-errors>0</high-availability-hardware-monitoring-data-plane-errors>
+            </high-availability-hardware-monitoring-status-information>
+            <hardware-monitoring-events>
+                <hardware-monitoring-event>May 20 10:04:14.401 : hw-mon errors read      Ctrl Plane  errors:0 Data plane  errors:0</hardware-monitoring-event>
+            </hardware-monitoring-events>
+        </high-availability-hardware-monitoring-information>
+        <chassis-high-availability-default-srg-info>
+            <current-state>ONLINE</current-state>
+            <peer-id>2</peer-id>
+        </chassis-high-availability-default-srg-info>
+        <chassis-high-availability-srg-info-detail>
+        </chassis-high-availability-srg-info-detail>
+    </chassis-high-availability-detail-information>
+    <cli>
+        <banner></banner>
+    </cli>
+</rpc-reply>`
+
+// Sample captured from a real SRX pair: "show chassis high-availability services-redundancy-group 0 | display xml"
+const srgSample = `<rpc-reply xmlns:junos="http://xml.juniper.net/junos/24.4R2-S2.6/junos">
+    <chassis-high-availability-default-srg-info>
+        <current-state>ONLINE</current-state>
+        <peer-id>1</peer-id>
+    </chassis-high-availability-default-srg-info>
+    <cli>
+        <banner></banner>
+    </cli>
+</rpc-reply>`
+
+func TestParseDetailResult(t *testing.T) {
+	var res detailResult
+	err := xml.Unmarshal([]byte(detailSample), &res)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	node := res.Info.NodeInfo
+	assert.Equal(t, "ONLINE", node.NodeStatus)
+	assert.Equal(t, 0, node.GridID)
+	assert.Equal(t, 1, node.LocalID)
+	assert.Equal(t, "192.168.12.250", node.LocalIP)
+	assert.Equal(t, "192.168.12.249", node.LocalFwdIP)
+
+	peer := node.Peer
+	assert.Equal(t, 2, peer.PeerID)
+	assert.Equal(t, "192.168.12.251", peer.PeerIPAddress)
+	assert.Equal(t, "lo0.1", peer.LocalInterface)
+	assert.Equal(t, "mnha_icl", peer.RoutingInstance)
+	assert.Equal(t, "NO", peer.EncryptionStatus)
+	assert.Equal(t, "UP", peer.BFDStatus)
+	assert.Equal(t, "3 * 1000ms", peer.DetectTime)
+	assert.Equal(t, "COMPLETE", peer.ColdSyncStatus)
+	assert.Equal(t, "192.168.12.252", peer.PeerFwdIPAddress)
+	assert.Equal(t, "lo0.1", peer.LocalFwdInterface)
+	assert.Equal(t, "UP", peer.PeerFwdBFDStatus)
+
+	assert.Equal(t, 0, peer.PacketStats.SendErrCount)
+	assert.Equal(t, 0, peer.PacketStats.RecvErrCount)
+	assert.Len(t, peer.PacketStats.Stats, 4)
+	assert.Equal(t, "SRG Status Msg", peer.PacketStats.Stats[0].Type)
+	assert.Equal(t, "Attribute Msg", peer.PacketStats.Stats[2].Type)
+	assert.Equal(t, 3, peer.PacketStats.Stats[2].SendCount)
+	assert.Equal(t, 2, peer.PacketStats.Stats[2].RecvCount)
+
+	assert.Equal(t, 4, res.Info.ColdSyncMonitoring.Statistics.Completed)
+	assert.Equal(t, 1, res.Info.ColdSyncMonitoring.Statistics.Failed)
+
+	assert.Equal(t, "Enabled", res.Info.SPUMonitoring.Status.State)
+	assert.Equal(t, 1, res.Info.SPUMonitoring.Statistics.SPUUp)
+	assert.Equal(t, 0, res.Info.SPUMonitoring.Statistics.NPCUp)
+	assert.Equal(t, 0, res.Info.SPUMonitoring.Statistics.SPUDown)
+	assert.Equal(t, 0, res.Info.SPUMonitoring.Statistics.NPCDown)
+	assert.Equal(t, 0, res.Info.SPUMonitoring.Statistics.ChinfoBlobErrs)
+
+	assert.Len(t, res.Info.LoopbackInformation.Checks, 1)
+	assert.Equal(t, "flowd", res.Info.LoopbackInformation.Checks[0].PFEName)
+	assert.Equal(t, "Success", res.Info.LoopbackInformation.Checks[0].LoopbackStatus)
+	assert.Equal(t, "Success", res.Info.LoopbackInformation.Checks[0].NexthopStatus)
+	assert.Equal(t, "Success", res.Info.LoopbackInformation.Checks[0].MbufStatus)
+
+	assert.Equal(t, "Enabled", res.Info.HardwareMonitoring.Status.ActivationStatus)
+	assert.Equal(t, 0, res.Info.HardwareMonitoring.Status.CtrlPlaneErrors)
+	assert.Equal(t, 0, res.Info.HardwareMonitoring.Status.DataPlaneErrors)
+
+	assert.Equal(t, "ONLINE", res.Info.DefaultSRG.CurrentState)
+	assert.Equal(t, 2, res.Info.DefaultSRG.PeerID)
+}
+
+func TestParseSRGResult(t *testing.T) {
+	var res srgResult
+	err := xml.Unmarshal([]byte(srgSample), &res)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "ONLINE", res.SRG.CurrentState)
+	assert.Equal(t, 1, res.SRG.PeerID)
+}


### PR DESCRIPTION
## Summary
Adds a new collector for MNHA (Multi-Node High Availability) on Juniper SRX devices.

## Metrics added
- `mnha_node_status` — local node status (online/offline/unknown)
- `mnha_peer_bfd_up`, `mnha_peer_fwd_bfd_up` — BFD session state (ICL and forwarding-path)
- `mnha_peer_encryption_enabled` — whether the ICL is encrypted
- `mnha_peer_detect_time_milliseconds` — BFD failure detection time
- `mnha_cold_sync_complete`, `mnha_cold_sync_completed_total`, `mnha_cold_sync_failed_total` — cold sync status/counters
- `mnha_peer_packets_total`, `mnha_peer_packet_errors_total` — ICL packet counters by direction
- `mnha_spu_up`, `mnha_spu_down`, `mnha_npc_up`, `mnha_npc_down`, `mnha_spu_monitoring_enabled` — SPU/NPC monitoring
- `mnha_hardware_monitoring_enabled`, `mnha_hardware_control_plane_errors_total`, `mnha_hardware_data_plane_errors_total` — hardware monitoring
- `mnha_chinfo_blob_errors_total` — chassis-info blob errors
- `mnha_loopback_check_success` — PFE loopback self-test result
- `mnha_srg_state` — services-redundancy-group state

## Usage
Enable per device via config:
```yaml
mnha: true