### PR TITLE
Add Security NAT collector for Juniper SRX

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following metrics are supported by now:
 * Storage (total, available and used blocks, used percentage)
 * Firewall filters (counters and policers) - needs explicit rights beyond read-only
 * Security policy (SRX) statistics
+* Security NAT (SRX): source NAT pool resource usage (current and historical peak) and per-rule translation hit counters
 * Interface queue statistics
 * Power (Power usage)
 * License statistics (installed/used/needed)
@@ -159,6 +160,39 @@ junos_evpn_duplicate_mac_total > 0   # forwarding loop or split-brain
 `junos_evpn_ip_prefix_advertisement_count` uses a `status` discriminator label (`accepted`, `rejected`, …) so rejected Type-5 routes can be alerted on without separate metric families:
 ```
 junos_evpn_ip_prefix_advertisement_count{status="rejected"} > 0
+```
+
+### Security NAT
+The pool metrics count ports for port-translating pools and addresses for every other pool type. The `style` label carries the pool type Junos reports (for example `all-pat-pool`), so it tells the two apart:
+
+```
+junos_security_nat_pool_resource_used / junos_security_nat_pool_resource_total > 0.9
+```
+
+`junos_security_nat_pool_peak_usage_percent` is the highest usage the device has seen since the counters were last cleared and cannot be derived from the current values. `junos_security_nat_pool_peak_usage_timestamp_seconds` is only emitted once a peak has actually been recorded.
+
+The rule counters are labelled with the rule identity and the pool it translates to, which allows joining rule load onto pool usage:
+
+```
+junos_security_nat_rule_concurrent_hits
+  * on(target, pool_name) group_left()
+    junos_security_nat_pool_usage_percent
+```
+
+Translations the device rejected (most commonly because the pool ran out of resources) are the difference between the attempted and the successful counter:
+
+```
+  rate(junos_security_nat_rule_translation_hits_total[5m])
+- rate(junos_security_nat_rule_translation_success_hits_total[5m]) > 0
+```
+
+The zones a rule matches are deliberately kept off those counters, because a rule can match many zones and that list changes on configuration changes, which would break `rate()` over the counters. They are exposed as an info-pattern gauge instead, one series per zone pair, always `1`. Join on the rule identity when zones are needed:
+
+```
+junos_security_nat_rule_translation_hits_total
+  * on(target, rule_name, rule_set_name, rule_id)
+  group_left(from_zone, to_zone)
+    junos_security_nat_rule_info
 ```
 
 ### License statistics
@@ -381,6 +415,7 @@ features:
   satellite: false
   security: false
   security_ike: false
+  security_nat: false
   security_policies: false
   storage: false
   subscriber: false

--- a/collectors.go
+++ b/collectors.go
@@ -51,6 +51,7 @@ import (
 	"github.com/czerwonk/junos_exporter/pkg/features/rpm"
 	"github.com/czerwonk/junos_exporter/pkg/features/security"
 	"github.com/czerwonk/junos_exporter/pkg/features/securityike"
+	"github.com/czerwonk/junos_exporter/pkg/features/securitynat"
 	"github.com/czerwonk/junos_exporter/pkg/features/securitypolicies"
 	"github.com/czerwonk/junos_exporter/pkg/features/storage"
 	"github.com/czerwonk/junos_exporter/pkg/features/subscriber"
@@ -137,6 +138,7 @@ func (c *collectors) initCollectorsForDevices(device *connector.Device, descRe *
 	c.addCollectorIfEnabledForDevice(device, "cluster", f.Cluster, cluster.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "security", f.Security, security.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "security_ike", f.SecurityIKE, securityike.NewCollector)
+	c.addCollectorIfEnabledForDevice(device, "security_nat", f.SecurityNAT, securitynat.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "security_policies", f.SecurityPolicies, securitypolicies.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "storage", f.Storage, storage.NewCollector)
 	c.addCollectorIfEnabledForDevice(device, "system", (f.System || f.License), system.NewCollector)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,7 @@ type FeatureConfig struct {
 	Cluster             bool `yaml:"cluster,omitempty"`
 	Security            bool `yaml:"security,omitempty"`
 	SecurityIKE         bool `yaml:"security_ike,omitempty"`
+	SecurityNAT         bool `yaml:"security_nat,omitempty"`
 	SecurityPolicies    bool `yaml:"security_policies,omitempty"`
 	FPC                 bool `yaml:"fpc,omitempty"`
 	RPKI                bool `yaml:"rpki,omitempty"`

--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ var (
 	ufdEnabled                  = flag.Bool("ufd.enabled", false, "Scrape UFD (uplink-failure-detection) metrics")
 	mnhaEnabled                 = flag.Bool("mnha.enabled", false, "Scrape MNHA (Mixed/Multi-Node High Availability) metrics")
 	mnhaSRGIDs                  = flag.String("mnha.srg-ids", "0", "Comma-separated list of MNHA services-redundancy-group IDs to scrape")
+	securityNATEnabled          = flag.Bool("security_nat.enabled", false, "Scrape security NAT (source NAT pool usage and rule hit counters) metrics")
 	cfg                         *config.Config
 	devices                     []*connector.Device
 	connManager                 *connector.SSHConnectionManager
@@ -367,6 +368,7 @@ func loadConfigFromFlags() *config.Config {
 	f.Satellite = *satelliteEnabled
 	f.Security = *securityEnabled
 	f.SecurityIKE = *securityIKEEnabled
+	f.SecurityNAT = *securityNATEnabled
 	f.SecurityPolicies = *securityPoliciesEnabled
 	f.Storage = *storageEnabled
 	f.Subscriber = *subscriberEnabled

--- a/pkg/features/securitynat/collector.go
+++ b/pkg/features/securitynat/collector.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MIT
+
+package securitynat
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/czerwonk/junos_exporter/pkg/collector"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const prefix string = "junos_security_nat_"
+
+const (
+	poolUsageRPC = "show security nat resource-usage source-pool all"
+	ruleRPC      = "show security nat source rule all"
+)
+
+var (
+	poolResourceUsedDesc              *prometheus.Desc
+	poolResourceAvailableDesc         *prometheus.Desc
+	poolResourceTotalDesc             *prometheus.Desc
+	poolUsagePercentDesc              *prometheus.Desc
+	poolPeakUsagePercentDesc          *prometheus.Desc
+	poolPeakUsageTimestampSecondsDesc *prometheus.Desc
+	poolAddressCountDesc              *prometheus.Desc
+	poolPortOverloadFactorDesc        *prometheus.Desc
+
+	rulesCountDesc                      *prometheus.Desc
+	ruleReferencedAddressCountDesc      *prometheus.Desc
+	ruleTranslationHitsTotalDesc        *prometheus.Desc
+	ruleTranslationSuccessHitsTotalDesc *prometheus.Desc
+	ruleConcurrentHitsDesc              *prometheus.Desc
+	ruleInfoDesc                        *prometheus.Desc
+)
+
+func init() {
+	// The used/available/total triple is counted in ports for port-translating
+	// pools and in addresses otherwise, which is what the style label conveys.
+	lp := []string{"target", "pool_name", "style"}
+	poolResourceUsedDesc = prometheus.NewDesc(prefix+"pool_resource_used", "Pool resources (ports for PAT pools, addresses otherwise) currently in use", lp, nil)
+	poolResourceAvailableDesc = prometheus.NewDesc(prefix+"pool_resource_available", "Pool resources currently available", lp, nil)
+	poolResourceTotalDesc = prometheus.NewDesc(prefix+"pool_resource_total", "Pool resources available in total", lp, nil)
+	poolUsagePercentDesc = prometheus.NewDesc(prefix+"pool_usage_percent", "Current pool usage in percent as reported by Junos", lp, nil)
+	poolPeakUsagePercentDesc = prometheus.NewDesc(prefix+"pool_peak_usage_percent", "Highest pool usage in percent observed by the device so far", lp, nil)
+	poolPeakUsageTimestampSecondsDesc = prometheus.NewDesc(prefix+"pool_peak_usage_timestamp_seconds", "Time the peak pool usage was observed (not reported while no peak was recorded)", lp, nil)
+	poolAddressCountDesc = prometheus.NewDesc(prefix+"pool_address_count", "Number of addresses in the pool", lp, nil)
+	poolPortOverloadFactorDesc = prometheus.NewDesc(prefix+"pool_port_overload_factor", "Port overloading factor configured for the pool", lp, nil)
+
+	l := []string{"target"}
+	rulesCountDesc = prometheus.NewDesc(prefix+"rules_count", "Number of source NAT rules configured", l, nil)
+
+	lv := []string{"target", "ip_version"}
+	ruleReferencedAddressCountDesc = prometheus.NewDesc(prefix+"rule_referenced_address_count", "Number of addresses referenced by source NAT rules", lv, nil)
+
+	// Only labels identifying the rule and the pool it translates to, so that
+	// rate() over the counters survives changes to the zones a rule matches.
+	lr := []string{"target", "rule_name", "rule_set_name", "rule_id", "pool_name"}
+	ruleTranslationHitsTotalDesc = prometheus.NewDesc(prefix+"rule_translation_hits_total", "Translations attempted by the rule", lr, nil)
+	ruleTranslationSuccessHitsTotalDesc = prometheus.NewDesc(prefix+"rule_translation_success_hits_total", "Translations performed successfully by the rule", lr, nil)
+	ruleConcurrentHitsDesc = prometheus.NewDesc(prefix+"rule_concurrent_hits", "Sessions currently using the rule", lr, nil)
+
+	// The zones a rule matches churn on configuration changes, so they are
+	// exposed as an info metric instead of on the counters above.
+	li := []string{"target", "rule_name", "rule_set_name", "rule_id", "from_zone", "to_zone"}
+	ruleInfoDesc = prometheus.NewDesc(prefix+"rule_info", "Zones matched by the source NAT rule, one series per zone pair (always 1)", li, nil)
+}
+
+type securityNATCollector struct{}
+
+// NewCollector creates a new collector
+func NewCollector() collector.RPCCollector {
+	return &securityNATCollector{}
+}
+
+// Name returns the name of the collector
+func (*securityNATCollector) Name() string {
+	return "Security NAT"
+}
+
+// Describe describes the metrics
+func (*securityNATCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- poolResourceUsedDesc
+	ch <- poolResourceAvailableDesc
+	ch <- poolResourceTotalDesc
+	ch <- poolUsagePercentDesc
+	ch <- poolPeakUsagePercentDesc
+	ch <- poolPeakUsageTimestampSecondsDesc
+	ch <- poolAddressCountDesc
+	ch <- poolPortOverloadFactorDesc
+	ch <- rulesCountDesc
+	ch <- ruleReferencedAddressCountDesc
+	ch <- ruleTranslationHitsTotalDesc
+	ch <- ruleTranslationSuccessHitsTotalDesc
+	ch <- ruleConcurrentHitsDesc
+	ch <- ruleInfoDesc
+}
+
+// Collect collects metrics from JunOS
+func (c *securityNATCollector) Collect(client collector.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var errs []error
+
+	if err := c.collectPoolUsage(client, ch, labelValues); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := c.collectRules(client, ch, labelValues); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
+}
+
+func (c *securityNATCollector) collectPoolUsage(client collector.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var res poolUsageResult
+	if err := client.RunCommandAndParse(poolUsageRPC, &res); err != nil {
+		return err
+	}
+
+	for _, e := range res.Info.Entries {
+		l := labelsFor(labelValues, trim(e.PoolName), trim(e.Style))
+
+		ch <- prometheus.MustNewConstMetric(poolResourceUsedDesc, prometheus.GaugeValue, e.TotalUsed, l...)
+		ch <- prometheus.MustNewConstMetric(poolResourceAvailableDesc, prometheus.GaugeValue, e.TotalAvail, l...)
+		ch <- prometheus.MustNewConstMetric(poolResourceTotalDesc, prometheus.GaugeValue, e.TotalTotal, l...)
+		ch <- prometheus.MustNewConstMetric(poolAddressCountDesc, prometheus.GaugeValue, e.TotalAddress, l...)
+		ch <- prometheus.MustNewConstMetric(poolPortOverloadFactorDesc, prometheus.GaugeValue, e.PortOlFactor, l...)
+
+		if v, ok := parsePercent(e.TotalUsage); ok {
+			ch <- prometheus.MustNewConstMetric(poolUsagePercentDesc, prometheus.GaugeValue, v, l...)
+		}
+
+		if v, ok := parsePercent(e.PeakUsage); ok {
+			ch <- prometheus.MustNewConstMetric(poolPeakUsagePercentDesc, prometheus.GaugeValue, v, l...)
+		}
+
+		// A pool that never saw traffic carries no peak timestamp; reporting it
+		// as 0 would claim a peak at the start of the unix epoch.
+		if e.PeakDateTime.Seconds > 0 {
+			ch <- prometheus.MustNewConstMetric(poolPeakUsageTimestampSecondsDesc, prometheus.GaugeValue, float64(e.PeakDateTime.Seconds), l...)
+		}
+	}
+
+	return nil
+}
+
+func (c *securityNATCollector) collectRules(client collector.Client, ch chan<- prometheus.Metric, labelValues []string) error {
+	var res ruleResult
+	if err := client.RunCommandAndParse(ruleRPC, &res); err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(rulesCountDesc, prometheus.GaugeValue, res.Info.TotalRules.Total, labelValues...)
+	ch <- prometheus.MustNewConstMetric(ruleReferencedAddressCountDesc, prometheus.GaugeValue, res.Info.TotalRefAddr.V4, labelsFor(labelValues, "ipv4")...)
+	ch <- prometheus.MustNewConstMetric(ruleReferencedAddressCountDesc, prometheus.GaugeValue, res.Info.TotalRefAddr.V6, labelsFor(labelValues, "ipv6")...)
+
+	for _, r := range res.Info.Rules {
+		name, setName, id := trim(r.Name), trim(r.SetName), trim(r.ID)
+
+		for _, from := range orEmpty(r.FromContextName) {
+			for _, to := range orEmpty(r.ToContextName) {
+				li := labelsFor(labelValues, name, setName, id, trim(from), trim(to))
+				ch <- prometheus.MustNewConstMetric(ruleInfoDesc, prometheus.GaugeValue, 1, li...)
+			}
+		}
+
+		if r.Hits == nil {
+			continue
+		}
+
+		lr := labelsFor(labelValues, name, setName, id, trim(r.Action.Pool))
+		ch <- prometheus.MustNewConstMetric(ruleTranslationHitsTotalDesc, prometheus.CounterValue, r.Hits.TranslationHits, lr...)
+		ch <- prometheus.MustNewConstMetric(ruleTranslationSuccessHitsTotalDesc, prometheus.CounterValue, r.Hits.SuccessHits, lr...)
+		ch <- prometheus.MustNewConstMetric(ruleConcurrentHitsDesc, prometheus.GaugeValue, r.Hits.ConcurrentHits, lr...)
+	}
+
+	return nil
+}
+
+// labelsFor appends values to the label values common to all metrics of this
+// collector without ever writing into the caller's backing array.
+func labelsFor(labelValues []string, values ...string) []string {
+	l := make([]string, 0, len(labelValues)+len(values))
+	l = append(l, labelValues...)
+
+	return append(l, values...)
+}
+
+// orEmpty makes a single iteration over an absent repeated element possible, so
+// a rule without an explicit context still produces an info series.
+func orEmpty(values []string) []string {
+	if len(values) == 0 {
+		return []string{""}
+	}
+
+	return values
+}
+
+// trim removes the padding Junos adds to some string elements.
+func trim(s string) string {
+	return strings.TrimSpace(s)
+}
+
+// parsePercent parses Junos' "<n>%" percentage format, e.g. "31%" -> 31.
+func parsePercent(s string) (float64, bool) {
+	v, err := strconv.ParseFloat(strings.TrimSuffix(trim(s), "%"), 64)
+	if err != nil {
+		return 0, false
+	}
+
+	return v, true
+}

--- a/pkg/features/securitynat/collector_test.go
+++ b/pkg/features/securitynat/collector_test.go
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: MIT
+
+package securitynat
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"testing"
+
+	"github.com/czerwonk/junos_exporter/pkg/connector"
+	"github.com/czerwonk/junos_exporter/pkg/rpc"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockClient is a minimal collector.Client fake, modelled on the one used in
+// pkg/features/mnha/collect_test.go. It serves canned XML bodies keyed by the
+// exact command string and records every command it was asked to run.
+type mockClient struct {
+	commands  []string
+	responses map[string]string
+	failing   map[string]error
+}
+
+func (m *mockClient) RunCommandAndParse(cmd string, obj any) error {
+	m.commands = append(m.commands, cmd)
+
+	if err, ok := m.failing[cmd]; ok {
+		return err
+	}
+
+	body, ok := m.responses[cmd]
+	if !ok {
+		return fmt.Errorf("mockClient: no canned response for %q", cmd)
+	}
+
+	return xml.Unmarshal([]byte(body), obj)
+}
+
+func (m *mockClient) RunCommandAndParseWithParser(cmd string, parser rpc.Parser) error {
+	m.commands = append(m.commands, cmd)
+
+	body, ok := m.responses[cmd]
+	if !ok {
+		return fmt.Errorf("mockClient: no canned response for %q", cmd)
+	}
+
+	return parser([]byte(body))
+}
+
+func (m *mockClient) IsSatelliteEnabled() bool {
+	return false
+}
+
+func (m *mockClient) IsScrapingLicenseEnabled() bool {
+	return false
+}
+
+func (m *mockClient) Device() *connector.Device {
+	return &connector.Device{Host: "srx1"}
+}
+
+func (m *mockClient) Context() context.Context {
+	return context.Background()
+}
+
+func clientWithSamples() *mockClient {
+	return &mockClient{
+		responses: map[string]string{
+			poolUsageRPC: poolUsageSample,
+			ruleRPC:      ruleSample,
+		},
+	}
+}
+
+func collect(t *testing.T, client *mockClient) []prometheus.Metric {
+	t.Helper()
+
+	ch := make(chan prometheus.Metric, 128)
+	err := NewCollector().Collect(client, ch, []string{"srx1"})
+	assert.NoError(t, err)
+
+	return drain(ch)
+}
+
+func drain(ch chan prometheus.Metric) []prometheus.Metric {
+	close(ch)
+
+	var out []prometheus.Metric
+	for m := range ch {
+		out = append(out, m)
+	}
+
+	return out
+}
+
+func findByDesc(metrics []prometheus.Metric, desc *prometheus.Desc) []prometheus.Metric {
+	var out []prometheus.Metric
+	for _, m := range metrics {
+		if m.Desc() == desc {
+			out = append(out, m)
+		}
+	}
+
+	return out
+}
+
+func labelMap(t *testing.T, m prometheus.Metric) map[string]string {
+	t.Helper()
+
+	var dm dto.Metric
+	if err := m.Write(&dm); err != nil {
+		t.Fatalf("writing metric: %v", err)
+	}
+
+	out := make(map[string]string, len(dm.Label))
+	for _, lp := range dm.Label {
+		out[lp.GetName()] = lp.GetValue()
+	}
+
+	return out
+}
+
+func metricValue(t *testing.T, m prometheus.Metric) float64 {
+	t.Helper()
+
+	var dm dto.Metric
+	if err := m.Write(&dm); err != nil {
+		t.Fatalf("writing metric: %v", err)
+	}
+
+	if dm.Gauge != nil {
+		return dm.Gauge.GetValue()
+	}
+
+	return dm.Counter.GetValue()
+}
+
+// byLabel indexes metrics of one family by the value of a single label.
+func byLabel(t *testing.T, metrics []prometheus.Metric, label string) map[string]float64 {
+	t.Helper()
+
+	out := make(map[string]float64, len(metrics))
+	for _, m := range metrics {
+		out[labelMap(t, m)[label]] = metricValue(t, m)
+	}
+
+	return out
+}
+
+func TestCollectPoolUsage(t *testing.T) {
+	metrics := collect(t, clientWithSamples())
+
+	assert.Equal(t, map[string]float64{"POOL-A": 13, "POOL-B": 0},
+		byLabel(t, findByDesc(metrics, poolUsagePercentDesc), "pool_name"))
+	assert.Equal(t, map[string]float64{"POOL-A": 31, "POOL-B": 0},
+		byLabel(t, findByDesc(metrics, poolPeakUsagePercentDesc), "pool_name"))
+	assert.Equal(t, map[string]float64{"POOL-A": 8967, "POOL-B": 0},
+		byLabel(t, findByDesc(metrics, poolResourceUsedDesc), "pool_name"))
+	assert.Equal(t, map[string]float64{"POOL-A": 55545, "POOL-B": 64512},
+		byLabel(t, findByDesc(metrics, poolResourceAvailableDesc), "pool_name"))
+	assert.Equal(t, map[string]float64{"POOL-A": 64512, "POOL-B": 64512},
+		byLabel(t, findByDesc(metrics, poolResourceTotalDesc), "pool_name"))
+
+	used := findByDesc(metrics, poolResourceUsedDesc)
+	assert.Equal(t, map[string]string{"target": "srx1", "pool_name": "POOL-A", "style": "all-pat-pool"},
+		labelMap(t, used[0]))
+}
+
+// POOL-B never recorded a peak, so it must not claim one at the unix epoch.
+func TestCollectSkipsUnsetPeakTimestamp(t *testing.T) {
+	metrics := collect(t, clientWithSamples())
+
+	peaks := byLabel(t, findByDesc(metrics, poolPeakUsageTimestampSecondsDesc), "pool_name")
+	assert.Equal(t, map[string]float64{"POOL-A": 1786981339}, peaks)
+}
+
+func TestCollectRules(t *testing.T) {
+	metrics := collect(t, clientWithSamples())
+
+	total := findByDesc(metrics, rulesCountDesc)
+	assert.Len(t, total, 1)
+	assert.Equal(t, float64(2), metricValue(t, total[0]))
+	assert.Equal(t, map[string]string{"target": "srx1"}, labelMap(t, total[0]))
+
+	assert.Equal(t, map[string]float64{"ipv4": 10, "ipv6": 0},
+		byLabel(t, findByDesc(metrics, ruleReferencedAddressCountDesc), "ip_version"))
+
+	assert.Equal(t, map[string]float64{"RULE-A": 228555982, "RULE-B": 915},
+		byLabel(t, findByDesc(metrics, ruleTranslationHitsTotalDesc), "rule_name"))
+	assert.Equal(t, map[string]float64{"RULE-A": 203932849, "RULE-B": 915},
+		byLabel(t, findByDesc(metrics, ruleTranslationSuccessHitsTotalDesc), "rule_name"))
+	assert.Equal(t, map[string]float64{"RULE-A": 8230, "RULE-B": 0},
+		byLabel(t, findByDesc(metrics, ruleConcurrentHitsDesc), "rule_name"))
+
+	hits := findByDesc(metrics, ruleTranslationHitsTotalDesc)
+	for _, m := range hits {
+		l := labelMap(t, m)
+		if l["rule_name"] != "RULE-A" {
+			continue
+		}
+
+		assert.Equal(t, map[string]string{
+			"target":        "srx1",
+			"rule_name":     "RULE-A",
+			"rule_set_name": "RULESET-A",
+			"rule_id":       "1",
+			"pool_name":     "POOL-A",
+		}, l, "the zones a rule matches must stay off the counters")
+	}
+}
+
+// A rule matching several zones gets one info series per zone pair, so the zones
+// are queryable without parsing a delimited label value.
+func TestCollectRuleInfoFansOutOverZones(t *testing.T) {
+	metrics := collect(t, clientWithSamples())
+
+	info := findByDesc(metrics, ruleInfoDesc)
+	assert.Len(t, info, 3, "RULE-A matches 2 from-zones, RULE-B matches 1")
+
+	got := make(map[string]struct{}, len(info))
+	for _, m := range info {
+		assert.Equal(t, float64(1), metricValue(t, m))
+
+		l := labelMap(t, m)
+		got[fmt.Sprintf("%s|%s|%s", l["rule_name"], l["from_zone"], l["to_zone"])] = struct{}{}
+	}
+
+	assert.Equal(t, map[string]struct{}{
+		"RULE-A|ZONE-TRUST-1|ZONE-INTERNET": {},
+		"RULE-A|ZONE-TRUST-2|ZONE-INTERNET": {},
+		"RULE-B|ZONE-TRUST-1|ZONE-PARTNER":  {},
+	}, got)
+}
+
+// Rules Junos reports no counters for still need to show up as configured, so
+// the info series is emitted while the counters are skipped.
+func TestCollectRuleWithoutHitsEmitsInfoOnly(t *testing.T) {
+	const body = `<rpc-reply>
+    <source-nat-rule-detail-information>
+        <total-source-nat-rules>
+            <total-src-rules>1</total-src-rules>
+        </total-source-nat-rules>
+        <source-nat-rule-entry>
+            <rule-name>RULE-NO-HITS</rule-name>
+            <rule-set-name>RULESET-A</rule-set-name>
+            <rule-id>7</rule-id>
+            <rule-to-context-name>ZONE-INTERNET</rule-to-context-name>
+            <source-nat-rule-action-entry>
+                <source-nat-rule-action>interface</source-nat-rule-action>
+            </source-nat-rule-action-entry>
+        </source-nat-rule-entry>
+    </source-nat-rule-detail-information>
+</rpc-reply>`
+
+	client := clientWithSamples()
+	client.responses[ruleRPC] = body
+
+	metrics := collect(t, client)
+
+	assert.Empty(t, findByDesc(metrics, ruleTranslationHitsTotalDesc))
+	assert.Empty(t, findByDesc(metrics, ruleConcurrentHitsDesc))
+
+	info := findByDesc(metrics, ruleInfoDesc)
+	assert.Len(t, info, 1)
+	assert.Equal(t, map[string]string{
+		"target":        "srx1",
+		"rule_name":     "RULE-NO-HITS",
+		"rule_set_name": "RULESET-A",
+		"rule_id":       "7",
+		"from_zone":     "",
+		"to_zone":       "ZONE-INTERNET",
+	}, labelMap(t, info[0]))
+}
+
+// A device without any source NAT configured answers both RPCs with empty
+// bodies, which must not be treated as an error.
+func TestCollectWithoutAnyNATConfigured(t *testing.T) {
+	client := &mockClient{
+		responses: map[string]string{
+			poolUsageRPC: `<rpc-reply><source-resource-usage-pool-information></source-resource-usage-pool-information></rpc-reply>`,
+			ruleRPC:      `<rpc-reply><source-nat-rule-detail-information></source-nat-rule-detail-information></rpc-reply>`,
+		},
+	}
+
+	metrics := collect(t, client)
+
+	assert.Empty(t, findByDesc(metrics, poolResourceUsedDesc))
+	assert.Empty(t, findByDesc(metrics, ruleInfoDesc))
+
+	rules := findByDesc(metrics, rulesCountDesc)
+	assert.Len(t, rules, 1)
+	assert.Equal(t, float64(0), metricValue(t, rules[0]))
+}
+
+func TestCollectQueriesBothRPCs(t *testing.T) {
+	client := clientWithSamples()
+	collect(t, client)
+
+	assert.Equal(t, []string{poolUsageRPC, ruleRPC}, client.commands)
+}
+
+// One failing RPC must not hide the other's error, nor abort the scrape.
+func TestCollectJoinsErrorsFromBothCalls(t *testing.T) {
+	client := &mockClient{
+		responses: map[string]string{},
+		failing: map[string]error{
+			poolUsageRPC: fmt.Errorf("pool usage failed"),
+			ruleRPC:      fmt.Errorf("rule query failed"),
+		},
+	}
+
+	ch := make(chan prometheus.Metric, 128)
+	err := NewCollector().Collect(client, ch, []string{"srx1"})
+
+	assert.ErrorContains(t, err, "pool usage failed")
+	assert.ErrorContains(t, err, "rule query failed")
+}
+
+func TestCollectStillReportsRulesWhenPoolUsageFails(t *testing.T) {
+	client := clientWithSamples()
+	client.failing = map[string]error{poolUsageRPC: fmt.Errorf("pool usage failed")}
+
+	ch := make(chan prometheus.Metric, 128)
+	err := NewCollector().Collect(client, ch, []string{"srx1"})
+	assert.ErrorContains(t, err, "pool usage failed")
+
+	metrics := drain(ch)
+	assert.Empty(t, findByDesc(metrics, poolResourceUsedDesc))
+	assert.Len(t, findByDesc(metrics, ruleTranslationHitsTotalDesc), 2, "a failing pool query must not drop rule metrics")
+}
+
+// Every metric this collector describes must be registerable together, which
+// catches duplicate names and label-set mismatches between Describe and Collect.
+func TestMetricsAreConsistentWithRegistry(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+
+	c := &wrappedCollector{client: clientWithSamples()}
+	assert.NoError(t, reg.Register(c))
+
+	_, err := reg.Gather()
+	assert.NoError(t, err)
+}
+
+// wrappedCollector adapts the RPCCollector to prometheus.Collector so the
+// pedantic registry can validate the emitted metrics.
+type wrappedCollector struct {
+	client *mockClient
+}
+
+func (w *wrappedCollector) Describe(ch chan<- *prometheus.Desc) {
+	NewCollector().Describe(ch)
+}
+
+func (w *wrappedCollector) Collect(ch chan<- prometheus.Metric) {
+	if err := NewCollector().Collect(w.client, ch, []string{"srx1"}); err != nil {
+		panic(err)
+	}
+}

--- a/pkg/features/securitynat/rpc.go
+++ b/pkg/features/securitynat/rpc.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+
+package securitynat
+
+import "encoding/xml"
+
+// poolUsageResult is the response to "show security nat resource-usage source-pool all".
+type poolUsageResult struct {
+	XMLName xml.Name      `xml:"rpc-reply"`
+	Info    poolUsageInfo `xml:"source-resource-usage-pool-information"`
+}
+
+type poolUsageInfo struct {
+	Entries []poolUsageEntry `xml:"resource-usage-entry"`
+}
+
+// poolUsageEntry is the resource usage of a single source NAT pool, e.g.:
+//
+//	<resource-usage-entry junos:style="all-pat-pool">
+//	    <resource-usage-pool-name>POOL-A</resource-usage-pool-name>
+//	    <resource-usage-port-ol-factor>1</resource-usage-port-ol-factor>
+//	    <resource-usage-peak-usage>31%</resource-usage-peak-usage>
+//	    <resource-usage-peak-date-time junos:seconds="1786981339">…</resource-usage-peak-date-time>
+//	    <resource-usage-total-address>1</resource-usage-total-address>
+//	    <resource-usage-total-used>8967</resource-usage-total-used>
+//	    <resource-usage-total-avail>55545</resource-usage-total-avail>
+//	    <resource-usage-total-total>64512</resource-usage-total-total>
+//	    <resource-usage-total-usage>13%</resource-usage-total-usage>
+//	</resource-usage-entry>
+//
+// The unit of the used/avail/total triple depends on the pool style: ports for
+// port-translating (PAT) pools, addresses otherwise. Hence the neutral
+// "resource" naming, mirroring the RPC itself.
+type poolUsageEntry struct {
+	Style        string  `xml:"style,attr"`
+	PoolName     string  `xml:"resource-usage-pool-name"`
+	PortOlFactor float64 `xml:"resource-usage-port-ol-factor"`
+	PeakUsage    string  `xml:"resource-usage-peak-usage"`
+	PeakDateTime struct {
+		Seconds int64 `xml:"seconds,attr"`
+	} `xml:"resource-usage-peak-date-time"`
+	TotalAddress float64 `xml:"resource-usage-total-address"`
+	TotalUsed    float64 `xml:"resource-usage-total-used"`
+	TotalAvail   float64 `xml:"resource-usage-total-avail"`
+	TotalTotal   float64 `xml:"resource-usage-total-total"`
+	TotalUsage   string  `xml:"resource-usage-total-usage"`
+}
+
+// ruleResult is the response to "show security nat source rule all".
+type ruleResult struct {
+	XMLName xml.Name `xml:"rpc-reply"`
+	Info    ruleInfo `xml:"source-nat-rule-detail-information"`
+}
+
+type ruleInfo struct {
+	TotalRules struct {
+		Total float64 `xml:"total-src-rules"`
+	} `xml:"total-source-nat-rules"`
+	TotalRefAddr struct {
+		V4 float64 `xml:"total-source-nat-rule-ref-addr-num-v4"`
+		V6 float64 `xml:"total-source-nat-rule-ref-addr-num-v6"`
+	} `xml:"total-source-nat-rule-ref-addr-num"`
+	Rules []ruleEntry `xml:"source-nat-rule-entry"`
+}
+
+type ruleEntry struct {
+	Name    string `xml:"rule-name"`
+	SetName string `xml:"rule-set-name"`
+	ID      string `xml:"rule-id"`
+	// A rule can match traffic from several zones/interfaces, so Junos repeats
+	// the context-name element once per entry.
+	FromContextName []string   `xml:"rule-from-context-name"`
+	ToContextName   []string   `xml:"rule-to-context-name"`
+	Action          ruleAction `xml:"source-nat-rule-action-entry"`
+	// Hits is absent for rules Junos has no counters for, which is not the same
+	// as a rule with zero hits, so keep it nullable.
+	Hits *ruleHits `xml:"source-nat-rule-hits-entry"`
+}
+
+type ruleAction struct {
+	Pool string `xml:"source-nat-rule-action"`
+}
+
+type ruleHits struct {
+	TranslationHits float64 `xml:"rule-translation-hits"`
+	SuccessHits     float64 `xml:"succ-hits"`
+	ConcurrentHits  float64 `xml:"concurrent-hits"`
+}

--- a/pkg/features/securitynat/rpc_test.go
+++ b/pkg/features/securitynat/rpc_test.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: MIT
+
+package securitynat
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The sample XML in this package is a sanitized version of real "show security
+// nat ... | display xml" output: pool, rule and zone names are replaced with
+// placeholders and addresses come from the RFC 5737 documentation ranges. The
+// structure and the element names are unchanged.
+
+const poolUsageSample = `<rpc-reply xmlns:junos="http://xml.juniper.net/junos/24.4R2-S2.6/junos">
+    <source-resource-usage-pool-information xmlns="http://xml.juniper.net/junos/24.4R0/junos-nat">
+        <resource-usage-entry junos:style="all-pat-pool">
+            <resource-usage-pool-name>POOL-A</resource-usage-pool-name>
+            <resource-usage-total-pool-num>2</resource-usage-total-pool-num>
+            <resource-usage-port-ol-factor>1</resource-usage-port-ol-factor>
+            <resource-usage-peak-usage>31%</resource-usage-peak-usage>
+            <resource-usage-peak-date-time junos:seconds="1786981339">
+                2026-08-17 18:42:19 UTC</resource-usage-peak-date-time>
+            <resource-usage-total-address>1</resource-usage-total-address>
+            <resource-usage-total-used>8967</resource-usage-total-used>
+            <resource-usage-total-avail>55545</resource-usage-total-avail>
+            <resource-usage-total-total>64512</resource-usage-total-total>
+            <resource-usage-total-usage>13%</resource-usage-total-usage>
+        </resource-usage-entry>
+        <resource-usage-entry junos:style="all-pat-pool">
+            <resource-usage-pool-name>POOL-B</resource-usage-pool-name>
+            <resource-usage-total-pool-num>2</resource-usage-total-pool-num>
+            <resource-usage-port-ol-factor>1</resource-usage-port-ol-factor>
+            <resource-usage-peak-usage>0%</resource-usage-peak-usage>
+            <resource-usage-peak-date-time junos:seconds="0">
+                </resource-usage-peak-date-time>
+            <resource-usage-total-address>1</resource-usage-total-address>
+            <resource-usage-total-used>0</resource-usage-total-used>
+            <resource-usage-total-avail>64512</resource-usage-total-avail>
+            <resource-usage-total-total>64512</resource-usage-total-total>
+            <resource-usage-total-usage>0%</resource-usage-total-usage>
+        </resource-usage-entry>
+    </source-resource-usage-pool-information>
+    <cli>
+        <banner></banner>
+    </cli>
+</rpc-reply>`
+
+func TestParsePoolUsageResult(t *testing.T) {
+	var res poolUsageResult
+	err := xml.Unmarshal([]byte(poolUsageSample), &res)
+	assert.NoError(t, err)
+
+	assert.Len(t, res.Info.Entries, 2)
+
+	a := res.Info.Entries[0]
+	assert.Equal(t, "all-pat-pool", a.Style, "the junos: prefixed style attribute must be picked up")
+	assert.Equal(t, "POOL-A", a.PoolName)
+	assert.Equal(t, float64(1), a.PortOlFactor)
+	assert.Equal(t, "31%", a.PeakUsage)
+	assert.Equal(t, int64(1786981339), a.PeakDateTime.Seconds)
+	assert.Equal(t, float64(1), a.TotalAddress)
+	assert.Equal(t, float64(8967), a.TotalUsed)
+	assert.Equal(t, float64(55545), a.TotalAvail)
+	assert.Equal(t, float64(64512), a.TotalTotal)
+	assert.Equal(t, "13%", a.TotalUsage)
+
+	b := res.Info.Entries[1]
+	assert.Equal(t, "POOL-B", b.PoolName)
+	assert.Equal(t, "0%", b.TotalUsage)
+	assert.Equal(t, int64(0), b.PeakDateTime.Seconds, "a pool without a recorded peak reports no timestamp")
+}
+
+const ruleSample = `<rpc-reply xmlns:junos="http://xml.juniper.net/junos/24.4R2-S2.6/junos">
+    <source-nat-rule-detail-information xmlns="http://xml.juniper.net/junos/24.4R0/junos-nat">
+        <total-source-nat-rules>
+            <total-src-rules>2</total-src-rules>
+        </total-source-nat-rules>
+        <total-source-nat-rule-ref-addr-num>
+            <total-source-nat-rule-ref-addr-num-v4>10</total-source-nat-rule-ref-addr-num-v4>
+            <total-source-nat-rule-ref-addr-num-v6>0</total-source-nat-rule-ref-addr-num-v6>
+        </total-source-nat-rule-ref-addr-num>
+        <source-nat-rule-entry>
+            <rule-name>RULE-A</rule-name>
+            <rule-set-name>RULESET-A</rule-set-name>
+            <rule-id>1</rule-id>
+            <rule-matching-position>1</rule-matching-position>
+            <rule-from-context>zone</rule-from-context>
+            <rule-from-context-name>ZONE-TRUST-1</rule-from-context-name>
+            <rule-from-context-name>ZONE-TRUST-2</rule-from-context-name>
+            <rule-to-context>zone</rule-to-context>
+            <rule-to-context-name>ZONE-INTERNET</rule-to-context-name>
+            <source-address-range-entry>
+                <rule-source-address-low-range>0.0.0.0</rule-source-address-low-range>
+                <rule-source-address-high-range>255.255.255.255</rule-source-address-high-range>
+            </source-address-range-entry>
+            <destination-address-range-entry>
+                <rule-destination-address-low-range>0.0.0.0</rule-destination-address-low-range>
+                <rule-destination-address-high-range>255.255.255.255</rule-destination-address-high-range>
+            </destination-address-range-entry>
+            <destination-port-entry>
+            </destination-port-entry>
+            <source-port-entry>
+            </source-port-entry>
+            <src-nat-protocol-entry>
+            </src-nat-protocol-entry>
+            <source-nat-rule-action-entry>
+                <source-nat-rule-action>POOL-A</source-nat-rule-action>
+                <persistent-nat-type>N/A </persistent-nat-type>
+                <persistent-nat-mapping-type>address-port-mapping </persistent-nat-mapping-type>
+                <persistent-nat-timeout>0</persistent-nat-timeout>
+                <persistent-nat-max-session>0</persistent-nat-max-session>
+                <persistent-nat-blocksess>disabled </persistent-nat-blocksess>
+            </source-nat-rule-action-entry>
+            <source-nat-rule-hits-entry>
+                <rule-translation-hits>228555982</rule-translation-hits>
+                <succ-hits>203932849</succ-hits>
+                <concurrent-hits>8230</concurrent-hits>
+            </source-nat-rule-hits-entry>
+        </source-nat-rule-entry>
+        <source-nat-rule-entry>
+            <rule-name>RULE-B</rule-name>
+            <rule-set-name>RULESET-B</rule-set-name>
+            <rule-id>2</rule-id>
+            <rule-matching-position>2</rule-matching-position>
+            <rule-from-context>zone</rule-from-context>
+            <rule-from-context-name>ZONE-TRUST-1</rule-from-context-name>
+            <rule-to-context>zone</rule-to-context>
+            <rule-to-context-name>ZONE-PARTNER</rule-to-context-name>
+            <source-address-range-entry>
+                <rule-source-address-low-range>192.0.2.1</rule-source-address-low-range>
+                <rule-source-address-high-range>192.0.2.1</rule-source-address-high-range>
+            </source-address-range-entry>
+            <destination-address-range-entry>
+                <rule-destination-address-low-range>198.51.100.0</rule-destination-address-low-range>
+                <rule-destination-address-high-range>198.51.100.255</rule-destination-address-high-range>
+            </destination-address-range-entry>
+            <destination-port-entry>
+            </destination-port-entry>
+            <source-port-entry>
+            </source-port-entry>
+            <src-nat-protocol-entry>
+            </src-nat-protocol-entry>
+            <source-nat-rule-action-entry>
+                <source-nat-rule-action>POOL-B</source-nat-rule-action>
+                <persistent-nat-type>N/A </persistent-nat-type>
+                <persistent-nat-mapping-type>address-port-mapping </persistent-nat-mapping-type>
+                <persistent-nat-timeout>0</persistent-nat-timeout>
+                <persistent-nat-max-session>0</persistent-nat-max-session>
+                <persistent-nat-blocksess>disabled </persistent-nat-blocksess>
+            </source-nat-rule-action-entry>
+            <source-nat-rule-hits-entry>
+                <rule-translation-hits>915</rule-translation-hits>
+                <succ-hits>915</succ-hits>
+                <concurrent-hits>0</concurrent-hits>
+            </source-nat-rule-hits-entry>
+        </source-nat-rule-entry>
+    </source-nat-rule-detail-information>
+    <cli>
+        <banner></banner>
+    </cli>
+</rpc-reply>`
+
+func TestParseRuleResult(t *testing.T) {
+	var res ruleResult
+	err := xml.Unmarshal([]byte(ruleSample), &res)
+	assert.NoError(t, err)
+
+	assert.Equal(t, float64(2), res.Info.TotalRules.Total)
+	assert.Equal(t, float64(10), res.Info.TotalRefAddr.V4)
+	assert.Equal(t, float64(0), res.Info.TotalRefAddr.V6)
+
+	assert.Len(t, res.Info.Rules, 2)
+
+	a := res.Info.Rules[0]
+	assert.Equal(t, "RULE-A", a.Name)
+	assert.Equal(t, "RULESET-A", a.SetName)
+	assert.Equal(t, "1", a.ID)
+	assert.Equal(t, []string{"ZONE-TRUST-1", "ZONE-TRUST-2"}, a.FromContextName, "every repeated context element must be kept")
+	assert.Equal(t, []string{"ZONE-INTERNET"}, a.ToContextName)
+	assert.Equal(t, "POOL-A", a.Action.Pool)
+
+	assert.NotNil(t, a.Hits)
+	assert.Equal(t, float64(228555982), a.Hits.TranslationHits)
+	assert.Equal(t, float64(203932849), a.Hits.SuccessHits)
+	assert.Equal(t, float64(8230), a.Hits.ConcurrentHits)
+
+	b := res.Info.Rules[1]
+	assert.Equal(t, "RULE-B", b.Name)
+	assert.Equal(t, "POOL-B", b.Action.Pool)
+	assert.Equal(t, float64(915), b.Hits.TranslationHits)
+	assert.Equal(t, float64(0), b.Hits.ConcurrentHits)
+}
+
+// A rule Junos reports no counters for must be distinguishable from a rule with
+// zero hits, so the hits element stays nil instead of unmarshalling to zeroes.
+func TestParseRuleResultWithoutHits(t *testing.T) {
+	const body = `<rpc-reply>
+    <source-nat-rule-detail-information>
+        <total-source-nat-rules>
+            <total-src-rules>1</total-src-rules>
+        </total-source-nat-rules>
+        <source-nat-rule-entry>
+            <rule-name>RULE-NO-HITS</rule-name>
+            <rule-set-name>RULESET-A</rule-set-name>
+            <rule-id>7</rule-id>
+            <rule-to-context-name>ZONE-INTERNET</rule-to-context-name>
+            <source-nat-rule-action-entry>
+                <source-nat-rule-action>interface</source-nat-rule-action>
+            </source-nat-rule-action-entry>
+        </source-nat-rule-entry>
+    </source-nat-rule-detail-information>
+</rpc-reply>`
+
+	var res ruleResult
+	err := xml.Unmarshal([]byte(body), &res)
+	assert.NoError(t, err)
+
+	assert.Len(t, res.Info.Rules, 1)
+	assert.Nil(t, res.Info.Rules[0].Hits)
+	assert.Empty(t, res.Info.Rules[0].FromContextName)
+}
+
+func TestParsePercent(t *testing.T) {
+	v, ok := parsePercent("31%")
+	assert.True(t, ok)
+	assert.Equal(t, float64(31), v)
+
+	v, ok = parsePercent(" 0% ")
+	assert.True(t, ok)
+	assert.Equal(t, float64(0), v)
+
+	_, ok = parsePercent("N/A")
+	assert.False(t, ok)
+
+	_, ok = parsePercent("")
+	assert.False(t, ok)
+}


### PR DESCRIPTION
## Summary
Adds a `security_nat` collector for Juniper SRX devices, covering the classic flow-based security NAT (`show security nat ...`), as distinct from the existing `nat`/`nat2` collectors, which are scoped to services-plane NAT (`show services nat ...`) and don't report anything for the far more common flow-based SRX NAT setup.

## Metrics added
Source NAT pool resource usage (`show security nat resource-usage source-pool all`):
- `junos_security_nat_pool_resource_used` / `_available` / `_total` — ports for PAT pools, addresses otherwise (see `style` label)
- `junos_security_nat_pool_usage_percent` — current pool usage
- `junos_security_nat_pool_peak_usage_percent` / `_peak_usage_timestamp_seconds` — historical peak and when it was observed (only emitted once a peak has been recorded)
- `junos_security_nat_pool_address_count`, `junos_security_nat_pool_port_overload_factor`

Source NAT rules (`show security nat source rule all`):
- `junos_security_nat_rules_count`, `junos_security_nat_rule_referenced_address_count{ip_version}`
- `junos_security_nat_rule_translation_hits_total` / `_translation_success_hits_total` (counters) and `junos_security_nat_rule_concurrent_hits` (gauge), labelled by rule and the pool it translates to
- `junos_security_nat_rule_info` — the zones a rule matches, exposed as an info-pattern gauge (one series per zone pair) rather than a label on the counters above, since the zone set can change without the rule's identity changing

## Usage
```yaml
features:
  security_nat: true